### PR TITLE
BOAC-44, CAS login button on landing; backend wiring

### DIFF
--- a/boac/auth/cas_auth.py
+++ b/boac/auth/cas_auth.py
@@ -1,35 +1,46 @@
 from boac.api.errors import ForbiddenRequestError
 import cas
 from flask import (
-    current_app as app, flash, redirect, request, url_for,
+    current_app as app, flash, jsonify, redirect, request, url_for,
 )
 from flask_login import (
-    login_user,
+    login_required, login_user, logout_user,
 )
 
 
-@app.route('/cas/login', methods=['GET', 'POST'])
+@app.route('/cas/login_url', methods=['GET'])
+def cas_login_url():
+    return jsonify({
+        'cas_login_url': _cas_client().get_login_url(),
+    })
+
+
+@app.route('/cas/callback', methods=['GET', 'POST'])
 def cas_login():
     logger = app.logger
+    ticket = request.args['ticket']
+    user_id, attributes, proxy_granting_ticket = _cas_client().verify_ticket(ticket)
+    logger.info('Logged into CAS as user {}'.format(user_id))
+    user = app.login_manager.user_callback(user_id)
+    if user is None:
+        logger.error('Unauthorized UID {}'.format(user_id))
+        raise ForbiddenRequestError('Unknown account')
+    login_user(user)
+    flash('Logged in successfully.')
+    return redirect('/')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return jsonify({
+        'cas_logout_url': _cas_client().get_logout_url(redirect_url=request.url_root),
+    })
+
+
+def _cas_client():
     cas_server = app.config['CAS_SERVER']
     # One (possible) advantage this has over "request.base_url" is that it embeds the configured SERVER_NAME.
-    cas_service_url = url_for('.cas_login', _external=True)
-    client = cas.CASClientV3(
-        server_url=cas_server,
-        service_url=cas_service_url,
-    )
-    if 'ticket' in request.args:
-        ticket = request.args['ticket']
-        user_id, attributes, proxy_granting_ticket = client.verify_ticket(ticket)
-        logger.info('Logged into CAS as user {} with attributes {}'.format(user_id, repr(attributes)))
-        user = app.login_manager.user_callback(user_id)
-        if user is None:
-            logger.error('Unauthorized UID {}'.format(user_id))
-            raise ForbiddenRequestError('Unknown account')
-        login_user(user)
-        flash('Logged in successfully.')
-        return redirect('/')
-    else:
-        cas_login = client.get_login_url()
-        logger.info('Redirecting to ' + cas_login)
-        return redirect(cas_login)
+    service_url = url_for('.cas_login', _external=True)
+    return cas.CASClientV3(server_url=cas_server, service_url=service_url)

--- a/boac/auth/dev_auth.py
+++ b/boac/auth/dev_auth.py
@@ -3,7 +3,7 @@ from flask import (
     current_app as app, flash, redirect, request,
 )
 from flask_login import (
-    login_required, login_user, logout_user,
+    login_user,
 )
 
 
@@ -26,10 +26,3 @@ def dev_login():
         return redirect('/')
     else:
         raise ResourceNotFoundError('Unknown path')
-
-
-@app.route('/logout')
-@login_required
-def logout():
-    logout_user()
-    return redirect('/')

--- a/boac/static/js/controllers/landingController.js
+++ b/boac/static/js/controllers/landingController.js
@@ -11,6 +11,8 @@
       password: null
     };
 
+    $scope.casLogIn = authFactory.casLogIn;
+
     $scope.devAuthLogIn = function() {
       return authFactory.devAuthLogIn($scope.devAuth.uid, $scope.devAuth.password);
     };

--- a/boac/static/js/factories/authFactory.js
+++ b/boac/static/js/factories/authFactory.js
@@ -17,6 +17,12 @@
       });
     };
 
+    var casLogIn = function() {
+      return $http.get('/cas/login_url').then(function(results) {
+        window.location = results.data.cas_login_url;
+      });
+    };
+
     var devAuthLogIn = function(uid, password) {
       var credentials = {
         uid: uid,
@@ -26,13 +32,16 @@
     };
 
     var logOut = function() {
-      return $http.get('/logout').then(refreshStatus);
+      return $http.get('/logout').then(function(results) {
+        window.location = results.data.cas_logout_url;
+      });
     };
 
     // Make current user available to templates
     $rootScope.me = me;
 
     return {
+      casLogIn: casLogIn,
       devAuthLogIn: devAuthLogIn,
       logOut: logOut
     };

--- a/boac/static/templates/landing.html
+++ b/boac/static/templates/landing.html
@@ -7,8 +7,14 @@
       </button>
     </div>
   </div>
+  <div data-ng-if="me.authenticated_as.is_anonymous">
+    CalNet
+    <div>
+      <button data-ng-click="casLogIn()">Sign In</button>
+    </div>
+  </div>
   <div data-ng-if="devAuthEnabled && me.authenticated_as.is_anonymous">
-    Would you mind logging in?
+    Dev Auth (test env only)
     <div>
       <form data-ng-submit="devAuthLogIn()">
         <p><input data-ng-model="devAuth.uid" type="text" placeholder="UID" required></p>

--- a/config/default.py
+++ b/config/default.py
@@ -27,6 +27,7 @@ DEVELOPER_AUTH_ENABLED = False
 DEVELOPER_AUTH_PASSWORD = 'another secret'
 
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
+CAS_LOGOUT_URL = 'https://auth-test.berkeley.edu/cas/logout'
 
 CANVAS_HTTP_SCHEME = 'https'
 CANVAS_HTTP_DOMAIN = 'wottsamatta.instructure.com'

--- a/tests/test_auth/test_cas_auth.py
+++ b/tests/test_auth/test_cas_auth.py
@@ -1,0 +1,16 @@
+import re
+
+
+class TestCasAuth:
+    """CAS login URL generation and redirects"""
+
+    def test_cas_login_url(self, client):
+        """fails if the chosen UID does not match an authorized user"""
+        response = client.get('/cas/login_url')
+        assert response.status_code == 200
+        assert re.compile('.*berkeley.edu/cas/login').match(str(response.data)) is not None
+
+    def test_cas_callback_with_invalid_ticket(self, client):
+        """fails if CAS can not verify the ticket"""
+        response = client.get('/cas/callback?ticket=is_invalid')
+        assert response.status_code == 403

--- a/tests/test_auth/test_dev_auth.py
+++ b/tests/test_auth/test_dev_auth.py
@@ -32,7 +32,7 @@ class TestDevAuth:
         assert response.status_code == 200
         assert response.json['authenticated_as']['uid'] == self.authorized_uid
         response = client.get('/logout')
-        assert response.status_code == 302
+        assert response.status_code == 200
         response = client.get('/api/status')
         assert response.status_code == 200
         assert response.json['authenticated_as']['is_anonymous']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-44

Notes:
* move CAS callback logic out of `/cas/login`
* dual-purpose `/logout` for simplicity
* `window.location = {redirect_url}` for simplicity and to skip _Access-Control-Allow-Origin_ error
