### PR TITLE
BOAC-103 Add DB-based caching

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -27,7 +27,7 @@ def cohort_details(cohort_code):
             if canvas_profile:
                 profile_json = canvas_profile.json()
                 member['avatar_url'] = profile_json['avatar_url']
-                canvas_courses = canvas_courses_api_feed(canvas.get_user_courses(member['uid']))
+                canvas_courses = canvas_courses_api_feed(canvas.get_student_courses_in_term(member['uid']))
                 if canvas_courses:
                     member['analytics'] = mean_course_analytics_for_user(canvas_courses, profile_json['id'])
         if app.cache:

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -44,7 +44,7 @@ def user_analytics(uid):
             raise errors.InternalServerError('Unable to reach bCourses')
     canvas_id = canvas_profile.json()['id']
 
-    user_courses = canvas.get_user_courses(uid)
+    user_courses = canvas.get_student_courses_in_term(uid)
     courses_api_feed = api_util.canvas_courses_api_feed(user_courses)
 
     cohort_data = Cohort.query.filter_by(member_uid=uid).first()
@@ -70,7 +70,7 @@ def merge_sis_enrollments(canvas_course_sites, cs_id, term_id):
     # app config. Once we start grabbing multiple terms, we'll need additional sorting logic.
     enrollments = sis_enrollments_api.get_enrollments(cs_id, term_id)
     if enrollments:
-        enrollments = enrollments.json().get('apiResponse', {}).get('response', {}).get('studentEnrollments', [])
+        enrollments = enrollments.get('studentEnrollments', [])
     else:
         return
 

--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -1,10 +1,16 @@
 from boac.lib import http
 from boac.lib.mockingbird import fixture
+from boac.models.json_cache import stow
 from flask import current_app as app
 
 
+@stow('canvas_course_sections_{course_id}', for_term=True)
+def get_course_sections(course_id):
+    return _get_course_sections(course_id)
+
+
 @fixture('canvas_course_sections_{course_id}')
-def get_course_sections(course_id, mock=None):
+def _get_course_sections(course_id, mock=None):
     path = f'/api/v1/courses/{course_id}/sections'
     return paged_request(path=path, mock=mock)
 
@@ -16,27 +22,42 @@ def get_user_for_uid(uid, mock=None):
         return authorized_request(url)
 
 
-@fixture('canvas_user_courses_{uid}')
-def get_user_courses(uid, mock=None):
-    path = f'/api/v1/users/sis_login_id:{uid}/courses'
-    query = {'include': ['term']}
-    response = paged_request(path=path, query=query, mock=mock)
-    if not response:
-        return response
+def get_student_courses_in_term(uid):
+    term_id = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
+    all_canvas_courses = get_all_user_courses(uid)
+    # The paged_request wrapper returns either a list of course sites or None to signal HTTP request failure.
+    # An empty list should be handled by higher-level logic even though it's falsey.
+    if all_canvas_courses is None:
+        return None
 
     def include_course(course):
-        # For now, keep things simple by including only student enrollments for the current term as defined in app
-        # config.
-        if course.get('enrollment_term_id') != app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM'):
-            return False
-        if not course['enrollments'] or not next((e for e in course['enrollments'] if e['type'] == 'student'), None):
-            return False
-        return True
-    return [course for course in response if include_course(course)]
+        if course.get('enrollment_term_id') == term_id and course['enrollments']:
+            if next((e for e in course['enrollments'] if e['type'] == 'student'), None):
+                return True
+        return False
+
+    return [course for course in all_canvas_courses if include_course(course)]
+
+
+@stow('canvas_user_courses_{uid}')
+def get_all_user_courses(uid):
+    return _get_all_user_courses(uid)
+
+
+@fixture('canvas_user_courses_{uid}')
+def _get_all_user_courses(uid, mock=None):
+    path = f'/api/v1/users/sis_login_id:{uid}/courses'
+    query = {'include': ['term']}
+    return paged_request(path=path, query=query, mock=mock)
+
+
+@stow('canvas_student_summaries_for_course_{course_id}', for_term=True)
+def get_student_summaries(course_id):
+    return _get_student_summaries(course_id)
 
 
 @fixture('canvas_student_summaries_for_course_{course_id}')
-def get_student_summaries(course_id, mock=None):
+def _get_student_summaries(course_id, mock=None):
     path = f'/api/v1/courses/{course_id}/analytics/student_summaries'
     return paged_request(path=path, mock=mock)
 
@@ -64,7 +85,7 @@ def paged_request(path, mock, query=None):
         with mock(url):
             response = authorized_request(url)
             if not response:
-                return response
+                return None
             results.extend(response.json())
             url = http.get_next_page(response)
     return results

--- a/boac/externals/sis_enrollments_api.py
+++ b/boac/externals/sis_enrollments_api.py
@@ -2,11 +2,21 @@
 
 from boac.lib import http
 from boac.lib.mockingbird import fixture
+from boac.models.json_cache import stow
 from flask import current_app as app
 
 
+@stow('sis_enrollments_api_{cs_id}_{term_id}', for_term=True)
+def get_enrollments(cs_id, term_id):
+    response = _get_enrollments(cs_id, term_id)
+    if response and hasattr(response, 'json'):
+        return response.json().get('apiResponse', {}).get('response', {})
+    else:
+        return
+
+
 @fixture('sis_enrollments_api_{cs_id}_{term_id}')
-def get_enrollments(cs_id, term_id, mock=None):
+def _get_enrollments(cs_id, term_id, mock=None):
     query = {
         'term-id': term_id,
         'primary-only': 'true',

--- a/boac/externals/sis_student_api.py
+++ b/boac/externals/sis_student_api.py
@@ -2,11 +2,24 @@
 
 from boac.lib import http
 from boac.lib.mockingbird import fixture
+from boac.models.json_cache import stow
 from flask import current_app as app
 
 
+@stow('sis_student_api_{cs_id}')
+def get_student(cs_id):
+    response = _get_student(cs_id)
+    if response and hasattr(response, 'json'):
+        unwrapped = response.json().get('apiResponse', {}).get('response', {}).get('any', {}).get('students', [])
+        if unwrapped:
+            unwrapped = unwrapped[0]
+        return unwrapped
+    else:
+        return
+
+
 @fixture('sis_student_api_{cs_id}')
-def get_student(cs_id, mock=None):
+def _get_student(cs_id, mock=None):
     url = http.build_url(app.config['STUDENT_API_URL'] + '/' + str(cs_id) + '/all')
     with mock(url):
         return authorized_request(url)

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -3,6 +3,7 @@ from boac import db
 from boac.models.authorized_user import AuthorizedUser
 # Needed for db.create_all to find the model.
 from boac.models.cohort import Cohort # noqa
+from boac.models.json_cache import JsonCache # noqa
 
 
 def clear():

--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -1,0 +1,68 @@
+import inspect
+
+from boac import db
+from boac.models.base import Base
+from decorator import decorator
+from flask import current_app as app
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+class JsonCache(Base):
+    __tablename__ = 'json_cache'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
+    key = db.Column(db.String, nullable=False, unique=True)
+    json = db.Column(JSONB)
+
+    def __init__(self, key, json=None):
+        self.key = key
+        self.json = json
+
+    def __repr__(self):
+        return '<JsonCache {}, json={}, updated={}, created={}>'.format(
+            self.key,
+            self.json,
+            self.updated_at,
+            self.created_at,
+        )
+
+
+def clear(key_like):
+    matches = db.session.query(JsonCache).filter(JsonCache.key.like(key_like))
+    app.logger.info(f'Will delete {matches.count()} entries matching {key_like}')
+    matches.delete(synchronize_session=False)
+
+
+def stow(key_pattern, for_term=False):
+    """Uses the Decorator module to preserve the wrapped function's signature,
+    allowing easy wrapping by other decorators.
+    TODO Mockingbird does not currently preserve signatures, and so JsonCache
+    cannot directly wrap a @fixture.
+    """
+    @decorator
+    def _stow(func, *args, **kw):
+        key = _format_from_args(func, key_pattern, *args, **kw)
+        if for_term:
+            term_id = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
+            key = f'term_{term_id}-{key}'
+        stowed = JsonCache.query.filter_by(key=key).first()
+        if stowed:
+            return stowed.json
+        else:
+            app.logger.info(f'{key} not found in DB')
+            to_stow = func(*args, **kw)
+            if to_stow is not None:
+                row = JsonCache(key=key, json=to_stow)
+                db.session.add(row)
+            else:
+                app.logger.info(f'{key} not generated and will not be stowed in DB')
+            return to_stow
+    return _stow
+
+
+def _format_from_args(func, pattern, *args, **kw):
+    """Copied from mockingbird module"""
+    arg_names = inspect.getfullargspec(func)[0]
+    args_dict = dict(zip(arg_names, args))
+    args_dict.update(kw)
+    return pattern.format(**args_dict)

--- a/config/default.py
+++ b/config/default.py
@@ -8,6 +8,9 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # Directory to search for mock fixtures, if running in "test" or "demo" mode.
 FIXTURES_PATH = None
 
+# Save DB changes at the end of a request.
+SQLALCHEMY_COMMIT_ON_TEARDOWN = True
+
 # Disable an expensive bit of the ORM.
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask-Login
 Flask-SQLAlchemy
 SQLAlchemy
 cx_Oracle
+decorator
 ldap3
 names
 pandas

--- a/scripts/cohort_fixtures.py
+++ b/scripts/cohort_fixtures.py
@@ -25,11 +25,11 @@ def main(app):
         for row in reader:
             uid = row[uid_index]
 
-            user_for_uid = canvas.get_user_for_uid(uid)
+            user_for_uid = canvas._get_user_for_uid(uid)
             if not user_for_uid:
                 failures['user_for_uid'].append(uid)
 
-            user_courses = canvas.get_user_courses(uid)
+            user_courses = canvas._get_all_user_courses(uid)
             if not user_courses:
                 failures['user_courses'].append(uid)
                 continue
@@ -38,7 +38,7 @@ def main(app):
                 if os.path.isfile(f"{os.environ['FIXTURE_OUTPUT_PATH']}/canvas_student_summaries_for_course_{course['id']}.json"):
                     print(f"Fixture already present for course {course['id']}, skipping")
                 else:
-                    student_summaries = canvas.get_student_summaries(course['id'])
+                    student_summaries = canvas._get_student_summaries(course['id'])
                     if not student_summaries:
                         failures['student_summaries'].append(course['id'])
 

--- a/scripts/student_api_fixtures.py
+++ b/scripts/student_api_fixtures.py
@@ -21,7 +21,7 @@ def main(app):
         csid_index = headers.index('member_csid')
         for row in reader:
             csid = row[csid_index]
-            response = sis_student_api.get_student(csid)
+            response = sis_student_api._get_student(csid)
             if response:
                 success_count += 1
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,9 @@ def db_session(db, request):
     Fixture database session used for the scope of a single test. All executions are wrapped
     in a transaction and then rolled back to keep individual tests isolated.
     """
+    # Mixing SQL-using test fixtures with SQL-using decorators can trigger not-yet-diagnosed
+    # freezes in Flask-SQLAlchemy due to DB session debris.
+    db.session.rollback()
     connection = db.engine.connect()
     transaction = connection.begin()
     options = dict(bind=connection, binds={})

--- a/tests/fixtures/cohorts.py
+++ b/tests/fixtures/cohorts.py
@@ -6,5 +6,4 @@ import pytest
 def fixture_cohorts(db_session):
     field_hockey_star = Cohort('FHW', '61889', '11667051', 'Brigitte Lin')
     db_session.add(field_hockey_star)
-    db_session.commit()
     return [field_hockey_star]

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -166,7 +166,7 @@ class TestUserAnalytics:
     def test_sis_enrollment_not_found(self, fixture_cohorts, authenticated_session, client):
         """gracefully handles missing SIS data"""
         sis_error = MockResponse(200, {}, '{"apiResponse": {"response": {"message": "Something unexpected."}}}')
-        with register_mock(sis_enrollments_api.get_enrollments, sis_error):
+        with register_mock(sis_enrollments_api._get_enrollments, sis_error):
             response = client.get(TestUserAnalytics.field_hockey_star)
             assert response.status_code == 200
             assert len(response.json['courses']) == 3

--- a/tests/test_externals/test_sis_student_api.py
+++ b/tests/test_externals/test_sis_student_api.py
@@ -7,21 +7,25 @@ class TestSisStudentApi:
     """SIS student API query"""
 
     def test_get_student(self):
-        """returns fixture data"""
-        oski_response = student_api.get_student(11667051)
-        assert oski_response
-        assert oski_response.status_code == 200
-        student = oski_response.json()['apiResponse']['response']['any']['students'][0]
-
+        """returns unwrapped data"""
+        student = student_api.get_student(11667051)
         assert student['academicStatuses'][0]['cumulativeGPA']['average'] == pytest.approx(3.8, 0.01)
         assert student['academicStatuses'][0]['currentRegistration']['academicLevel']['level']['description'] == 'Junior'
         assert student['academicStatuses'][0]['currentRegistration']['athlete'] is True
         assert student['academicStatuses'][0]['studentPlans'][0]['academicPlan']['plan']['description'] == 'English BA'
         assert student['emails'][0]['emailAddress'] == 'oski@berkeley.edu'
 
+    def test_inner_get_student(self):
+        """returns fixture data"""
+        oski_response = student_api._get_student(11667051)
+        assert oski_response
+        assert oski_response.status_code == 200
+        students = oski_response.json()['apiResponse']['response']['any']['students']
+        assert len(students) == 1
+
     def test_user_not_found(self, caplog):
         """logs 404 for unknown user and returns informative message"""
-        response = student_api.get_student(9999999)
+        response = student_api._get_student(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
         assert response.raw_response.status_code == 404
@@ -30,8 +34,8 @@ class TestSisStudentApi:
     def test_server_error(self, caplog):
         """logs unexpected server errors and returns informative message"""
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
-        with register_mock(student_api.get_student, api_error):
-            response = student_api.get_student(11667051)
+        with register_mock(student_api._get_student, api_error):
+            response = student_api._get_student(11667051)
             assert 'HTTP/1.1" 500' in caplog.text
             assert not response
             assert response.raw_response.status_code == 500


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-103
Also:
- Avoid Flask-SQLAlchemy session deadlocks in tests.
- Enable automatic transaction handling.

Known minuses:
- Because HTTP responses aren't JSON-serializable, failure information is discarded on the way up the call stack.
- Extra functions are defined to work around the lack of clean decorator nesting.
