### PR TITLE
NOJIRA Ensure mocks are unregistered on assertion failure

### DIFF
--- a/boac/lib/mockingbird.py
+++ b/boac/lib/mockingbird.py
@@ -176,8 +176,10 @@ def register_mock(request_function, response):
         response_function = response
 
     _register_mock(request_function, response_function)
-    yield
-    _unregister_mock(request_function)
+    try:
+        yield
+    finally:
+        _unregister_mock(request_function)
 
 
 @contextmanager


### PR DESCRIPTION
As it turns out, without this little fix test failures will cascade in confounding ways.