### PR TITLE
NOJIRA, upgrade flake8-import-order per Travis; two lint-py fixes

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -3,7 +3,6 @@ from boac.externals import canvas
 from boac.lib.analytics import mean_course_analytics_for_user
 from boac.lib.http import tolerant_jsonify
 from boac.models.cohort import Cohort
-
 from flask import current_app as app, jsonify
 from flask_login import login_required
 

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -6,7 +6,6 @@ from boac.lib.berkeley import sis_term_id_for_name
 from boac.lib.http import tolerant_jsonify
 from boac.lib.merged import merge_sis_enrollments, merge_sis_profile
 from boac.models.cohort import Cohort
-
 from flask import current_app as app
 from flask_login import current_user, login_required
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     flake8
     flake8-colors
     flake8-commas
-    flake8-import-order
+    flake8-import-order>=0.15
     flake8-pep3101
     flake8-pytest
     flake8-quotes
@@ -47,7 +47,7 @@ exclude =
     *.pyc
     .cache
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
-ignore = E731
+ignore = E731,I201
 import-order-style = google
 max-complexity = 10
 max-line-length = 155


### PR DESCRIPTION
Cause of mysterious Travis failure (https://travis-ci.org/ets-berkeley-edu/boac/builds/298832425) was unexpected `flake8-import-order` version. Devs will get latest with this PR. 