### PR TITLE
BOAC-51 Simple API feeds for cohort data

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -1,0 +1,18 @@
+from boac.models.cohort import Cohort
+
+from flask import current_app as app, jsonify
+from flask_login import login_required
+
+
+@app.route('/api/cohorts')
+@login_required
+def cohorts_list():
+    cohorts = Cohort.list_all()
+    return jsonify(cohorts)
+
+
+@app.route('/api/cohort/<cohort_code>')
+@login_required
+def cohort_details(cohort_code):
+    cohort = Cohort.for_code(cohort_code)
+    return jsonify(cohort)

--- a/boac/api/error_handlers.py
+++ b/boac/api/error_handlers.py
@@ -1,0 +1,33 @@
+import boac.api.errors
+from flask import current_app as app, jsonify
+
+
+@app.errorhandler(boac.api.errors.BadRequestError)
+def handle_bad_request(error):
+    return error.to_json(), 400
+
+
+@app.errorhandler(boac.api.errors.UnauthorizedRequestError)
+def handle_unauthorized(error):
+    return error.to_json(), 401
+
+
+@app.errorhandler(boac.api.errors.ForbiddenRequestError)
+def handle_forbidden(error):
+    return error.to_json(), 403
+
+
+@app.errorhandler(boac.api.errors.ResourceNotFoundError)
+def handle_resource_not_found(error):
+    return error.to_json(), 404
+
+
+@app.errorhandler(boac.api.errors.InternalServerError)
+def handle_internal_server_error(error):
+    return error.to_json(), 500
+
+
+@app.errorhandler(Exception)
+def handle_unexpected_error(error):
+    app.logger.exception(error)
+    return jsonify({'message': 'An unexpected server error occurred.'}), 500

--- a/boac/api/errors.py
+++ b/boac/api/errors.py
@@ -1,4 +1,3 @@
-from flask import current_app as app
 from flask import jsonify
 
 
@@ -32,34 +31,3 @@ class ResourceNotFoundError(JsonableException):
 
 class InternalServerError(JsonableException):
     pass
-
-
-@app.errorhandler(BadRequestError)
-def handle_bad_request(error):
-    return error.to_json(), 400
-
-
-@app.errorhandler(UnauthorizedRequestError)
-def handle_unauthorized(error):
-    return error.to_json(), 401
-
-
-@app.errorhandler(ForbiddenRequestError)
-def handle_forbidden(error):
-    return error.to_json(), 403
-
-
-@app.errorhandler(ResourceNotFoundError)
-def handle_resource_not_found(error):
-    return error.to_json(), 404
-
-
-@app.errorhandler(InternalServerError)
-def handle_internal_server_error(error):
-    return error.to_json(), 500
-
-
-@app.errorhandler(Exception)
-def handle_unexpected_error(error):
-    app.logger.exception(error)
-    return jsonify({'message': 'An unexpected server error occurred.'}), 500

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -14,12 +14,13 @@ def register_routes(app):
     import boac.auth.cas_auth
 
     # Register API routes.
+    import boac.api.cohort_controller
+    import boac.api.config_controller
     import boac.api.status_controller
     import boac.api.user_controller
-    import boac.api.config_controller
 
     # Register error handlers.
-    import boac.api.errors
+    import boac.api.error_handlers
 
     # Unmatched API routes return a 404.
     @app.route('/api/<path:path>')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@ import os
 import boac.factory
 import pytest
 
+from tests.fixtures.cohorts import fixture_cohorts # noqa
+
+
 os.environ['BOAC_ENV'] = 'test'
 
 
@@ -66,10 +69,9 @@ def db_session(db, request):
     _session = db.create_scoped_session(options=options)
     db.session = _session
 
-    # Roll back transaction and close connection when the test is complete.
+    # Roll back transaction when the test is complete.
     def teardown():
         transaction.rollback()
-        connection.close()
         _session.remove()
     request.addfinalizer(teardown)
 

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -1,0 +1,55 @@
+import pytest
+
+
+@pytest.fixture()
+def authenticated_session(fake_auth):
+    test_uid = '1133399'
+    fake_auth.login(test_uid)
+
+
+class TestCohortsList:
+    """Cohorts list API"""
+
+    api_path = '/api/cohorts'
+
+    def test_not_authenticated(self, client, fixture_cohorts):
+        """returns 401 if not authenticated"""
+        response = client.get(TestCohortsList.api_path)
+        assert response.status_code == 401
+
+    def test_authenticated(self, authenticated_session, client, fixture_cohorts):
+        """returns a well-formed response if authenticated"""
+        response = client.get(TestCohortsList.api_path)
+        assert response.status_code == 200
+        assert len(response.json) == 1
+        assert response.json[0]['code'] == 'FHW'
+        assert response.json[0]['name'] == 'Field Hockey - Women'
+        assert response.json[0]['memberCount'] == 1
+
+
+class TestCohortDetail:
+    """Cohort detail API"""
+
+    valid_api_path = '/api/cohort/FHW'
+    invalid_api_path = '/api/cohort/XYZ'
+
+    def test_not_authenticated(self, client, fixture_cohorts):
+        """returns 401 if not authenticated"""
+        response = client.get(TestCohortDetail.valid_api_path)
+        assert response.status_code == 401
+
+    def test_invalid_path(self, authenticated_session, client, fixture_cohorts):
+        """returns 400 on a nonexistent code"""
+        response = client.get(TestCohortDetail.invalid_api_path)
+        assert response.status_code == 400
+        assert response.json['message'] == 'Cohort code "XYZ" not found'
+
+    def test_valid_path(self, authenticated_session, client, fixture_cohorts):
+        """returns a well-formed response on a valid code if authenticated"""
+        response = client.get(TestCohortDetail.valid_api_path)
+        assert response.status_code == 200
+        assert response.json['code'] == 'FHW'
+        assert response.json['name'] == 'Field Hockey - Women'
+        assert len(response.json['members']) == 1
+        assert response.json['members'][0]['name'] == 'Brigitte Lin'
+        assert response.json['members'][0]['uid'] == '61889'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-51

Since the whole backing of the cohort model is likely to change, I kept tests simple and at the controller level.

However, these are BOAC's first tests that directly depend on database-backed fixtures, and some additional changes were needed to get things working.