### PR TITLE
BOAC-75 Include SIS enrollment data in user API feeds when present

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -1,3 +1,4 @@
+from boac.api.util import canvas_courses_api_feed
 from boac.externals import canvas
 from boac.lib.analytics import mean_course_analytics_for_user
 from boac.lib.http import tolerant_jsonify
@@ -26,7 +27,9 @@ def cohort_details(cohort_code):
             if canvas_profile:
                 profile_json = canvas_profile.json()
                 member['avatar_url'] = profile_json['avatar_url']
-                member['analytics'] = mean_course_analytics_for_user(member['uid'], profile_json['id'])
+                canvas_courses = canvas_courses_api_feed(canvas.get_user_courses(app.canvas_instance, member['uid']))
+                if canvas_courses:
+                    member['analytics'] = mean_course_analytics_for_user(canvas_courses, profile_json['id'])
         if app.cache:
             app.cache.set(cache_key, cohort)
     return tolerant_jsonify(cohort)

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -1,6 +1,11 @@
+import re
+
 from boac.api import errors
+import boac.api.util as api_util
 from boac.externals import canvas
-from boac.lib.analytics import course_analytics_for_user
+from boac.externals import sis_enrollments_api
+from boac.lib.analytics import merge_analytics_for_user
+from boac.lib.berkeley import sis_term_id_for_name
 from boac.lib.http import tolerant_jsonify
 from boac.models.cohort import Cohort
 
@@ -39,17 +44,49 @@ def user_analytics(uid):
             raise errors.InternalServerError('Unable to reach bCourses')
     canvas_id = canvas_profile.json()['id']
 
-    course_analytics_feed = course_analytics_for_user(uid, canvas_id)
+    user_courses = canvas.get_user_courses(app.canvas_instance, uid)
+    courses_api_feed = api_util.canvas_courses_api_feed(user_courses)
 
     cohort_data = Cohort.query.filter_by(member_uid=uid).first()
+    if cohort_data and len(user_courses):
+        term_id = sis_term_id_for_name(user_courses[0].get('term', {}).get('name'))
+        merge_sis_enrollments(courses_api_feed, cohort_data.member_csid, term_id)
+
+    merge_analytics_for_user(courses_api_feed, canvas_id)
+
     if cohort_data:
         cohort_data = cohort_data.to_api_json()
-
-    app.logger.error('User {} analytics: {}'.format(uid, repr(course_analytics_feed)))
 
     return tolerant_jsonify({
         'uid': uid,
         'canvasProfile': canvas_profile.json(),
         'cohortData': cohort_data,
-        'courses': course_analytics_feed,
+        'courses': courses_api_feed,
     })
+
+
+def merge_sis_enrollments(canvas_course_sites, cs_id, term_id):
+    # TODO For the moment, we're returning Canvas courses only for the current term as defined in
+    # app config. Once we start grabbing multiple terms, we'll need additional sorting logic.
+    enrollments = sis_enrollments_api.get_enrollments(cs_id, term_id)
+    if enrollments:
+        enrollments = enrollments.json().get('apiResponse', {}).get('response', {}).get('studentEnrollments', [])
+    else:
+        return
+
+    for site in canvas_course_sites:
+        site['sisEnrollments'] = []
+        sections = canvas.get_course_sections(app.canvas_instance, site['canvasCourseId'])
+        if not sections:
+            continue
+        for section in sections:
+            ccn_match = re.match(r'\ASEC:20\d{2}-[BCD]-(\d{5})\Z', section.get('sis_section_id'))
+            if ccn_match:
+                canvas_ccn = ccn_match.group(1)
+            if not canvas_ccn:
+                continue
+            for enrollment in enrollments:
+                sis_ccn = str(enrollment.get('classSection', {}).get('id'))
+                if canvas_ccn == sis_ccn:
+                    site['sisEnrollments'].append(api_util.sis_enrollment_api_feed(enrollment))
+                    break

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -1,0 +1,29 @@
+"""Utility module containing standard API-feed translations of data objects."""
+
+
+def canvas_courses_api_feed(courses):
+    if not courses:
+        return []
+
+    def course_api_values(course):
+        return {
+            'canvasCourseId': course.get('id'),
+            'courseName': course.get('name'),
+            'courseCode': course.get('course_code'),
+        }
+    return [course_api_values(course) for course in courses]
+
+
+def sis_enrollment_api_feed(enrollment):
+    sectionData = enrollment.get('classSection', {})
+    classData = sectionData.get('class', {})
+    grades = enrollment.get('grades', [])
+    return {
+        'ccn': sectionData.get('id'),
+        'displayName': classData.get('course', {}).get('displayName'),
+        'sectionNumber': classData.get('number'),
+        'enrollmentStatus': enrollment.get('enrollmentStatus', {}).get('status', {}).get('code'),
+        'units': enrollment.get('enrolledUnits', {}).get('taken'),
+        'gradingBasis': enrollment.get('gradingBasis', {}).get('code'),
+        'grade': next((grade.get('mark') for grade in grades if grade.get('type', {}).get('code') == 'OFFL'), None),
+    }

--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -7,9 +7,8 @@ from flask import current_app as app
 
 @fixture('canvas_course_sections_{course_id}')
 def get_course_sections(canvas_instance, course_id, mock=None):
-    url = build_url(canvas_instance, f'/api/v1/courses/{course_id}/sections')
-    with mock(url):
-        return authorized_request(canvas_instance, url)
+    path = f'/api/v1/courses/{course_id}/sections'
+    return paged_request(canvas_instance, path=path, mock=mock)
 
 
 @fixture('canvas_user_for_uid_{uid}')

--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -5,31 +5,22 @@ from flask import current_app as app
 import pandas
 
 
-def course_analytics_for_user(uid, canvas_user_id):
-    analytics_per_course = []
-    user_courses = canvas.get_user_courses(app.canvas_instance, uid)
+def merge_analytics_for_user(user_courses, canvas_user_id):
     if user_courses:
         for course in user_courses:
-            course_analytics = {
-                'canvasCourseId': course['id'],
-                'courseName': course['name'],
-                'courseCode': course['course_code'],
-            }
-            student_summaries = canvas.get_student_summaries(app.canvas_instance, course['id'])
+            student_summaries = canvas.get_student_summaries(app.canvas_instance, course['canvasCourseId'])
             if not student_summaries:
-                course_analytics['analytics'] = {'error': 'Unable to retrieve analytics'}
+                course['analytics'] = {'error': 'Unable to retrieve analytics'}
             else:
-                course_analytics['analytics'] = analytics_from_summary_feed(student_summaries, canvas_user_id, course)
-            analytics_per_course.append(course_analytics)
-    return analytics_per_course
+                course['analytics'] = analytics_from_summary_feed(student_summaries, canvas_user_id, course)
 
 
-def mean_course_analytics_for_user(uid, canvas_user_id):
-    courses = course_analytics_for_user(uid, canvas_user_id)
+def mean_course_analytics_for_user(user_courses, canvas_user_id):
+    merge_analytics_for_user(user_courses, canvas_user_id)
     meanValues = {}
     for metric in ['assignmentsOnTime', 'pageViews', 'participations']:
         percentiles = []
-        for course in courses:
+        for course in user_courses:
             if course['analytics'].get(metric):
                 percentile = course['analytics'][metric]['student']['percentile']
                 if percentile and not math.isnan(percentile):

--- a/tests/fixtures/cohorts.py
+++ b/tests/fixtures/cohorts.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture
 def fixture_cohorts(db_session):
-    field_hockey_star = Cohort('FHW', '61889', '12345678', 'Brigitte Lin')
+    field_hockey_star = Cohort('FHW', '61889', '11667051', 'Brigitte Lin')
     db_session.add(field_hockey_star)
     db_session.commit()
     return [field_hockey_star]

--- a/tests/test_externals/test_canvas.py
+++ b/tests/test_externals/test_canvas.py
@@ -14,21 +14,21 @@ class TestCanvasGetCourseSections:
     def test_get_course_sections(self, ucb_canvas):
         """returns fixture data"""
         burmese_sections = canvas.get_course_sections(ucb_canvas, 7654320)
-        assert burmese_sections.status_code == 200
-        assert len(burmese_sections.json()) == 2
-        assert burmese_sections.json()[0]['sis_section_id'] == 'SEC:2017-D-90100'
-        assert burmese_sections.json()[1]['sis_section_id'] == 'SEC:2017-D-90101'
+        assert burmese_sections
+        assert len(burmese_sections) == 2
+        assert burmese_sections[0]['sis_section_id'] == 'SEC:2017-D-90100'
+        assert burmese_sections[1]['sis_section_id'] == 'SEC:2017-D-90101'
 
         medieval_sections = canvas.get_course_sections(ucb_canvas, 7654321)
-        assert medieval_sections.status_code == 200
-        assert len(medieval_sections.json()) == 1
-        assert medieval_sections.json()[0]['sis_section_id'] == 'SEC:2017-D-90200'
+        assert medieval_sections
+        assert len(medieval_sections) == 1
+        assert medieval_sections[0]['sis_section_id'] == 'SEC:2017-D-90200'
 
         nuclear_sections = canvas.get_course_sections(ucb_canvas, 7654323)
-        assert nuclear_sections.status_code == 200
-        assert len(nuclear_sections.json()) == 2
-        assert nuclear_sections.json()[0]['sis_section_id'] == 'SEC:2017-D-90299'
-        assert nuclear_sections.json()[1]['sis_section_id'] == 'SEC:2017-D-90300'
+        assert nuclear_sections
+        assert len(nuclear_sections) == 2
+        assert nuclear_sections[0]['sis_section_id'] == 'SEC:2017-D-90299'
+        assert nuclear_sections[1]['sis_section_id'] == 'SEC:2017-D-90300'
 
     def test_course_not_found(self, ucb_canvas, caplog):
         """logs 404 for unknown user and returns informative message"""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-75

It's a good old Junction-style data munge, with some extra refactoring to keep the analytics module focused on analytics rather than overall feed transformation.