### PR TITLE
BOAC-46 Support sample cohorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ boac/static/lib
 # Local configs
 config/*-local.py
 
+# Temporary files
+tmp/
+
 ########################################
 # GitHub boilerplate below...
 

--- a/boac/externals/sis_athlete_api.py
+++ b/boac/externals/sis_athlete_api.py
@@ -1,0 +1,18 @@
+"""Official access to team memberships"""
+
+from boac.lib import http
+from flask import current_app as app
+
+
+def get_team(sport):
+    url = f"{app.config['ATHLETE_API_URL']}/sport/{sport}"
+    return authorized_request(url)
+
+
+def authorized_request(url):
+    auth_headers = {
+        'app_id': app.config['ATHLETE_API_ID'],
+        'app_key': app.config['ATHLETE_API_KEY'],
+        'Accept': 'application/json',
+    }
+    return http.request(url, auth_headers)

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -25,11 +25,13 @@ class AuthorizedUser(Base, UserMixin):
         self.is_director = is_director
 
     def __repr__(self):
-        return '<AuthorizedUser {}, is_advisor={}, is_admin={}, is_director={}>'.format(
+        return '<AuthorizedUser {}, is_advisor={}, is_admin={}, is_director={}, updated={}, created={}>'.format(
             self.uid,
             self.is_advisor,
             self.is_admin,
             self.is_director,
+            self.updated_at,
+            self.created_at,
         )
 
     def get_id(self):

--- a/boac/models/base.py
+++ b/boac/models/base.py
@@ -1,3 +1,4 @@
+import csv
 from datetime import datetime
 
 from boac import db
@@ -14,3 +15,12 @@ class Base(db.Model):
 
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
+
+    @classmethod
+    def load_csv(klass, filename):
+        with open(filename) as csvfile:
+            reader = csv.DictReader(csvfile)
+            for csvrow in reader:
+                record = klass(**csvrow)
+                db.session.add(record)
+        db.session.commit()

--- a/boac/models/cohort.py
+++ b/boac/models/cohort.py
@@ -1,0 +1,72 @@
+"""Cohort definitions and memberships
+
+This table is a temporary aid for early development. It will be dropped
+when LDAP binds and caching are in place.
+"""
+
+from boac import db
+from boac.models.base import Base
+from sqlalchemy import UniqueConstraint
+
+
+class Cohort(Base):
+    __tablename__ = 'cohorts'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
+    code = db.Column(db.String(255), nullable=False)
+    member_uid = db.Column(db.String(80), nullable=False)
+    member_csid = db.Column(db.String(80))
+    member_name = db.Column(db.String(255))
+    UniqueConstraint('code', 'member_uid', name='cohort_membership')
+
+    def __init__(self, code, member_uid, member_csid=None, member_name=None):
+        self.code = code
+        self.member_uid = member_uid
+        self.member_csid = member_csid
+        self.member_name = member_name
+
+    def __repr__(self):
+        return '<Cohort {} ({}), uid={}, csid={}, name={}, updated={}, created={}>'.format(
+            self.cohort_definitions.get(self.code),
+            self.code,
+            self.member_uid,
+            self.member_csid,
+            self.member_name,
+            self.updated_at,
+            self.created_at,
+        )
+
+    cohort_definitions = {
+        'BAM': 'Baseball - Men',
+        'BBM': 'Basketball - Men',
+        'BBW': 'Basketball - Women',
+        'CCM': 'Cross Country - Men',
+        'CCW': 'Cross Country - Women',
+        'CRM': 'Crew - Men',
+        'CRW': 'Crew - Women',
+        'EMX': 'Equipment Managers',
+        'FBM': 'Football - Men',
+        'FHW': 'Field Hockey - Women',
+        'GOM': 'Golf - Men',
+        'GOW': 'Golf - Women',
+        'GYM': 'Gymnastics - Men',
+        'GYW': 'Gymnastics - Women',
+        'LCW': 'Lacrosse - Women',
+        'RGM': 'Rugby - Men',
+        'SBW': 'Softball - Women',
+        'SCM': 'Soccer - Men',
+        'SCW': 'Soccer - Women',
+        'SDM': 'Swimming & Diving - Men',
+        'SDW': 'Swimming & Diving - Women',
+        'STX': 'Student Trainers',
+        'SVW': 'Sand Volleyball - Women',
+        'TIM': 'Indoor Track & Field - Men',
+        'TIW': 'Indoor Track & Field - Women',
+        'TNM': 'Tennis - Men',
+        'TNW': 'Tennis - Women',
+        'TOM': 'Outdoor Track & Field - Men',
+        'TOW': 'Outdoor Track & Field - Women',
+        'VBW': 'Volleyball - Women',
+        'WPM': 'Water Polo - Men',
+        'WPW': 'Water Polo - Women',
+    }

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -1,6 +1,8 @@
 import csv
 from boac import db
 from boac.models.authorized_user import AuthorizedUser
+# Needed for db.create_all to find the model.
+from boac.models.cohort import Cohort # noqa
 
 
 def clear():

--- a/config/default.py
+++ b/config/default.py
@@ -29,11 +29,17 @@ DEVELOPER_AUTH_PASSWORD = 'another secret'
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
 CAS_LOGOUT_URL = 'https://auth-test.berkeley.edu/cas/logout'
 
+# Canvas APIs
 CANVAS_HTTP_SCHEME = 'https'
 CANVAS_HTTP_DOMAIN = 'wottsamatta.instructure.com'
 CANVAS_HTTP_TOKEN = 'yet another secret'
 
 CANVAS_CURRENT_ENROLLMENT_TERM = 5493
+
+# SIS APIs
+ATHLETE_API_ID = 'secretid'
+ATHLETE_API_KEY = 'secretkey'
+ATHLETE_API_URL = 'https://secreturl/athletes'
 
 # Logging
 LOGGING_FORMAT = '[%(asctime)s] - %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'

--- a/fixtures/sis_athlete_api_FHW.json
+++ b/fixtures/sis_athlete_api_FHW.json
@@ -1,0 +1,43 @@
+{
+  "apiResponse": {
+    "httpStatus": {
+      "code": "200",
+      "description": "OK"
+    },
+    "responseType": "namespaceURI=\"http://bmeta.berkeley.edu/student/athleteV0.xsd\" element=\"athletes\"",
+    "response": {
+      "athletes": {
+        "athlete": [
+          {
+            "identifier": {
+              "type": "student-id",
+              "id": "12345678",
+              "disclose": false
+            },
+            "athleteSport": [
+              {
+                "sport": {
+                  "code": "FHW",
+                  "description": "Field Hockey - Women"
+                },
+                "currentParticipant": true,
+                "enteredOnFinancialAid": false,
+                "participation": [
+                  {
+                    "type": {
+                      "code": "ACTCM",
+                      "description": "Active, Compete"
+                    },
+                    "ncaaEligible": true,
+                    "fromDate": "2017-08-09",
+                    "comments": "Eligible to Compete."
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-Login
 Flask-SQLAlchemy
 SQLAlchemy
 cx_Oracle
+names
 pandas
 psycopg2
 requests

--- a/tests/fixtures/cohorts.py
+++ b/tests/fixtures/cohorts.py
@@ -1,0 +1,10 @@
+from boac.models.cohort import Cohort
+import pytest
+
+
+@pytest.fixture
+def fixture_cohorts(db_session):
+    field_hockey_star = Cohort('FHW', '61889', '12345678', 'Brigitte Lin')
+    db_session.add(field_hockey_star)
+    db_session.commit()
+    return [field_hockey_star]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-46

It would be nice to be able to load the sample Cohorts data (at the JIRA ticket) through a `run.py` CLI command, but I didn't want to delay this PR any longer. Here's how I did it through a scriptified console:

```
from boac.models.cohort import Cohort
Cohort.load_csv('tmp/cohorts.csv')
```