### PR TITLE
BOAC-62 Upgrade D3 to v4; constrain panning on cohort plot

### DIFF
--- a/boac/static/app/shared/scatterplot.css
+++ b/boac/static/app/shared/scatterplot.css
@@ -1,7 +1,7 @@
 #scatterplot {
-  width: 960px;
-  height: 546px;
-  margin-bottom: 60px;
+  width: 910px;
+  height: 500px;
+  margin: 45px 20px 60px 20px;
 }
 
 rect {

--- a/boac/templates/index.html
+++ b/boac/templates/index.html
@@ -13,7 +13,7 @@
     <!-- Third-party -->
     <script src="/static/lib/angular/angular.min.js"></script>
     <script src="/static/lib/angular-ui-router/release/angular-ui-router.min.js"></script>
-    <script src="/static/lib/d3/d3.v2.min.js"></script>
+    <script src="/static/lib/d3/d3.min.js"></script>
     <script src="/static/lib/highcharts-release/adapters/standalone-framework.js"></script>
     <script src="/static/lib/highcharts-release/highcharts.js"></script>
     <script src="/static/lib/highcharts-release/highcharts-more.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "angular": "^1.6.6",
     "angular-ui-router": "^0.3.2",
     "bootstrap": "^3.3.7",
-    "d3": "2.9.2",
+    "d3": "4.8.0",
     "highcharts-release": "4.1.10",
     "lodash": "^4.17.4"
   }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-62

- Newer D3 versions have a substantially different API;
- `translateExtent` keeps us from panning out of bounds;
- moving chart margins out of SVG calculations and into straight CSS fixes weird offset-on-zoom issues.