### PR TITLE
NOJIRA Let external API clients see error statuses

### DIFF
--- a/boac/lib/http.py
+++ b/boac/lib/http.py
@@ -2,15 +2,32 @@ from flask import current_app as app
 import requests
 
 
+class ResponseExceptionWrapper:
+    def __init__(self, exception, original_response = None):
+        self.exception = exception
+        self.raw_response = original_response
+    def __bool__(self):
+        return False
+
 def request(url, headers):
+    """
+    Exception and error catching wrapper for outgoing HTTP requests.
+    :param url:
+    :param headers:
+    :return: The HTTP response from the external server, if the request was successful.
+        Otherwise, a wrapper containing the exception and the original HTTP response, if
+        one was returned.
+        Borrowing the Requests convention, successful responses are truthy and failures are falsey.
+    """
     app.logger.debug({'message': 'HTTP request', 'url': url, 'headers': sanitize_headers(headers)})
+    response = None
     try:
         # TODO handle methods other than GET
         response = requests.get(url, headers=headers)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
         app.logger.error(e)
-        return None
+        return ResponseExceptionWrapper(e, response)
     else:
         return response
 

--- a/tests/test_externals/test_canvas.py
+++ b/tests/test_externals/test_canvas.py
@@ -10,30 +10,36 @@ def ucb_canvas(app):
 
 
 class TestCanvasGetUserForSisId:
-    '''Canvas API query (user for SIS ID)'''
+    """Canvas API query (user for SIS ID)"""
 
     def test_user_for_sis_id(self, ucb_canvas):
-        '''returns fixture data'''
+        """returns fixture data"""
         oliver_response = canvas.get_user_for_sis_id(ucb_canvas, 2040)
+        assert oliver_response
         assert oliver_response.status_code == 200
         assert oliver_response.json()['sortable_name'] == 'Heyer, Oliver'
         assert oliver_response.json()['avatar_url'] == 'https://upload.wikimedia.org/wikipedia/en/thumb/b/b4/Donald_Duck.svg/618px-Donald_Duck.svg.png'
 
         paul_response = canvas.get_user_for_sis_id(ucb_canvas, 242881)
+        assert paul_response
         assert paul_response.status_code == 200
         assert paul_response.json()['sortable_name'] == 'Kerschen, Paul'
         assert paul_response.json()['avatar_url'] == 'https://en.wikipedia.org/wiki/Daffy_Duck#/media/File:Daffy_Duck.svg'
 
     def test_user_not_found(self, ucb_canvas, caplog):
-        '''logs 404 for unknown user and returns empty response'''
+        """logs 404 for unknown user and returns informative message"""
         response = canvas.get_user_for_sis_id(ucb_canvas, 9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
+        assert response.raw_response.status_code == 404
+        assert response.raw_response.json()['message']
 
     def test_server_error(self, ucb_canvas, caplog):
-        '''logs unexpected server errors and returns empty response'''
+        """logs unexpected server errors and returns informative message"""
         canvas_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(canvas.get_user_for_sis_id, canvas_error):
             response = canvas.get_user_for_sis_id(ucb_canvas, 2040)
             assert 'HTTP/1.1" 500' in caplog.text
             assert not response
+            assert response.raw_response.status_code == 500
+            assert response.raw_response.json()['message']


### PR DESCRIPTION
For starters, we'll want to distinguish "this user has no Canvas account" from "Canvas is being unfriendly."