### PR TITLE
NOJIRA Make python scripts lintable

### DIFF
--- a/scripts/example_generate_fixtures.py
+++ b/scripts/example_generate_fixtures.py
@@ -1,15 +1,15 @@
 import os
-# Boilerplate allowing scripts in the /scripts directory to find the boac module.
-import sys
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from boac.lib import scriptify
+from .scriptpath import scriptify
+
 
 os.environ['FIXTURE_OUTPUT_PATH'] = os.path.expanduser('~/tmp')
+
 
 @scriptify.in_app
 def main(app):
     from boac.externals import canvas
     for uid in range(1, 20):
         canvas.get_user_for_uid(app.canvas_instance, uid)
+
 
 main()

--- a/scripts/scriptpath.py
+++ b/scripts/scriptpath.py
@@ -1,0 +1,6 @@
+# Boilerplate allowing scripts in the /scripts directory to find the boac module.
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from boac.lib import scriptify

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
 [testenv:lint-py]
 # Bottom of file has Flake8 settings
 commands =
-    flake8 boac config tests run.py
+    flake8 boac config scripts tests run.py
 deps =
     flake8
     flake8-colors
@@ -46,6 +46,7 @@ exclude =
     __pycache__
     build,dist
     node_modules
+    scriptpath.py
     *.pyc
     .cache
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s


### PR DESCRIPTION
This seems to work - put the funny business in `scriptpath.py` and tell flake8 to ignore it.