### PR TITLE
BOAC-92, cohort_filters table, many-to-many with authorized_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ tox -e lint-py
 tox -e lint-js
 tox -e lint-css
 
+# Run specific test(s)
+tox -e test -- tests/test_models/test_authorized_user.py
+tox -e test -- tests/test_externals/
+
 # Lint specific file(s)
 tox -e lint-js -- boac/static/js/controllers/cohortController.js
 tox -e lint-py -- scripts/cohort_fixtures.py

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -1,9 +1,10 @@
 import csv
 from boac import db
 from boac.models.authorized_user import AuthorizedUser
+from boac.models.authorized_user import CohortFilter
 # Needed for db.create_all to find the model.
-from boac.models.team_member import TeamMember # noqa
 from boac.models.json_cache import JsonCache # noqa
+from boac.models.team_member import TeamMember # noqa
 
 
 def clear():
@@ -38,10 +39,27 @@ _default_users_csv = """uid,is_admin,is_director,is_advisor
 
 def load_development_data():
     csv_reader = csv.DictReader(_default_users_csv.splitlines())
+    cohort_filter_crew = create_cohort_filter('Men and women\'s crew', 'CRM', 'CRW')
+    cohort_filter_soccer = create_cohort_filter('Men and women\'s soccer', 'SCW', 'SCW')
     for row in csv_reader:
-        obj = AuthorizedUser(**row)
-        db.session.add(obj)
+        user = AuthorizedUser(**row)
+        db.session.add(user)
+        uid = int(user.uid)
+        # A subset of users get one or more cohort_filters
+        if uid > 60000:
+            # The 'crew' and 'soccer' cohort_filters are both shared by multiple users
+            choose_crew = uid < 100000
+            cohort = cohort_filter_crew if choose_crew else cohort_filter_soccer
+            user.cohort_filters.append(cohort)
+
     db.session.commit()
+
+
+def create_cohort_filter(label, code1, code2):
+    return CohortFilter(
+        label=label,
+        filter_criteria='{\'teams\': [\'' + code1 + '\', \'' + code2 + '\']}',
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/db/migrate/20171107-BOAC-92/create_cohort_filters_table.sql
+++ b/scripts/db/migrate/20171107-BOAC-92/create_cohort_filters_table.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+CREATE TABLE cohort_filters (
+  id SERIAL NOT NULL,
+  label VARCHAR(255) NOT NULL,
+  filter_criteria TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE cohort_filter_owners (
+  cohort_filter_id INTEGER NOT NULL REFERENCES cohort_filters (id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES authorized_users (id) ON DELETE CASCADE,
+
+  PRIMARY KEY (cohort_filter_id, user_id)
+);
+
+COMMIT;

--- a/tests/test_models/test_authorized_user.py
+++ b/tests/test_models/test_authorized_user.py
@@ -1,4 +1,5 @@
 import boac.models.authorized_user as subject
+from boac.models.authorized_user import CohortFilter
 
 
 class TestAuthorizedUser:
@@ -16,3 +17,37 @@ class TestAuthorizedUser:
         assert loaded_user.is_active
         assert loaded_user.get_id() == admin_uid
         assert loaded_user.is_admin
+        assert len(loaded_user.cohort_filters) == 1
+
+        owners = loaded_user.cohort_filters[0].owners
+        assert len(owners) > 0
+        assert loaded_user in owners
+
+    def test_create_and_delete_cohort_filter(self, db_session):
+        """ cohort_filter  record to Flask-Login for recognized UID"""
+        sebastian_uid = '2040'
+        aloysius_uid = '1133399'
+        # Create cohort_filter
+        cohort_filter = CohortFilter(label='High-risk Badminton', filter_criteria='{\'teams\': [\'MBK\', \'WBK\']}')
+        subject.create_cohort_filter(cohort_filter, sebastian_uid)
+        sebastian = subject.load_user(sebastian_uid)
+
+        # Share existing cohort_filter
+        cohort_filter_id = sebastian.cohort_filters[0].id
+        subject.share_cohort_filter(cohort_filter_id, aloysius_uid)
+        aloysius = subject.load_user(aloysius_uid)
+
+        owners = sebastian.cohort_filters[0].owners
+        assert len(owners) == 2
+        assert sebastian, aloysius in owners
+
+        sebastian_count = cohort_filter_count(sebastian_uid)
+        aloysius_count = cohort_filter_count(aloysius_uid)
+
+        subject.delete_cohort_filter(cohort_filter_id)
+        assert sebastian_count - cohort_filter_count(sebastian_uid) == 1
+        assert aloysius_count - cohort_filter_count(aloysius_uid) == 1
+
+
+def cohort_filter_count(uid):
+    return len(subject.load_user(uid).cohort_filters)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-92

We don't need to roll out many-to-many in BOAC UX and yet having such support on the backend gives us the option to manually create shared filters (e.g., low_gpa_filter). Plus, we avoid a future refactor.

**Note:** I'll amend this with a few more tests if we like this direction.