### PR TITLE
BOAC-37 Distill per-user analytics feed from Canvas stats

### DIFF
--- a/boac/api/errors.py
+++ b/boac/api/errors.py
@@ -30,6 +30,10 @@ class ResourceNotFoundError(JsonableException):
     pass
 
 
+class InternalServerError(JsonableException):
+    pass
+
+
 @app.errorhandler(BadRequestError)
 def handle_bad_request(error):
     return error.to_json(), 400
@@ -48,6 +52,11 @@ def handle_forbidden(error):
 @app.errorhandler(ResourceNotFoundError)
 def handle_resource_not_found(error):
     return error.to_json(), 404
+
+
+@app.errorhandler(InternalServerError)
+def handle_internal_server_error(error):
+    return error.to_json(), 500
 
 
 @app.errorhandler(Exception)

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -1,6 +1,9 @@
+from boac.api import errors
 from boac.externals import canvas
+from boac.lib.analytics import analytics_from_summary_feed
+
 from flask import current_app as app, jsonify
-from flask_login import current_user
+from flask_login import current_user, login_required
 
 
 @app.route('/api/profile')
@@ -20,4 +23,40 @@ def user_profile():
     return jsonify({
         'uid': uid,
         'canvas_profile': canvas_profile,
+    })
+
+
+@app.route('/api/user/<uid>/analytics')
+@login_required
+def user_analytics(uid):
+    canvas_profile = canvas.get_user_for_uid(app.canvas_instance, uid)
+    if not canvas_profile:
+        if (canvas_profile.raw_response is not None) and (canvas_profile.raw_response.status_code == 404):
+            raise errors.ResourceNotFoundError('No Canvas profile found for user')
+        else:
+            raise errors.InternalServerError('Unable to reach bCourses')
+    canvas_id = canvas_profile.json()['id']
+
+    user_courses = canvas.get_user_courses(app.canvas_instance, uid)
+    if not user_courses:
+        raise errors.ResourceNotFoundError('No courses found for user')
+
+    course_analytics_feed = []
+    for course in user_courses:
+        course_analytics = {
+            'canvasCourseId': course['id'],
+            'courseName': course['name'],
+            'courseCode': course['course_code'],
+        }
+        student_summaries = canvas.get_student_summaries(app.canvas_instance, course['id'])
+        if not student_summaries:
+            course_analytics['analytics'] = {'error': 'Unable to retrieve analytics'}
+        else:
+            course_analytics['analytics'] = analytics_from_summary_feed(student_summaries, canvas_id, course)
+        course_analytics_feed.append(course_analytics)
+
+    return jsonify({
+        'uid': uid,
+        'canvasProfile': canvas_profile.json(),
+        'courses': course_analytics_feed,
     })

--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -1,0 +1,47 @@
+import math
+from flask import current_app as app
+import pandas
+
+
+def analytics_from_summary_feed(summary_feed, canvas_user_id, canvas_course):
+    """Given a student summary feed for a Canvas course, return analytics for a given user"""
+    df = pandas.DataFrame(summary_feed, columns=['id', 'page_views', 'participations', 'tardiness_breakdown'])
+    df.fillna(0, inplace=True)
+    df['on_time'] = df['tardiness_breakdown'].map(lambda t: t['on_time'])
+
+    student_row = df.loc[df['id'].values == canvas_user_id]
+    if not len(student_row):
+        app.logger.error('Canvas ID {} not found in student summaries for course site {}'.format(canvas_user_id, canvas_course['id']))
+        return {'error': 'Unable to retrieve analytics'}
+
+    def analytics_for_column(column_name):
+        column_zscore = zscore(df, student_row, column_name)
+        return {
+            'courseDeciles': quantiles(df[column_name], 10),
+            'student': {
+                'raw': student_row[column_name].values[0].item(),
+                'zscore': column_zscore,
+                'percentile': zptile(column_zscore),
+            },
+        }
+
+    return {
+        'assignmentsOnTime': analytics_for_column('on_time'),
+        'pageViews': analytics_for_column('page_views'),
+        'participations': analytics_for_column('participations'),
+    }
+
+
+def quantiles(series, count):
+    """Return a given number of evenly spaced quantiles for a given series"""
+    return [series.quantile(n / count) for n in range(0, count + 1)]
+
+
+def zptile(z_score):
+    """Derive percentile from zscore"""
+    return 50 * (math.erf(z_score / 2 ** .5) + 1)
+
+
+def zscore(dataframe, row, column_name):
+    """Given a dataframe, an individual row, and column name, return a zscore for the value at that position"""
+    return (row[column_name].values[0] - dataframe[column_name].mean()) / dataframe[column_name].std(ddof=0)

--- a/fixtures/canvas_user_for_uid_61889.json
+++ b/fixtures/canvas_user_for_uid_61889.json
@@ -1,0 +1,17 @@
+{
+  "id": 9000100,
+  "name": "Oski Bear",
+  "sortable_name": "Bear, Oski",
+  "short_name": "Oski Bear",
+  "sis_user_id": "UID:61889",
+  "integration_id": null,
+  "sis_login_id": "61889",
+  "sis_import_id": 123456,
+  "login_id": "61889",
+  "avatar_url": "https://calspirit.berkeley.edu/oski/images/oskibio.jpg",
+  "locale": null,
+  "permissions": {
+    "can_update_name": false,
+    "can_update_avatar": true
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-Login
 Flask-SQLAlchemy
 SQLAlchemy
 cx_Oracle
+pandas
 psycopg2
 requests
 https://github.com/python-cas/python-cas/archive/master.zip


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-37

Big thanks to @sandeepmjay for the introduction to pandas.

This endpoint will be slow in production, given the number of Canvas requests involved; however, it should provide enough data to construct a demo-worthy view of an individual user.