### PR TITLE
BOAC-65 Handle cohort codes with no hardcoded code-to-name translation

### DIFF
--- a/boac/models/cohort.py
+++ b/boac/models/cohort.py
@@ -5,7 +5,6 @@ when LDAP binds and caching are in place.
 """
 
 from boac import db
-import boac.api.errors
 from boac.models.base import Base
 from sqlalchemy import func, UniqueConstraint
 
@@ -79,21 +78,17 @@ class Cohort(Base):
         def translate_row(row):
             return {
                 'code': row[0],
-                'name': cls.cohort_definitions.get(row[0]),
+                'name': cls.cohort_definitions.get(row[0], row[0]),
                 'memberCount': row[1],
             }
         return [translate_row(row) for row in results]
 
     @classmethod
     def for_code(cls, code):
-        name = cls.cohort_definitions.get(code)
-        if not name:
-            raise boac.api.errors.BadRequestError('Cohort code "{}" not found'.format(code))
-
         members = cls.query.filter_by(code=code).all()
         return {
             'code': code,
-            'name': name,
+            'name': cls.cohort_definitions.get(code, code),
             'members': [member.to_api_json() for member in members],
         }
 

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -38,11 +38,13 @@ class TestCohortDetail:
         response = client.get(TestCohortDetail.valid_api_path)
         assert response.status_code == 401
 
-    def test_invalid_path(self, authenticated_session, client, fixture_cohorts):
-        """returns 400 on a nonexistent code"""
+    def test_path_without_translation(self, authenticated_session, client, fixture_cohorts):
+        """returns code as name when no code-to-name translation exists"""
         response = client.get(TestCohortDetail.invalid_api_path)
-        assert response.status_code == 400
-        assert response.json['message'] == 'Cohort code "XYZ" not found'
+        assert response.status_code == 200
+        assert response.json['code'] == 'XYZ'
+        assert response.json['name'] == 'XYZ'
+        assert len(response.json['members']) == 0
 
     def test_valid_path(self, authenticated_session, client, fixture_cohorts):
         """returns a well-formed response on a valid code if authenticated"""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-65

This is a quick way to support obfuscated team names without explicitly defining them in code. With this change, Postgres data can be altered to use arbitrary demo codes:

`update cohorts set code = 'Demo Team - Women' where code = 'CRW';`

and the app will handle them without complaint.