### PR TITLE
BOAC-52, npm install tox deps only if necessary (faster linting)

### DIFF
--- a/scripts/install-tox-deps.sh
+++ b/scripts/install-tox-deps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Fail the entire script when one of the commands in it fails
+set -e
+
+hash eslint 2>/dev/null || npm install --save-dev --silent -g eslint
+
+hash stylelint 2>/dev/null || \
+  (
+    npm install --save-dev --silent -g stylelint && \
+    npm install --save-dev --silent stylelint-config-standard stylelint-order stylelint-scss debug
+  )
+
+exit 0

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 
 [testenv:lint-js]
 commands =
-    npm install -g eslint --silent
+    {toxinidir}/scripts/install-tox-deps.sh
     eslint --color boac/static/js
 
 [testenv:lint-py]
@@ -35,8 +35,7 @@ deps =
 
 [testenv:lint-css]
 commands =
-    npm install -g stylelint --silent
-    npm install stylelint-config-standard stylelint-order stylelint-scss debug --save-dev --silent
+    {toxinidir}/scripts/install-tox-deps.sh
     stylelint boac/static/css/*
 
 [flake8]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-52

The `commands` section of tox.ini file does not allow for BASH-like conditional. Delegating to a script seems acceptable if we get faster linting.