### PR TITLE
NOJIRA, expand scope of code linting (py, js)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,12 +18,12 @@ rules:
     - 2
     - multiline: true
       minItems: 4
-  # block-scoped-var: 2
+  block-scoped-var: 2
   brace-style:
     - 2
     - 1tbs
     - allowSingleLine: true
-  # camelcase: 2
+  camelcase: 2
   comma-dangle:
     - 2
     - never
@@ -31,21 +31,21 @@ rules:
   comma-style:
     - 2
     - last
-  # complexity:
-  #   - 2
-  #   - 11
+  complexity:
+    - 2
+    - 11
   computed-property-spacing: 2
   consistent-return: 0
-  # consistent-this:
-  #   - 2
-  #   - that
+  consistent-this:
+    - 2
+    - that
   curly:
     - 2
     - all
   default-case: 2
   dot-notation:
     - 2
-    # - allowKeywords: false
+    - allowKeywords: false
   eol-last: 2
   eqeqeq: 2
   for-direction: 2
@@ -54,7 +54,7 @@ rules:
     - 0
     - declaration
   guard-for-in: 2
-  # handle-callback-err: 2
+  handle-callback-err: 2
   indent:
     - 2
     - 2
@@ -88,8 +88,8 @@ rules:
   no-dupe-args: 2
   no-dupe-keys: 2
   no-duplicate-case: 2
-  # no-else-return: 2
-  # no-extra-parens: 2
+  no-else-return: 2
+  no-extra-parens: 2
   no-empty-character-class: 2
   no-empty:
     - 2
@@ -135,37 +135,37 @@ rules:
   no-obj-calls: 2
   no-octal-escape: 2
   no-octal: 2
-  # no-param-reassign: 2
-  # no-path-concat: 2
+  no-param-reassign: 2
+  no-path-concat: 2
   no-process-env: 0
-  # no-process-exit: 2
+  no-process-exit: 2
   no-proto: 2
-  # no-redeclare: 2
+  no-redeclare: 2
   no-regex-spaces: 2
   no-restricted-modules: 2
   no-script-url: 2
   no-self-compare: 2
-  # no-sequences: 2
+  no-sequences: 2
   no-shadow: 2
   no-shadow-restricted-names: 2
   no-spaced-func: 2
   no-sparse-arrays: 2
-  # no-sync: 2
+  no-sync: 2
   no-ternary: 0
   no-throw-literal: 2
   no-trailing-spaces: 2
   no-undef-init: 2
   no-undefined: 0
   no-underscore-dangle: 2
-  # no-unneeded-ternary: 2
+  no-unneeded-ternary: 2
   no-unreachable: 2
   no-unused-expressions: 2
-  # no-unused-vars:
-  #   - 2
-  #   - vars: all
-  #     args: after-used
-  # no-use-before-define: 2
-  # no-useless-escape: 2
+  no-unused-vars:
+    - 2
+    - vars: all
+      args: after-used
+  no-use-before-define: 2
+  no-useless-escape: 2
   no-void: 2
   no-warning-comments:
     - 1
@@ -182,17 +182,17 @@ rules:
   one-var:
     - 2
     - never
-  # operator-assignment:
-  #   - 2
-  #   - always
+  operator-assignment:
+    - 2
+    - always
   operator-linebreak:
     - 2
     - after
   padded-blocks: 0
   padding-line-between-statements: 2
-  # quote-props:
-  #   - 2
-  #   - as-needed
+  quote-props:
+    - 2
+    - as-needed
   quotes:
     - 2
     - single
@@ -230,7 +230,7 @@ rules:
     - prefer:
         return: return
   valid-typeof: 2
-  # vars-on-top: 2
+  vars-on-top: 2
   wrap-iife: 2
   wrap-regex: 2
   yoda:

--- a/boac/static/js/factories/authFactory.js
+++ b/boac/static/js/factories/authFactory.js
@@ -5,8 +5,8 @@
   angular.module('boac').factory('authFactory', function($http) {
     var devAuthLogIn = function(uid, password) {
       return $http.post('/devauth/login', {
-        'uid': uid,
-        'password': password
+        uid: uid,
+        password: password
       });
     };
 
@@ -15,8 +15,8 @@
     };
 
     return {
-      'devAuthLogIn': devAuthLogIn,
-      'status': status
+      devAuthLogIn: devAuthLogIn,
+      status: status
     };
   });
 

--- a/config/default.py
+++ b/config/default.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 
 # Base directory.
@@ -13,9 +13,9 @@ THREADS_PER_PAGE = 2
 
 # Some defaults.
 CSRF_ENABLED = True
-CSRF_SESSION_KEY = "secret"
+CSRF_SESSION_KEY = 'secret'
 # Used to encrypt session cookie.
-SECRET_KEY = "secret"
+SECRET_KEY = 'secret'
 
 # Override in local configs.
 SQLALCHEMY_DATABASE_URI = 'postgres://boac:boac@localhost:5432/boac'
@@ -24,7 +24,7 @@ HOST = '0.0.0.0'
 PORT = 5000
 
 DEVELOPER_AUTH_ENABLED = False
-DEVELOPER_AUTH_PASSWORD = "another secret"
+DEVELOPER_AUTH_PASSWORD = 'another secret'
 
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
 

--- a/run.py
+++ b/run.py
@@ -16,10 +16,12 @@ from boac.factory import create_app
 
 app = create_app()
 
+
 @app.cli.command()
 def initdb():
     from boac.models import development_db
     development_db.load()
+
 
 if __name__ == '__main__':
     app.logger.info('BOAC server running on http://%s:%s !', app.config['HOST'], app.config['PORT'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-import boac.factory
 import os
+import boac.factory
 import pytest
 
 os.environ['BOAC_ENV'] = 'test'
@@ -12,8 +12,10 @@ class FakeAuth(object):
 
     def login(self, uid):
         self.app.config['DEVELOPER_AUTH_ENABLED'] = True
-        self.client.post('/devauth/login',
-            data={'uid': uid, 'password': self.app.config['DEVELOPER_AUTH_PASSWORD']})
+        self.client.post(
+            '/devauth/login',
+            data={'uid': uid, 'password': self.app.config['DEVELOPER_AUTH_PASSWORD']},
+        )
 
 
 # Because app and db fixtures are only created once per pytest run, individual tests

--- a/tests/test_externals/test_canvas.py
+++ b/tests/test_externals/test_canvas.py
@@ -1,7 +1,6 @@
-import pytest
-
-from boac.lib.mockingbird import MockResponse, register_mock
 import boac.externals.canvas as canvas
+from boac.lib.mockingbird import MockResponse, register_mock
+import pytest
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -24,21 +24,22 @@ commands =
 commands =
     # Flake8 error/violation codes:
     #   http://flake8.pycqa.org/en/latest/user/error-codes.html
-    #   http://www.pydocstyle.org/en/latest/error_codes.html
     #   https://github.com/PyCQA/flake8-import-order
 
-    pip3 --quiet install flake8 flake8-commas flake8-docstrings flake8-import-order flake8-pytest flake8-quotes
+    pip3 --quiet install flake8 flake8-commas flake8-import-order flake8-pytest flake8-quotes
     flake8 \
         --exclude .tox,.git,__pycache__,build,dist,node_modules,*.pyc,.cache \
-        --ignore D100,D101,D102,D103,D104,D105,D205,D400,D401,E731 \
+        --ignore E731 \
         --import-order-style google \
         --max-complexity 10 \
         --max-line-length 155 \
-        boac
+        boac config tests run.py
 deps =
     flake8
-    flake8-docstrings
+    flake8-commas
     flake8-import-order
+    flake8-pytest
+    flake8-quotes
 
 [testenv:lint-css]
 commands =


### PR DESCRIPTION
As promised, `flake8` covers all py files. Bonus: eslint rules unleashed.