### PR TITLE
BOAC-103 Add cache-filling script

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -25,11 +25,10 @@ def cohort_details(cohort_code):
         for member in cohort['members']:
             canvas_profile = canvas.get_user_for_uid(member['uid'])
             if canvas_profile:
-                profile_json = canvas_profile.json()
-                member['avatar_url'] = profile_json['avatar_url']
+                member['avatar_url'] = canvas_profile['avatar_url']
                 canvas_courses = canvas_courses_api_feed(canvas.get_student_courses_in_term(member['uid']))
                 if canvas_courses:
-                    member['analytics'] = mean_course_analytics_for_user(canvas_courses, profile_json['id'])
+                    member['analytics'] = mean_course_analytics_for_user(canvas_courses, canvas_profile['id'])
         if app.cache:
             app.cache.set(cache_key, cohort)
     return tolerant_jsonify(cohort)

--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -15,15 +15,30 @@ def _get_course_sections(course_id, mock=None):
     return paged_request(path=path, mock=mock)
 
 
+@stow('canvas_user_for_uid_{uid}')
+def get_user_for_uid(uid):
+    """If the user is not found, returns False (which can be cached).
+    For any other error response, returns None (which will not be cached).
+    """
+    response = _get_user_for_uid(uid)
+    if response and hasattr(response, 'json'):
+        return response.json()
+    else:
+        if hasattr(response, 'raw_response') and response.raw_response.status_code == 404:
+            return False
+        else:
+            return None
+
+
 @fixture('canvas_user_for_uid_{uid}')
-def get_user_for_uid(uid, mock=None):
+def _get_user_for_uid(uid, mock=None):
     url = build_url('/api/v1/users/sis_login_id:{uid}'.format(uid=uid))
     with mock(url):
         return authorized_request(url)
 
 
 def get_student_courses_in_term(uid):
-    term_id = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
+    term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
     all_canvas_courses = get_all_user_courses(uid)
     # The paged_request wrapper returns either a list of course sites or None to signal HTTP request failure.
     # An empty list should be handled by higher-level logic even though it's falsey.
@@ -31,7 +46,7 @@ def get_student_courses_in_term(uid):
         return None
 
     def include_course(course):
-        if course.get('enrollment_term_id') == term_id and course['enrollments']:
+        if course.get('term', {}).get('name') == term_name and course['enrollments']:
             if next((e for e in course['enrollments'] if e['type'] == 'student'), None):
                 return True
         return False

--- a/boac/lib/merged.py
+++ b/boac/lib/merged.py
@@ -36,10 +36,7 @@ def merge_sis_enrollments(canvas_course_sites, cs_id, term_id):
 def merge_sis_profile(csid):
     sis_response = sis_student_api.get_student(csid)
     if not sis_response:
-        if hasattr(sis_response, 'raw_response') and sis_response.raw_response.status_code == 404:
-            return {'error': 'No SIS profile found for user'}
-        else:
-            return {'error': 'Unable to reach SIS Student API'}
+        return False
 
     sis_profile = {}
     merge_sis_profile_academic_status(sis_response, sis_profile)

--- a/boac/lib/scriptify.py
+++ b/boac/lib/scriptify.py
@@ -16,3 +16,23 @@ def in_app(func):
         finally:
             ac.pop()
     return _in_app_func
+
+
+def in_session_request(func):
+    """Flask-SQLAlchemy requires a request context to do any DB work."""
+    @wraps(func)
+    def _in_session_request_func(*args, **kw):
+        request_ctx = None
+        app = create_app()
+        ac = app.app_context()
+        try:
+            ac.push()
+            request_ctx = app.test_request_context('/')
+            request_ctx.push()
+            kw['app'] = app
+            func(*args, **kw)
+        finally:
+            if request_ctx:
+                request_ctx.pop()
+            ac.pop()
+    return _in_session_request_func

--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -43,8 +43,11 @@ def stow(key_pattern, for_term=False):
     def _stow(func, *args, **kw):
         key = _format_from_args(func, key_pattern, *args, **kw)
         if for_term:
-            term_id = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
-            key = 'term_{term_id}-{key}'.format(term_id=term_id, key=key)
+            term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
+            key = 'term_{}-{}'.format(
+                term_name,
+                key,
+            )
         stowed = JsonCache.query.filter_by(key=key).first()
         if stowed:
             return stowed.json

--- a/config/default.py
+++ b/config/default.py
@@ -43,7 +43,7 @@ LDAP_PASSWORD = 'secret'
 CANVAS_HTTP_URL = 'https://wottsamatta.instructure.com'
 CANVAS_HTTP_TOKEN = 'yet another secret'
 
-CANVAS_CURRENT_ENROLLMENT_TERM = 5493
+CANVAS_CURRENT_ENROLLMENT_TERM = 'Fall 2017'
 
 # SIS APIs
 ATHLETE_API_ID = 'secretid'

--- a/scripts/refresh_external_data_for_term.py
+++ b/scripts/refresh_external_data_for_term.py
@@ -1,0 +1,83 @@
+from scriptpath import scriptify
+
+success_count = 0
+failures = []
+
+
+def load_canvas_externals(uid):
+    from boac.externals import canvas
+
+    global success_count, failures
+
+    canvas_user_profile = canvas.get_user_for_uid(uid)
+    if canvas_user_profile is None:
+        failures.append('canvas.get_user_for_uid failed for UID {}'.format(
+            uid,
+        ))
+    elif canvas_user_profile:
+        success_count += 1
+        sites = canvas.get_student_courses_in_term(uid)
+        if sites:
+            success_count += 1
+            for site in sites:
+                site_id = site['id']
+                if not canvas.get_course_sections(site_id):
+                    failures.append('canvas.get_course_sections failed for UID {}, site_id {}'.format(
+                        uid,
+                        site_id,
+                    ))
+                    continue
+                success_count += 1
+                if not canvas.get_student_summaries(site_id):
+                    failures.append('canvas.get_student_summaries failed for site_id {}'.format(
+                        site_id,
+                    ))
+                    continue
+                success_count += 1
+
+
+def load_sis_externals(sis_term_id, csid):
+    from boac.externals import sis_enrollments_api, sis_student_api
+
+    global success_count, failures
+
+    if sis_student_api.get_student(csid):
+        success_count += 1
+    else:
+        failures.append('SIS get_student failed for CSID {}'.format(
+            csid,
+        ))
+
+    if sis_enrollments_api.get_enrollments(csid, sis_term_id):
+        success_count += 1
+    else:
+        failures.append('SIS get_student failed for CSID {}, sis_term_id {}'.format(
+            csid,
+            sis_term_id,
+        ))
+
+
+@scriptify.in_session_request
+def main(app):
+    from boac import db
+    from boac.lib import berkeley
+    from boac.models.cohort import Cohort
+
+    global success_count, failures
+
+    term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
+    sis_term_id = berkeley.sis_term_id_for_name(term_name)
+
+    # Currently, all external data is loaded starting from the individuals who belong
+    # to one or more Cohorts.
+    for csid, uid in db.session.query(Cohort.member_csid, Cohort.member_uid).distinct():
+        load_canvas_externals(uid)
+        load_sis_externals(sis_term_id, csid)
+
+    print('Complete. Fetched {} external feeds.'.format(success_count))
+    if len(failures):
+        print('Failed to fetch {} feeds:'.format(len(failures)))
+        print(failures)
+
+
+main()

--- a/tests/test_externals/test_canvas.py
+++ b/tests/test_externals/test_canvas.py
@@ -46,29 +46,33 @@ class TestCanvasGetUserForUid:
         """returns fixture data"""
         oliver_response = canvas.get_user_for_uid(2040)
         assert oliver_response
-        assert oliver_response.status_code == 200
-        assert oliver_response.json()['sortable_name'] == 'Heyer, Oliver'
-        assert oliver_response.json()['avatar_url'] == 'https://upload.wikimedia.org/wikipedia/en/thumb/b/b4/Donald_Duck.svg/618px-Donald_Duck.svg.png'
+        assert oliver_response['sortable_name'] == 'Heyer, Oliver'
+        assert oliver_response['avatar_url'] == 'https://upload.wikimedia.org/wikipedia/en/thumb/b/b4/Donald_Duck.svg/618px-Donald_Duck.svg.png'
 
         paul_response = canvas.get_user_for_uid(242881)
         assert paul_response
-        assert paul_response.status_code == 200
-        assert paul_response.json()['sortable_name'] == 'Kerschen, Paul'
-        assert paul_response.json()['avatar_url'] == 'https://en.wikipedia.org/wiki/Daffy_Duck#/media/File:Daffy_Duck.svg'
+        assert paul_response['sortable_name'] == 'Kerschen, Paul'
+        assert paul_response['avatar_url'] == 'https://en.wikipedia.org/wiki/Daffy_Duck#/media/File:Daffy_Duck.svg'
 
     def test_user_not_found(self, app, caplog):
-        """logs 404 for unknown user and returns informative message"""
+        """logs 404 for unknown user and returns False rather than None"""
         response = canvas.get_user_for_uid(9999999)
+        assert 'HTTP/1.1" 404' in caplog.text
+        assert response is False
+
+    def test_raw_user_not_found(self, app, caplog):
+        """logs 404 for unknown user and returns informative message"""
+        response = canvas._get_user_for_uid(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
         assert response.raw_response.status_code == 404
         assert response.raw_response.json()['message']
 
-    def test_server_error(self, app, caplog):
+    def test_raw_server_error(self, app, caplog):
         """logs unexpected server errors and returns informative message"""
         canvas_error = MockResponse(500, {}, '{"message": "Internal server error."}')
-        with register_mock(canvas.get_user_for_uid, canvas_error):
-            response = canvas.get_user_for_uid(2040)
+        with register_mock(canvas._get_user_for_uid, canvas_error):
+            response = canvas._get_user_for_uid(2040)
             assert 'HTTP/1.1" 500' in caplog.text
             assert not response
             assert response.raw_response.status_code == 500
@@ -103,9 +107,7 @@ class TestCanvasGetUserCourses:
         """returns only enrollments in current term"""
         courses = canvas.get_student_courses_in_term(61889)
         for course in courses:
-            assert course['enrollment_term_id'] == app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM')
-            assert course['term']['id'] == course['enrollment_term_id']
-            assert course['term']['name'] == 'Fall 2017'
+            assert course['term']['name'] == app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM')
 
     def test_user_not_found(self, app, caplog):
         """logs 404 for unknown user"""

--- a/tests/test_externals/test_sis_enrollments_api.py
+++ b/tests/test_externals/test_sis_enrollments_api.py
@@ -5,7 +5,7 @@ from boac.lib.mockingbird import MockResponse, register_mock
 class TestSisEnrollmentsApi:
     """SIS enrollments API query"""
 
-    def test_get_enrollments(self):
+    def test_get_enrollments(self, app):
         """returns unwrapped data"""
         oski_response = enrollments_api.get_enrollments(11667051, 2178)
         student = oski_response['student']
@@ -35,7 +35,7 @@ class TestSisEnrollmentsApi:
         assert enrollments[2]['gradingBasis']['code'] == 'PNP'
         assert enrollments[2]['grades'][0]['mark'] == 'P'
 
-    def test_inner_get_enrollments(self):
+    def test_inner_get_enrollments(self, app):
         """returns fixture data"""
         oski_response = enrollments_api._get_enrollments(11667051, 2178)
         assert oski_response
@@ -68,7 +68,7 @@ class TestSisEnrollmentsApi:
         assert enrollments[2]['gradingBasis']['code'] == 'PNP'
         assert enrollments[2]['grades'][0]['mark'] == 'P'
 
-    def test_user_not_found(self, caplog):
+    def test_user_not_found(self, app, caplog):
         """logs 404 for unknown user and returns informative message"""
         response = enrollments_api._get_enrollments(9999999, 2178)
         assert 'HTTP/1.1" 404' in caplog.text
@@ -76,7 +76,7 @@ class TestSisEnrollmentsApi:
         assert response.raw_response.status_code == 404
         assert response.raw_response.json()['message']
 
-    def test_server_error(self, caplog):
+    def test_server_error(self, app, caplog):
         """logs unexpected server errors and returns informative message"""
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(enrollments_api._get_enrollments, api_error):

--- a/tests/test_externals/test_sis_student_api.py
+++ b/tests/test_externals/test_sis_student_api.py
@@ -6,7 +6,7 @@ import pytest
 class TestSisStudentApi:
     """SIS student API query"""
 
-    def test_get_student(self):
+    def test_get_student(self, app):
         """returns unwrapped data"""
         student = student_api.get_student(11667051)
         assert student['academicStatuses'][0]['cumulativeGPA']['average'] == pytest.approx(3.8, 0.01)
@@ -15,7 +15,7 @@ class TestSisStudentApi:
         assert student['academicStatuses'][0]['studentPlans'][0]['academicPlan']['plan']['description'] == 'English BA'
         assert student['emails'][0]['emailAddress'] == 'oski@berkeley.edu'
 
-    def test_inner_get_student(self):
+    def test_inner_get_student(self, app):
         """returns fixture data"""
         oski_response = student_api._get_student(11667051)
         assert oski_response
@@ -23,7 +23,7 @@ class TestSisStudentApi:
         students = oski_response.json()['apiResponse']['response']['any']['students']
         assert len(students) == 1
 
-    def test_user_not_found(self, caplog):
+    def test_user_not_found(self, app, caplog):
         """logs 404 for unknown user and returns informative message"""
         response = student_api._get_student(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
@@ -31,7 +31,7 @@ class TestSisStudentApi:
         assert response.raw_response.status_code == 404
         assert response.raw_response.json()['message']
 
-    def test_server_error(self, caplog):
+    def test_server_error(self, app, caplog):
         """logs unexpected server errors and returns informative message"""
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(student_api._get_student, api_error):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-103

Also:

* Change our CANVAS_CURRENT_ENROLLMENT_TERM configuration from an unpredictable number to something more human-readable (e.g., "Fall 2017").
* Cache the Canvas User Profile (unless it encountered a non-404 error).
* Add some missing test fixtures.