### PR TITLE
BOAC-45, /api/config provides devAuthEnabled (needed in templates) and version

### DIFF
--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -1,0 +1,19 @@
+import json
+from flask import current_app as app, jsonify
+
+
+@app.route('/api/config')
+def app_config():
+    return jsonify({
+        'boacEnv': app.config['BOAC_ENV'],
+        'devAuthEnabled': app.config['DEVELOPER_AUTH_ENABLED'],
+        'version': _get_app_version(),
+    })
+
+
+def _get_app_version():
+    try:
+        file = open(app.config['BASE_DIR'] + '/../bower.json')
+        return json.load(file)['version']
+    except (FileNotFoundError, KeyError, TypeError):
+        return None

--- a/boac/configs.py
+++ b/boac/configs.py
@@ -14,6 +14,7 @@ def load_configs(app):
     app_env = os.environ.get('BOAC_ENV', 'development')
     load_module_config(app, app_env)
     load_local_config(app, '{}-local.py'.format(app_env))
+    app.config['BOAC_ENV'] = app_env
     app.canvas_instance = CanvasInstance(app)
 
 

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -16,6 +16,7 @@ def register_routes(app):
     # Register API routes.
     import boac.api.status_controller
     import boac.api.user_controller
+    import boac.api.config_controller
 
     # Register error handlers.
     import boac.api.errors

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -1,0 +1,9 @@
+class TestConfigController:
+    """Config API"""
+
+    def test_anonymous_request(self, client):
+        """returns a well-formed response"""
+        response = client.get('/api/config')
+        assert response.status_code == 200
+        assert 'boacEnv' in response.json
+        assert 'version' in response.json


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-45

Front-end bootstrap will use `/api/config` such that:
```
<div data-ng-if="config.devAuthEnabled && ...">
   Log in with dev-auth credentials.
```
`/api/config` is public and contains 'version'.
