### PR TITLE
BOAC-47, tolerant_jsonify will not put NaN to JSON response; student view ng-repeats

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,7 +44,7 @@ rules:
     - all
   default-case: 2
   dot-notation:
-    - 2
+    - 1
     - allowKeywords: false
   eol-last: 2
   eqeqeq: 2

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -1,8 +1,9 @@
 from boac.api import errors
 from boac.externals import canvas
 from boac.lib.analytics import analytics_from_summary_feed
+from boac.lib.http import tolerant_jsonify
 
-from flask import current_app as app, jsonify
+from flask import current_app as app
 from flask_login import current_user, login_required
 
 
@@ -20,7 +21,7 @@ def user_profile():
             }
     else:
         uid = False
-    return jsonify({
+    return tolerant_jsonify({
         'uid': uid,
         'canvas_profile': canvas_profile,
     })
@@ -55,7 +56,7 @@ def user_analytics(uid):
             course_analytics['analytics'] = analytics_from_summary_feed(student_summaries, canvas_id, course)
         course_analytics_feed.append(course_analytics)
 
-    return jsonify({
+    return tolerant_jsonify({
         'uid': uid,
         'canvasProfile': canvas_profile.json(),
         'courses': course_analytics_feed,

--- a/boac/lib/http.py
+++ b/boac/lib/http.py
@@ -1,5 +1,7 @@
 from flask import current_app as app
+from flask import Response
 import requests
+import simplejson as json
 
 
 class ResponseExceptionWrapper:
@@ -56,3 +58,7 @@ def sanitize_headers(headers):
         return sanitized
     else:
         return headers
+
+
+def tolerant_jsonify(obj, **kwargs):
+    return Response(json.dumps(obj, ignore_nan=True, **kwargs), mimetype='application/json')

--- a/boac/static/js/controllers/studentController.js
+++ b/boac/static/js/controllers/studentController.js
@@ -4,14 +4,24 @@
 
   angular.module('boac').controller('StudentController', function(analyticsFactory, $scope, $stateParams) {
 
-    $scope.student = {
-      canvasProfile: null,
-      courses: null
+    var loadAnalytics = function() {
+      $scope.student.isLoading = true;
+      analyticsFactory.analyticsPerUser($stateParams.uid).then(function(analytics) {
+        $scope.student = analytics.data;
+      }).catch(function(error) {
+        $scope.error = _.truncate(error.message, {length: 200});
+      }).then(function() {
+        $scope.student.isLoading = false;
+      });
     };
 
-    analyticsFactory.analyticsPerUser($stateParams.uid).then(function(analytics) {
-      $scope.student = analytics.data;
-    });
+    $scope.student = {
+      canvasProfile: null,
+      courses: null,
+      isLoading: true
+    };
+
+    loadAnalytics();
   });
 
 }(window.angular));

--- a/boac/static/templates/student.html
+++ b/boac/static/templates/student.html
@@ -1,17 +1,15 @@
 <div data-ng-include="'/static/templates/header.html'"></div>
 
 <div class="container" data-ng-controller="StudentController">
-  <div class="container-left" data-ng-if="student.canvasProfile">
+  <div class="container-left" data-ng-if="!student.isLoading && !error">
      <img class="profile-summary-avatar" data-ng-src="{{student.canvasProfile.avatar_url}}" data-ng-if="student.canvasProfile.avatar_url"/>
      <h1 data-ng-bind="student.canvasProfile.name"></h1>
   </div>
-  <div class="container-left" data-ng-if="student">
+  <div class="container-left" data-ng-if="!student.isLoading && !error">
       <div data-ng-if="student.courses">
         <ul>
             <li data-ng-repeat="course in student.courses">
-              <div class="media-left media-middle">
-                <h2 data-ng-bind="course.courseCode"></h2>
-              </div>
+              <h2 data-ng-bind="course.courseCode"></h2>
               <ul>
                   <li data-ng-repeat="report in course.analytics">
                       <div data-ng-bind="report.assignmentsOnTime.student"></div>
@@ -25,6 +23,10 @@
       <div data-ng-if="!student.courses">
           No courses
       </div>
+  </div>
+  <div class="container-left" data-ng-if="!student.isLoading && error">
+    <h1>Error</h1>
+    <div data-ng-bind="error"></div>
   </div>
 </div>
 

--- a/boac/templates/index.html
+++ b/boac/templates/index.html
@@ -8,9 +8,12 @@
   </head>
 
   <body ui-view>
+    <!-- Third-party -->
     <script src="/static/lib/angular/angular.min.js"></script>
     <script src="/static/lib/angular-ui-router/release/angular-ui-router.min.js"></script>
+    <script src="/static/lib/lodash/dist/lodash.min.js"></script>
 
+    <!-- BOAC -->
     <script src="/static/js/app.js"></script>
     <script src="/static/js/routes.js"></script>
     <script src="/static/js/controllers/authController.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "angular": "^1.6.6",
     "angular-ui-router": "^0.3.2",
-    "bootstrap": "^3.3.7"
+    "bootstrap": "^3.3.7",
+    "lodash": "^4.17.4"
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ names
 pandas
 psycopg2
 requests
+simplejson
 https://github.com/python-cas/python-cas/archive/master.zip
 # For testing
 https://github.com/gabrielfalcao/HTTPretty/archive/master.zip


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-47

Standard (Flask) encoder does not produce valid JSON when given `float('nan')`.  The front-end would choke when, for example, feed included: `"zscore": NaN`.   [simplejson](https://simplejson.readthedocs.io) has a solution whereby _float('nan')_ translates to `null` in the feed.
