### PR TITLE
NOJIRA, script to load cohort.csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,8 @@ tox -e test
 tox -e lint-py
 tox -e lint-js
 tox -e lint-css
+
+# Lint specific file(s)
+tox -e lint-js -- boac/static/js/controllers/cohortController.js
+tox -e lint-py -- scripts/cohort_fixtures.py
 ```

--- a/scripts/load_cohorts_csv.py
+++ b/scripts/load_cohorts_csv.py
@@ -1,0 +1,13 @@
+import os
+from scriptpath import scriptify
+
+
+@scriptify.in_app
+def main(app):
+    from boac.models.cohort import Cohort
+    cohorts_csv = '{}/cohorts.csv'.format(os.path.expanduser('~/tmp/fixtures'))
+    Cohort.load_csv(cohorts_csv)
+    print('\nDone. Data inserted in BOAC db.'.format(cohorts_csv), end='\n\n')
+
+
+main()

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,12 @@ commands =
 [testenv:lint-js]
 commands =
     {toxinidir}/scripts/install-tox-deps.sh
-    eslint --color boac/static/js
+    eslint --color {posargs:boac/static/js}
 
 [testenv:lint-py]
 # Bottom of file has Flake8 settings
 commands =
-    flake8 boac config scripts tests run.py
+    flake8 {posargs:boac config scripts tests run.py}
 deps =
     flake8
     flake8-colors
@@ -36,7 +36,7 @@ deps =
 [testenv:lint-css]
 commands =
     {toxinidir}/scripts/install-tox-deps.sh
-    stylelint boac/static/css/*
+    stylelint {posargs:boac/static/css/*}
 
 [flake8]
 exclude =


### PR DESCRIPTION
`scripts/load_cohorts_csv.py` will be removed when we're done with `cohorts` table (demo mode).

PR includes `tox.ini` enhancement:
```
# Lint specific file(s)
tox -e lint-js -- boac/static/js/controllers/cohortController.js
tox -e lint-py -- scripts/cohort_fixtures.py
```