### PR TITLE
NOJIRA, a cleaner tox.ini; pep fix on py file

### DIFF
--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -25,8 +25,11 @@ class AuthorizedUser(Base, UserMixin):
         self.is_director = is_director
 
     def __repr__(self):
-        return '<AuthorizedUser %r, is_advisor=%r, is_admin=%r, is_director=%r>' % (
-            self.uid, self.is_advisor, self.is_admin, self.is_director,
+        return '<AuthorizedUser {}, is_advisor={}, is_admin={}, is_director={}>'.format(
+            self.uid,
+            self.is_advisor,
+            self.is_admin,
+            self.is_director,
         )
 
     def get_id(self):

--- a/tox.ini
+++ b/tox.ini
@@ -18,26 +18,18 @@ commands =
 [testenv:lint-js]
 commands =
     npm install -g eslint --silent
-    eslint boac/static/js
+    eslint --color boac/static/js
 
 [testenv:lint-py]
+# Bottom of file has Flake8 settings
 commands =
-    # Flake8 error/violation codes:
-    #   http://flake8.pycqa.org/en/latest/user/error-codes.html
-    #   https://github.com/PyCQA/flake8-import-order
-
-    pip3 --quiet install flake8 flake8-commas flake8-import-order flake8-pytest flake8-quotes
-    flake8 \
-        --exclude .tox,.git,__pycache__,build,dist,node_modules,*.pyc,.cache \
-        --ignore E731 \
-        --import-order-style google \
-        --max-complexity 10 \
-        --max-line-length 155 \
-        boac config tests run.py
+    flake8 boac config tests run.py
 deps =
     flake8
+    flake8-colors
     flake8-commas
     flake8-import-order
+    flake8-pep3101
     flake8-pytest
     flake8-quotes
 
@@ -46,3 +38,20 @@ commands =
     npm install -g stylelint --silent
     npm install stylelint-config-standard stylelint-order stylelint-scss debug --save-dev --silent
     stylelint boac/static/css/*
+
+[flake8]
+exclude =
+    .tox
+    .git
+    __pycache__
+    build,dist
+    node_modules
+    *.pyc
+    .cache
+format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+ignore = E731
+import-order-style = google
+max-complexity = 10
+max-line-length = 155
+show-source = True
+statistics = True


### PR DESCRIPTION
Notes:
* `tox.ini` is cleaner with `[flake8]` configs at bottom.
* colorful output for eslint and flake8
