### PR TITLE
BOAC-35, Python, JS, CSS linters

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,238 @@
+####################################################
+# ESLint enforces the desired code style.
+#
+# Certain RULES WE WANT TO ENFORCE are commented
+# out because refactoring is necessary.
+####################################################
+
+rules:
+  array-bracket-newline:
+    - 2
+    - multiline: true
+      minItems: 4
+  array-bracket-spacing:
+    - 2
+    - never
+    - singleValue: true
+  array-element-newline:
+    - 2
+    - multiline: true
+      minItems: 4
+  # block-scoped-var: 2
+  brace-style:
+    - 2
+    - 1tbs
+    - allowSingleLine: true
+  # camelcase: 2
+  comma-dangle:
+    - 2
+    - never
+  comma-spacing: 2
+  comma-style:
+    - 2
+    - last
+  # complexity:
+  #   - 2
+  #   - 11
+  computed-property-spacing: 2
+  consistent-return: 0
+  # consistent-this:
+  #   - 2
+  #   - that
+  curly:
+    - 2
+    - all
+  default-case: 2
+  dot-notation:
+    - 2
+    # - allowKeywords: false
+  eol-last: 2
+  eqeqeq: 2
+  for-direction: 2
+  func-names: 0
+  func-style:
+    - 0
+    - declaration
+  guard-for-in: 2
+  # handle-callback-err: 2
+  indent:
+    - 2
+    - 2
+    - SwitchCase: 1
+  key-spacing:
+    - 2
+    - beforeColon: false
+      afterColon: true
+  keyword-spacing: 2
+  linebreak-style:
+    - 2
+    - unix
+  # max-nested-callbacks:
+  #   - 2
+  #   - 2
+  new-cap: 2
+  new-parens: 2
+  no-array-constructor: 2
+  no-buffer-constructor: 2
+  no-caller: 2
+  no-catch-shadow: 2
+  no-compare-neg-zero: 2
+  no-cond-assign: 2
+  no-confusing-arrow: 2
+  no-constant-condition: 2
+  no-continue: 2
+  no-control-regex: 2
+  no-debugger: 2
+  no-delete-var: 2
+  no-div-regex: 2
+  no-dupe-args: 2
+  no-dupe-keys: 2
+  no-duplicate-case: 2
+  # no-else-return: 2
+  # no-extra-parens: 2
+  no-empty-character-class: 2
+  no-empty:
+    - 2
+    - allowEmptyCatch: true
+  no-eq-null: 2
+  no-eval: 2
+  no-ex-assign: 2
+  no-extend-native: 2
+  no-extra-bind: 2
+  no-extra-boolean-cast: 2
+  no-extra-semi: 2
+  no-fallthrough: 2
+  no-floating-decimal: 2
+  no-func-assign: 2
+  no-implied-eval: 2
+  no-inner-declarations:
+    - 2
+    - functions
+  no-inline-comments: 2
+  no-invalid-regexp: 2
+  no-irregular-whitespace: 2
+  no-iterator: 2
+  no-label-var: 2
+  no-labels: 2
+  no-lone-blocks: 2
+  no-lonely-if: 2
+  no-loop-func: 2
+  no-mixed-requires:
+    - 2
+    - false
+  no-mixed-spaces-and-tabs: 2
+  no-multi-spaces: 2
+  no-multi-str: 2
+  no-multiple-empty-lines: 2
+  no-native-reassign: 2
+  no-negated-in-lhs: 2
+  no-nested-ternary: 2
+  no-new-func: 2
+  no-new-require: 2
+  no-new-wrappers: 2
+  no-new-object: 2
+  no-new: 2
+  no-obj-calls: 2
+  no-octal-escape: 2
+  no-octal: 2
+  # no-param-reassign: 2
+  # no-path-concat: 2
+  no-process-env: 0
+  # no-process-exit: 2
+  no-proto: 2
+  # no-redeclare: 2
+  no-regex-spaces: 2
+  no-restricted-modules: 2
+  no-script-url: 2
+  no-self-compare: 2
+  # no-sequences: 2
+  no-shadow: 2
+  no-shadow-restricted-names: 2
+  no-spaced-func: 2
+  no-sparse-arrays: 2
+  # no-sync: 2
+  no-ternary: 0
+  no-throw-literal: 2
+  no-trailing-spaces: 2
+  no-undef-init: 2
+  no-undefined: 0
+  no-underscore-dangle: 2
+  # no-unneeded-ternary: 2
+  no-unreachable: 2
+  no-unused-expressions: 2
+  # no-unused-vars:
+  #   - 2
+  #   - vars: all
+  #     args: after-used
+  # no-use-before-define: 2
+  # no-useless-escape: 2
+  no-void: 2
+  no-warning-comments:
+    - 1
+    - terms:
+        - todo
+        - fixme
+        - xxx
+      location: start
+  no-with: 2
+  object-curly-newline:
+    - 2
+    - consistent: true
+  object-curly-spacing: 2
+  one-var:
+    - 2
+    - never
+  # operator-assignment:
+  #   - 2
+  #   - always
+  operator-linebreak:
+    - 2
+    - after
+  padded-blocks: 0
+  padding-line-between-statements: 2
+  # quote-props:
+  #   - 2
+  #   - as-needed
+  quotes:
+    - 2
+    - single
+  radix: 2
+  semi-spacing:
+    - 2
+    - before: false
+      after: true
+  semi:
+    - 2
+    - always
+  semi-style: 2
+  sort-vars: 2
+  space-before-blocks:
+    - 2
+    - always
+  space-before-function-paren:
+    - 2
+    - never
+  space-in-parens:
+    - 2
+    - never
+  space-infix-ops: 2
+  space-unary-ops:
+    - 2
+    - words: false
+      nonwords: false
+  spaced-comment:
+    - 2
+    - always
+  switch-colon-spacing: 2
+  use-isnan: 2
+  valid-jsdoc:
+    - 2
+    - prefer:
+        return: return
+  valid-typeof: 2
+  # vars-on-top: 2
+  wrap-iife: 2
+  wrap-regex: 2
+  yoda:
+    - 2
+    - never

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+package-lock.json
+node_modules
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,0 +1,22 @@
+extends: stylelint-config-standard
+ignoreFiles:
+  - node_modules/**/*
+  - boac/static/lib
+plugins:
+  - stylelint-scss
+  - stylelint-order
+rules:
+  font-family-name-quotes: always-where-recommended
+  function-url-quotes: never
+  selector-attribute-quotes: always
+  selector-type-no-unknown: null
+  shorthand-property-no-redundant-values: null
+  string-quotes: double
+  # https://github.com/sasstools/sass-lint/blob/develop/lib/config/property-sort-orders/smacss.yml
+  order/properties-order:
+    - display
+    - position
+    - top
+    - right
+    - bottom
+    - left

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+language: python
+python: "3.6"
+
+addons:
+  postgresql: "9.5"
+
+before_install:
+  - cd ${TRAVIS_BUILD_DIR}
+
+  # Set up test db
+  - psql -c 'create database boac_test;' -U postgres
+  - psql boac_test -c 'create extension pg_trgm;' -U postgres
+  - psql boac_test -c 'create role boac superuser login; alter schema public owner to boac;' -U postgres
+
+install:
+  - pip3 install -r requirements.txt
+  - pip3 install tox
+
+script:
+  - tox

--- a/boac/api/errors.py
+++ b/boac/api/errors.py
@@ -15,8 +15,14 @@ class JsonableException(Exception):
 
 
 class BadRequestError(JsonableException): pass
+
+
 class UnauthorizedRequestError(JsonableException): pass
+
+
 class ForbiddenRequestError(JsonableException): pass
+
+
 class ResourceNotFoundError(JsonableException): pass
 
 
@@ -24,17 +30,21 @@ class ResourceNotFoundError(JsonableException): pass
 def handle_bad_request(error):
     return error.to_json(), 400
 
+
 @app.errorhandler(UnauthorizedRequestError)
 def handle_unauthorized(error):
     return error.to_json(), 401
+
 
 @app.errorhandler(ForbiddenRequestError)
 def handle_forbidden(error):
     return error.to_json(), 403
 
+
 @app.errorhandler(ResourceNotFoundError)
 def handle_resource_not_found(error):
     return error.to_json(), 404
+
 
 @app.errorhandler(Exception)
 def handle_unexpected_error(error):

--- a/boac/api/status_controller.py
+++ b/boac/api/status_controller.py
@@ -3,6 +3,7 @@ from flask_login import current_user
 
 from boac.externals import canvas
 
+
 @app.route('/api/status')
 def app_status():
     uid = current_user.get_id()

--- a/boac/auth/cas_auth.py
+++ b/boac/auth/cas_auth.py
@@ -8,6 +8,7 @@ import cas
 
 from boac.api.errors import ForbiddenRequestError
 
+
 @app.route('/cas/login', methods=['GET', 'POST'])
 def cas_login():
     logger = app.logger

--- a/boac/auth/dev_auth.py
+++ b/boac/auth/dev_auth.py
@@ -6,6 +6,7 @@ from flask_login import (
 )
 from boac.api.errors import ForbiddenRequestError, ResourceNotFoundError
 
+
 @app.route('/devauth/login', methods=['GET', 'POST'])
 def dev_login():
     logger = app.logger
@@ -33,6 +34,7 @@ def dev_login():
             '''
     else:
         raise ResourceNotFoundError('Unknown path')
+
 
 @app.route("/logout")
 @login_required

--- a/boac/db.py
+++ b/boac/db.py
@@ -1,5 +1,6 @@
 from boac import db
 
+
 def initialize_db(app):
     db.init_app(app)
     return db

--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -3,6 +3,7 @@ import urllib
 from boac.lib import http
 from boac.lib.mockingbird import fixture, mockable, mocking
 
+
 @mockable
 def get_user_for_sis_id(canvas_instance, sis_id, mock=None):
     url = build_url(canvas_instance, '/api/v1/users/sis_user_id:UID:{}'.format(sis_id))

--- a/boac/lib/http.py
+++ b/boac/lib/http.py
@@ -2,6 +2,7 @@ import requests
 
 from flask import current_app as app
 
+
 def request(url, headers):
     app.logger.debug({'message': 'HTTP request', 'url': url, 'headers': sanitize_headers(headers)})
     try:
@@ -13,6 +14,7 @@ def request(url, headers):
         return None
     else:
         return response
+
 
 def sanitize_headers(headers):
     '''Suppress authorization token in logged headers.'''

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -9,6 +9,7 @@ from flask_login import UserMixin
 
 MockedUser = namedtuple('MockedUser', 'uid is_admin is_director is_advisor')
 
+
 class AuthorizedUser(MockedUser, UserMixin):
     def get_id(self):
         """Override UserMixin, since our DB conventionally reserves 'id' for generated keys."""
@@ -27,6 +28,7 @@ _mocked_users_csv = """uid,is_admin,is_director,is_advisor
 """
 _csv_reader = csv.DictReader(_mocked_users_csv.splitlines())
 _mocked_users = {m['uid']: AuthorizedUser(**m) for m in _csv_reader}
+
 
 def load_user(user_id):
     return _mocked_users.get(user_id)

--- a/boac/models/base.py
+++ b/boac/models/base.py
@@ -7,6 +7,8 @@ from boac import db
 This base model class defines common behavior inherited by all database-backed models. Here the
 only such common behavior is timestamp columns.
 """
+
+
 class Base(db.Model):
     __abstract__ = True
 

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -3,6 +3,7 @@ import flask_login
 
 from boac.models import authorized_user
 
+
 def register_routes(app):
     """Register app routes."""
 

--- a/boac/static/css/main.css
+++ b/boac/static/css/main.css
@@ -1,55 +1,55 @@
 .body-text {
-	font-size: 20px;
-	font-weight: 400;
-	line-height: 1.8em;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.8em;
 }
 
 .container-left {
-	float: left;
+  float: left;
 }
 
 .container-right {
-	float: right;
+  float: right;
 }
 
 .container-top {
-	font-weight: 300;
-	padding-top: 10px;
+  font-weight: 300;
+  padding-top: 10px;
 }
 
 .masthead {
-	padding: 30px 0 30px;
-	margin-bottom: 0;
+  padding: 30px 0 30px;
+  margin-bottom: 0;
 }
 
 .masthead h1 {
-	font-size: 40px;
-	line-height: 1;
-	font-weight: 400;
+  font-size: 40px;
+  line-height: 1;
+  font-weight: 400;
 }
 
 .header-section {
-	padding: 20px 0;
-	background: #222;
-	position: absolute;
-	top: 40px;
-	left: 0px;
-	width: 100%;
-	padding-left: 0;
-	margin-left: 0;
-	color: #FFF;
+  padding: 20px 0;
+  background: #222;
+  position: absolute;
+  top: 40px;
+  left: 0;
+  width: 100%;
+  padding-left: 0;
+  margin-left: 0;
+  color: #fff;
 }
 
 .header-push {
-	height: 180px;
+  height: 180px;
 }
 
 .header-row {
-	width: 960px;
-	margin: auto;
+  width: 960px;
+  margin: auto;
 }
 
 .main {
-	padding-top: 20px;
-	min-height: 370px;
+  padding-top: 20px;
+  min-height: 370px;
 }

--- a/boac/static/js/app.js
+++ b/boac/static/js/app.js
@@ -1,6 +1,6 @@
 (function(angular) {
 
-  angular.module('boac', ['ngRoute']);
+  angular.module('boac', [ 'ngRoute' ]);
 
   var bootstrap = function() {
     angular.element(document).ready(function() {

--- a/boac/static/js/factories/landingFactory.js
+++ b/boac/static/js/factories/landingFactory.js
@@ -9,7 +9,7 @@
 
     return {
       'getAppState': getAppState
-    }
+    };
   });
 
 }(window.angular));

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ httpretty
 pytest
 pytest-catchlog
 pytest-flask
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+# Tox (https://tox.readthedocs.io/) is a tool for running tests in multiple virtualenvs.
+
+[tox]
+envlist =
+    eslint,
+    flake8,
+    pytest,
+    stylelint
+skipsdist = True
+
+[testenv]
+whitelist_externals = *
+
+[testenv:pytest]
+commands =
+    pytest {posargs}
+
+[testenv:eslint]
+commands =
+    npm install -g eslint --silent
+    eslint boac/static/js
+
+[testenv:flake8]
+commands =
+    # Flake8 error/violation codes:
+    # http://flake8.pycqa.org/en/latest/user/error-codes.html
+
+    pip3 --quiet install flake8 flake8-docstrings flake8-import-order
+    flake8 \
+        --exclude .tox,.git,__pycache__,build,dist,node_modules,*.pyc,.cache \
+        --ignore D100,D101,D102,D103,D104,D200,D202,D204,D205,D209,D210,D300,D400,D401,D403,E701,E731,H101,H104,H238,H301,H306,H403,H404,H405,I100 \
+        --max-complexity 10 \
+        --max-line-length 155 \
+        boac
+deps =
+    flake8
+    flake8-docstrings
+    flake8-import-order
+
+[testenv:stylelint]
+commands =
+    npm install -g stylelint --silent
+    npm install stylelint-config-standard stylelint-order stylelint-scss debug --save-dev --silent
+    stylelint boac/static/css/*


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-35

ESLint:
* absorbed JSCS
* solid adoption and documentation
* eslintrc.yml copied from SuiteC)

Stylelint
* impressive docs: https://stylelint.io
* active committers
* nice plugins
* lacks the annoying verbosity of other linters
* I believe it's worth a try

Tox
* https://tox.readthedocs.io/en/latest/
* designed for Python projects
* Gulp equivalent without the need for wrapper modules (e.g., gulp-eslint)
* lightweight and familiar syntax

