### PR TITLE
BOAC-103 Add ability to create Cohorts from ASC data export

### DIFF
--- a/boac/externals/asc_cohorts.py
+++ b/boac/externals/asc_cohorts.py
@@ -1,0 +1,77 @@
+import csv
+
+from boac import db
+from boac.lib import merged
+from boac.models.cohort import Cohort
+
+THIS_ACAD_YR = '2017-18'
+
+SPORT_TRANSLATIONS = {
+    'MBB': 'BAM',
+    'MBK': 'BBM',
+    'WBK': 'BBW',
+    'MCR': 'CRM',
+    'WCR': 'CRW',
+    'MFB': 'FBM',
+    'WFH': 'FHW',
+    'MGO': 'GOM',
+    'WGO': 'GOW',
+    'MGY': 'GYM',
+    'WGY': 'GYW',
+    'WLC': 'LCW',
+    'MRU': 'RGM',
+    'WSF': 'SBW',
+    'MSC': 'SCM',
+    'WSC': 'SCW',
+    'MSW': 'SDM',
+    'WSW': 'SDW',
+    # 'Beach Volleyball' vs. 'Sand Volleyball'.
+    'WBV': 'SVW',
+    'MTE': 'TNM',
+    'WTE': 'TNW',
+    # ASC's subsets of Track do not directly match the Athlete API's subsets. In ASC's initial data transfer,
+    # all track athletes were mapped to 'TO*', 'Outdoor Track & Field'.
+    'MTR': 'TOM',
+    'WTR': 'TOW',
+    'WVB': 'VBW',
+    'MWP': 'WPM',
+    'WWP': 'WPW',
+}
+
+
+def load_cohort_from_csv(app, csv_file='tmp/FilteredAscStudents.csv'):
+    with open(csv_file) as f:
+        reader = csv.DictReader(f)
+        for r in reader:
+            if r['AcadYr'] != THIS_ACAD_YR or r['SportActiveYN'] != 'Yes':
+                continue
+            asc_sport_code_core = r['cSportCodeCore']
+            if asc_sport_code_core not in SPORT_TRANSLATIONS:
+                app.logger.error('Unmapped Sport Code {} has SportActiveYN for SID {}'.format(
+                    asc_sport_code_core,
+                    r['SID'],
+                ))
+                continue
+            sis_sport_code = SPORT_TRANSLATIONS[asc_sport_code_core]
+            record = Cohort(
+                member_csid=r['SID'],
+                member_name=r['cName'],
+                code=sis_sport_code,
+                asc_sport_code=r['SportCode'],
+                asc_sport=r['Sport'],
+                asc_sport_code_core=asc_sport_code_core,
+                asc_sport_core=r['acSportCore'],
+            )
+            db.session.add(record)
+    app.logger.info('Loaded {} Cohort records from {}'.format(
+        len(db.session.new),
+        csv_file,
+    ))
+    db.session.commit()
+
+
+def fill_empty_uids_from_calnet(app):
+    to_update = Cohort.query.filter(Cohort.member_uid.is_(None)).all()
+    merged.refresh_cohort_attributes_from_calnet(app, to_update)
+    app.logger.info('Modified {} Cohort records from calnet'.format(len(db.session.dirty)))
+    db.session.commit()

--- a/boac/externals/calnet.py
+++ b/boac/externals/calnet.py
@@ -18,6 +18,8 @@ SCHEMA_DICT = {
     'uid': 'uid',
 }
 
+BATCH_QUERY_MAXIMUM = 500
+
 
 def client(app):
     if mockingbird._environment_supports_mocks():
@@ -51,9 +53,13 @@ class Client:
         return conn
 
     def search_csids(self, csids):
-        entries = self._search_csids(csids)
-        out = [_attributes_to_dict(entry) for entry in entries]
-        return out
+        all_out = []
+        for i in range(0, len(csids), BATCH_QUERY_MAXIMUM):
+            csids_batch = csids[i:i + BATCH_QUERY_MAXIMUM]
+            entries = self._search_csids(csids_batch)
+            out = [_attributes_to_dict(entry) for entry in entries]
+            all_out += out
+        return all_out
 
     def _csids_filter(self, csids):
         clauses = ''.join(f'(berkeleyeducsid={id})' for id in csids)

--- a/boac/models/cohort.py
+++ b/boac/models/cohort.py
@@ -14,21 +14,23 @@ class Cohort(Base):
 
     id = db.Column(db.Integer, nullable=False, primary_key=True)
     code = db.Column(db.String(255), nullable=False)
-    member_uid = db.Column(db.String(80), nullable=False)
-    member_csid = db.Column(db.String(80))
+    member_uid = db.Column(db.String(80))
+    member_csid = db.Column(db.String(80), nullable=False)
     member_name = db.Column(db.String(255))
-    UniqueConstraint('code', 'member_uid', name='cohort_membership')
-
-    def __init__(self, code, member_uid, member_csid=None, member_name=None):
-        self.code = code
-        self.member_uid = member_uid
-        self.member_csid = member_csid
-        self.member_name = member_name
+    asc_sport_code_core = db.Column(db.String(80))
+    asc_sport_code = db.Column(db.String(80))
+    asc_sport = db.Column(db.String(80))
+    asc_sport_core = db.Column(db.String(80))
+    UniqueConstraint('code', 'member_csid', name='cohort_membership')
 
     def __repr__(self):
-        return '<Cohort {} ({}), uid={}, csid={}, name={}, updated={}, created={}>'.format(
+        return '<Cohort {} ({}), asc_sport {} ({}), asc_sport_core {} ({}), uid={}, csid={}, name={}, updated={}, created={}>'.format(
             self.cohort_definitions.get(self.code),
             self.code,
+            self.asc_sport,
+            self.asc_sport_code,
+            self.asc_sport_core,
+            self.asc_sport_code_core,
             self.member_uid,
             self.member_csid,
             self.member_name,

--- a/scripts/load_cohorts_from_asc.py
+++ b/scripts/load_cohorts_from_asc.py
@@ -1,0 +1,11 @@
+from scriptpath import scriptify
+
+
+@scriptify.in_app
+def main(app):
+    from boac.externals import asc_cohorts
+    asc_cohorts.load_cohort_from_csv(app)
+    asc_cohorts.fill_empty_uids_from_calnet(app)
+
+
+main()

--- a/tests/fixtures/cohorts.py
+++ b/tests/fixtures/cohorts.py
@@ -4,6 +4,6 @@ import pytest
 
 @pytest.fixture
 def fixture_cohorts(db_session):
-    field_hockey_star = Cohort('FHW', '61889', '11667051', 'Brigitte Lin')
+    field_hockey_star = Cohort(code='FHW', member_uid='61889', member_csid='11667051', member_name='Brigitte Lin')
     db_session.add(field_hockey_star)
     return [field_hockey_star]

--- a/tests/test_lib/test_merged.py
+++ b/tests/test_lib/test_merged.py
@@ -10,7 +10,7 @@ class TestMerged:
         for member in members:
             member.member_uid = None
             member.member_name = None
-        subject.refresh_cohort_attributes(app, members)
+        subject.refresh_cohort_attributes_from_calnet(app, members)
         for member in members:
             assert member.member_csid in original_csids
             # For this test, assume that there are no blank attributes.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-103 (although in retrospect this really should have been broken out into its own task)

Besides loading relevant rows from an ASC-provided spreadsheet, this PR add columns to the Cohorts table for ASC's in-house team names, which differ quite a bit from the Athletes API.