### PR TITLE
NOJIRA Make it easy to use fixtures outside source control

### DIFF
--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -13,7 +13,7 @@ def app_config():
 
 def _get_app_version():
     try:
-        file = open(app.config['BASE_DIR'] + '/../bower.json')
+        file = open(app.config['BASE_DIR'] + '/bower.json')
         return json.load(file)['version']
     except (FileNotFoundError, KeyError, TypeError):
         return None

--- a/boac/lib/mockingbird.py
+++ b/boac/lib/mockingbird.py
@@ -200,7 +200,7 @@ def _environment_supports_mocks():
 
 
 def _get_fixtures_path():
-    return app.config['BASE_DIR'] + '/../fixtures'
+    return app.config.get('FIXTURES_PATH') or (app.config['BASE_DIR'] + '/fixtures')
 
 
 @contextmanager

--- a/config/default.py
+++ b/config/default.py
@@ -2,8 +2,8 @@ import os
 import logging
 
 
-# Base directory.
-BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+# Base directory for the application (one level up from this config file).
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 # Disable an expensive bit of the ORM.
 SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
This change makes the fixtures path configurable per environment. For example, including a `FIXTURES_PATH` value in your `demo-local.py` will load fixtures from that path under `BOAC_ENV=demo`, rather than from the default path in source control. This allows us to demo from large bodies of local unobfuscated JSON if need be.

The BASE_DIR config value is also changed to a better path.