### PR TITLE
BOAC-97, buildspec does not need npm and pip install

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,14 +9,13 @@ eb_codebuild_settings:
 phases:
   install:
     commands:
-      - npm install -g bower
+      - echo "install phase"
   pre_build:
     commands:
       - echo "pre_build phase"
   build:
     commands:
-      - pip install -r requirements.txt
-      - bower install
+      - echo "build phase"
   post_build:
     commands:
       - echo "post_build phase"


### PR DESCRIPTION
For now, buildspec only serves to exclude `test/` and similar resources