### PR TITLE
BOAC-8 Allow scripts to quickly pull down a whole lotta JSON

### DIFF
--- a/boac/lib/scriptify.py
+++ b/boac/lib/scriptify.py
@@ -1,0 +1,18 @@
+"""Execute script functions in an app context."""
+
+from functools import wraps
+from boac.factory import create_app
+
+
+def in_app(func):
+    @wraps(func)
+    def _in_app_func(*args, **kw):
+        app = create_app()
+        ac = app.app_context()
+        try:
+            ac.push()
+            kw['app'] = app
+            func(*args, **kw)
+        finally:
+            ac.pop()
+    return _in_app_func

--- a/scripts/example_generate_fixtures.py
+++ b/scripts/example_generate_fixtures.py
@@ -1,0 +1,15 @@
+import os
+# Boilerplate allowing scripts in the /scripts directory to find the boac module.
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from boac.lib import scriptify
+
+os.environ['FIXTURE_OUTPUT_PATH'] = os.path.expanduser('~/tmp')
+
+@scriptify.in_app
+def main(app):
+    from boac.externals import canvas
+    for uid in range(1, 20):
+        canvas.get_user_for_uid(app.canvas_instance, uid)
+
+main()


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-8

Thanks @raydavis for working out the scriptify part of this!

Usage as shown in `scripts/example_generate_fixtures.py` is straightforward. Request functions must be decorated with `@fixture` in order to write fixture files; but then you can rest easy that the function will find the right file when it comes time to read the fixture back.

It's also possible to generate fixtures by starting the app with a `FIXTURE_OUTPUT_PATH` environment variable and clicking around; but I assume that will be a less common case for us.