### PR TITLE
NOJIRA Fix example fixture script

### DIFF
--- a/scripts/example_generate_fixtures.py
+++ b/scripts/example_generate_fixtures.py
@@ -1,5 +1,5 @@
 import os
-from .scriptpath import scriptify
+from scriptpath import scriptify
 
 
 os.environ['FIXTURE_OUTPUT_PATH'] = os.path.expanduser('~/tmp')


### PR DESCRIPTION
PyCharm wants a dot, but the dot seems to make the script unrunnable. Sorry, PyCharm!