### PR TITLE
BOAC-93, BOAC/api to support GET custom cohorts

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -1,26 +1,53 @@
+import json
 from boac.api.util import canvas_courses_api_feed
 from boac.externals import canvas
 from boac.lib.analytics import mean_course_analytics_for_user
 from boac.lib.http import tolerant_jsonify
+from boac.models import authorized_user
 from boac.models.team_member import TeamMember
 from flask import current_app as app, jsonify
-from flask_login import login_required
+from flask_login import current_user, login_required
 
 
-@app.route('/api/cohorts')
+@app.route('/api/teams')
 @login_required
-def cohorts_list():
-    cohorts = TeamMember.list_all()
-    return jsonify(cohorts)
+def teams_list():
+    return jsonify(TeamMember.list_all())
 
 
 @app.route('/api/cohort/<cohort_code>')
 @login_required
 def cohort_details(cohort_code):
-    cache_key = 'cohort/{cohort_code}'.format(cohort_code=cohort_code)
-    cohort = app.cache.get(cache_key) if (app.cache) else None
+    cohort = None
+    if cohort_code.isdigit():
+        uid = current_user.get_id()
+        cohort_filter_id = int(cohort_code)
+        # Find matching cohort_filter owned by user
+        for cohort_filter in authorized_user.cohort_filters_owned_by(uid):
+            if cohort_filter_id == cohort_filter.id:
+                members = []
+                # Extract team codes from filter_criteria
+                filter_criteria = json.loads(cohort_filter.filter_criteria)
+                for team_code in filter_criteria['teams']:
+                    team = get_team_details(team_code)
+                    members.append(team['members'])
+                # Prepare the response
+                cohort = {
+                    'code': cohort_filter.id,
+                    'name': cohort_filter.label,
+                    'members': members,
+                }
+    else:
+        cohort = get_team_details(cohort_code)
+
+    return tolerant_jsonify(cohort)
+
+
+def get_team_details(team_code):
+    cache_key = 'cohort/{team_code}'.format(team_code=team_code)
+    cohort = app.cache.get(cache_key) if app.cache else None
     if cohort is None:
-        cohort = TeamMember.for_code(cohort_code)
+        cohort = TeamMember.for_code(team_code)
         for member in cohort['members']:
             canvas_profile = canvas.get_user_for_uid(member['uid'])
             if canvas_profile:
@@ -30,4 +57,5 @@ def cohort_details(cohort_code):
                     member['analytics'] = mean_course_analytics_for_user(canvas_courses, canvas_profile['id'])
         if app.cache:
             app.cache.set(cache_key, cohort)
-    return tolerant_jsonify(cohort)
+
+    return cohort

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -72,6 +72,10 @@ def load_user(user_id):
     return AuthorizedUser.query.filter_by(uid=user_id).first()
 
 
+def cohort_filters_owned_by(user_id):
+    return CohortFilter.query.filter(CohortFilter.owners.any(uid=user_id)).all()
+
+
 def load_cohort_filter(cohort_filter_id):
     return CohortFilter.query.filter_by(id=cohort_filter_id).first()
 

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -40,15 +40,15 @@ _default_users_csv = """uid,is_admin,is_director,is_advisor
 def load_development_data():
     csv_reader = csv.DictReader(_default_users_csv.splitlines())
     cohort_filter_crew = create_cohort_filter('Men and women\'s crew', 'CRM', 'CRW')
-    cohort_filter_soccer = create_cohort_filter('Men and women\'s soccer', 'SCW', 'SCW')
+    cohort_filter_soccer = create_cohort_filter('Men and women\'s soccer', 'SCW', 'SCM')
     for row in csv_reader:
         user = AuthorizedUser(**row)
         db.session.add(user)
         uid = int(user.uid)
         # A subset of users get one or more cohort_filters
-        if uid > 60000:
+        if uid > 100000:
             # The 'crew' and 'soccer' cohort_filters are both shared by multiple users
-            choose_crew = uid < 100000
+            choose_crew = uid < 1000000
             cohort = cohort_filter_crew if choose_crew else cohort_filter_soccer
             user.cohort_filters.append(cohort)
 
@@ -58,7 +58,7 @@ def load_development_data():
 def create_cohort_filter(label, code1, code2):
     return CohortFilter(
         label=label,
-        filter_criteria='{\'teams\': [\'' + code1 + '\', \'' + code2 + '\']}',
+        filter_criteria='{"teams": ["' + code1 + '", "' + code2 + '"]}',
     )
 
 

--- a/boac/static/app/cohort/cohortFactory.js
+++ b/boac/static/app/cohort/cohortFactory.js
@@ -6,8 +6,8 @@
 
   boac.factory('cohortFactory', function($http) {
 
-    var getCohorts = function() {
-      return $http.get('/api/cohorts');
+    var getTeams = function() {
+      return $http.get('/api/teams');
     };
 
     var getCohortDetails = function(code) {
@@ -15,7 +15,7 @@
     };
 
     return {
-      getCohorts: getCohorts,
+      getTeams: getTeams,
       getCohortDetails: getCohortDetails
     };
   });

--- a/boac/static/app/landing/landing.html
+++ b/boac/static/app/landing/landing.html
@@ -3,13 +3,13 @@
 <div class="container">
   <h1>Welcome to BOAC</h1>
   <div class="body-text" data-ng-if="me.authenticated_as.is_authenticated">
-    <div>Choose a cohort:</div>
+    <div>Choose a team:</div>
     <div class="container" data-ng-if="isLoading">
       <div>Loading.... </div>
     </div>
     <ul data-ng-if="!isLoading">
-      <li data-ng-repeat="cohort in cohorts">
-        <a data-ng-bind="cohort.name" data-ng-href="/cohort/{{cohort.code}}"></a>
+      <li data-ng-repeat="team in teams">
+        <a data-ng-bind="team.name" data-ng-href="/cohort/{{team.code}}"></a>
       </li>
     </ul>
   </div>

--- a/boac/static/app/landing/landingController.js
+++ b/boac/static/app/landing/landingController.js
@@ -6,11 +6,11 @@
 
     $scope.isLoading = false;
 
-    var loadCohorts = authService.authWrap(function() {
+    var loadTeams = authService.authWrap(function() {
       $scope.isLoading = true;
 
-      cohortFactory.getCohorts().then(function(cohorts) {
-        $scope.cohorts = cohorts.data;
+      cohortFactory.getTeams().then(function(teams) {
+        $scope.teams = teams.data;
         $scope.isLoading = false;
       });
     });
@@ -19,7 +19,7 @@
       $scope.alertMessage = 'Log in failed. Please try again.';
     });
 
-    loadCohorts();
+    loadTeams();
   });
 
 }(window.angular));

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@ import os
 import boac.factory
 import pytest
 
-from tests.fixtures.cohorts import fixture_cohorts # noqa
+from tests.fixtures.cohorts import fixture_team_members # noqa
+from tests.fixtures.cohorts import fixture_custom_cohorts # noqa
 
 
 os.environ['BOAC_ENV'] = 'test'

--- a/tests/fixtures/cohorts.py
+++ b/tests/fixtures/cohorts.py
@@ -1,9 +1,36 @@
+from boac.models import authorized_user
+from boac.models.authorized_user import CohortFilter
 from boac.models.team_member import TeamMember
 import pytest
 
 
 @pytest.fixture
-def fixture_cohorts(db_session):
+def fixture_team_members(db_session):
     field_hockey_star = TeamMember(code='FHW', member_uid='61889', member_csid='11667051', member_name='Brigitte Lin')
     db_session.add(field_hockey_star)
     return [field_hockey_star]
+
+
+@pytest.fixture
+def fixture_custom_cohorts():
+    all_runners = CohortFilter(
+        label='Runners',
+        filter_criteria='{"teams": ["CCM", "CCW", "TIM", "TIW"]}',
+    )
+    male_swimmers = CohortFilter(
+        label='Punk Rockers',
+        filter_criteria='{"teams": ["WPM", "SDM"]}',
+    )
+    sid = authorized_user.load_user('53791')
+    nancy = authorized_user.load_user('95509')
+    # Sid gets two custom cohorts
+    all_runners = create_cohort_filter(all_runners, sid.uid)
+    male_swimmers = create_cohort_filter(male_swimmers, sid.uid)
+    # One is shared with Nancy
+    authorized_user.share_cohort_filter(male_swimmers.id, nancy.uid)
+    return [all_runners, male_swimmers]
+
+
+def create_cohort_filter(cohort_filter, user_id):
+    authorized_user.create_cohort_filter(cohort_filter, user_id)
+    return authorized_user.load_user(user_id=user_id).cohort_filters[0]

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -1,25 +1,27 @@
+from boac.models import authorized_user
 import pytest
+
+test_uid = '1133399'
 
 
 @pytest.fixture()
 def authenticated_session(fake_auth):
-    test_uid = '1133399'
     fake_auth.login(test_uid)
 
 
-class TestCohortsList:
+class TestTeamsList:
     """Cohorts list API"""
 
-    api_path = '/api/cohorts'
+    api_path = '/api/teams'
 
-    def test_not_authenticated(self, client, fixture_cohorts):
+    def test_not_authenticated(self, client, fixture_team_members):
         """returns 401 if not authenticated"""
-        response = client.get(TestCohortsList.api_path)
+        response = client.get(TestTeamsList.api_path)
         assert response.status_code == 401
 
-    def test_authenticated(self, authenticated_session, client, fixture_cohorts):
+    def test_authenticated(self, authenticated_session, client, fixture_team_members):
         """returns a well-formed response if authenticated"""
-        response = client.get(TestCohortsList.api_path)
+        response = client.get(TestTeamsList.api_path)
         assert response.status_code == 200
         assert len(response.json) == 1
         assert response.json[0]['code'] == 'FHW'
@@ -33,12 +35,12 @@ class TestCohortDetail:
     valid_api_path = '/api/cohort/FHW'
     invalid_api_path = '/api/cohort/XYZ'
 
-    def test_not_authenticated(self, client, fixture_cohorts):
+    def test_not_authenticated(self, client, fixture_team_members):
         """returns 401 if not authenticated"""
         response = client.get(TestCohortDetail.valid_api_path)
         assert response.status_code == 401
 
-    def test_path_without_translation(self, authenticated_session, client, fixture_cohorts):
+    def test_path_without_translation(self, authenticated_session, client, fixture_team_members):
         """returns code as name when no code-to-name translation exists"""
         response = client.get(TestCohortDetail.invalid_api_path)
         assert response.status_code == 200
@@ -46,7 +48,7 @@ class TestCohortDetail:
         assert response.json['name'] == 'XYZ'
         assert len(response.json['members']) == 0
 
-    def test_valid_path(self, authenticated_session, client, fixture_cohorts):
+    def test_valid_path(self, authenticated_session, client, fixture_team_members):
         """returns a well-formed response on a valid code if authenticated"""
         response = client.get(TestCohortDetail.valid_api_path)
         assert response.status_code == 200
@@ -56,3 +58,11 @@ class TestCohortDetail:
         assert response.json['members'][0]['name'] == 'Brigitte Lin'
         assert response.json['members'][0]['uid'] == '61889'
         assert response.json['members'][0]['avatar_url'] == 'https://calspirit.berkeley.edu/oski/images/oskibio.jpg'
+
+    def test_custom_cohort_details(self, authenticated_session, client, fixture_team_members):
+        """returns a well-formed response with custom cohort"""
+        user = authorized_user.load_user(test_uid)
+        cohort_filter_id = user.cohort_filters[0].id
+        response = client.get('/api/cohort/{}'.format(cohort_filter_id))
+        assert response.status_code == 200
+        # TODO: Verify contents of response

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -26,6 +26,12 @@ class TestUserProfile:
         response = client.get('/api/profile')
         assert response.json['canvas_profile']['sis_login_id'] == test_uid
 
+    def test_custom_cohorts(self, fixture_custom_cohorts, client, fake_auth):
+        test_uid = '53791'
+        fake_auth.login(test_uid)
+        response = client.get('/api/profile')
+        assert len(response.json['cohort_filters']) == 2
+
 
 class TestUserAnalytics:
     """User Analytics API"""
@@ -55,7 +61,7 @@ class TestUserAnalytics:
         response = client.get(TestUserAnalytics.field_hockey_star)
         assert response.status_code == 401
 
-    def test_user_analytics_authenticated(self, fixture_cohorts, authenticated_response):
+    def test_user_analytics_authenticated(self, fixture_team_members, authenticated_response):
         """returns a well-formed response if authenticated"""
         assert authenticated_response.status_code == 200
         assert authenticated_response.json['uid'] == '61889'
@@ -112,7 +118,7 @@ class TestUserAnalytics:
         assert response.status_code == 404
         assert response.json['message'] == 'No Canvas profile found for user'
 
-    def test_sis_enrollment_merge(self, fixture_cohorts, authenticated_response):
+    def test_sis_enrollment_merge(self, fixture_team_members, authenticated_response):
         """merges SIS enrollment data"""
         burmese = TestUserAnalytics.get_course_for_code(authenticated_response, 'BURMESE 1A')
         assert len(burmese['sisEnrollments']) == 1
@@ -144,7 +150,7 @@ class TestUserAnalytics:
         assert nuclear['sisEnrollments'][0]['gradingBasis'] == 'PNP'
         assert nuclear['sisEnrollments'][0]['grade'] == 'P'
 
-    def test_sis_enrollment_not_found(self, fixture_cohorts, authenticated_session, client):
+    def test_sis_enrollment_not_found(self, fixture_team_members, authenticated_session, client):
         """gracefully handles missing SIS enrollments"""
         sis_error = MockResponse(200, {}, '{"apiResponse": {"response": {"message": "Something unexpected."}}}')
         with register_mock(sis_enrollments_api._get_enrollments, sis_error):
@@ -154,7 +160,7 @@ class TestUserAnalytics:
             for course in response.json['courses']:
                 assert not course.get('sisEnrollments')
 
-    def test_sis_profile(self, fixture_cohorts, authenticated_response):
+    def test_sis_profile(self, fixture_team_members, authenticated_response):
         """provides SIS profile data"""
         sis_profile = authenticated_response.json['sisProfile']
         assert sis_profile['cumulativeGPA'] == 3.8
@@ -174,7 +180,7 @@ class TestUserAnalytics:
         assert sis_profile['preferredName'] == 'Osk Bear'
         assert sis_profile['primaryName'] == 'Oski Bear'
 
-    def test_sis_profile_unexpected_payload(self, fixture_cohorts, authenticated_session, client):
+    def test_sis_profile_unexpected_payload(self, fixture_team_members, authenticated_session, client):
         """gracefully handles unexpected SIS profile data"""
         sis_response = MockResponse(200, {}, '{"apiResponse": {"response": {"message": "Something wicked."}}}')
         with register_mock(sis_student_api._get_student, sis_response):
@@ -183,7 +189,7 @@ class TestUserAnalytics:
             assert response.json['canvasProfile']
             assert not response.json['sisProfile']
 
-    def test_sis_profile_error(self, fixture_cohorts, authenticated_session, client):
+    def test_sis_profile_error(self, fixture_team_members, authenticated_session, client):
         """gracefully handles SIS profile error"""
         sis_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(sis_student_api._get_student, sis_error):

--- a/tests/test_lib/test_merged.py
+++ b/tests/test_lib/test_merged.py
@@ -4,8 +4,8 @@ from boac.lib import merged as subject
 class TestMerged:
     """TestMerged"""
 
-    def test_refresh_cohort_attributes(self, app, fixture_cohorts):
-        members = fixture_cohorts
+    def test_refresh_cohort_attributes(self, app, fixture_team_members):
+        members = fixture_team_members
         original_csids = (m.member_csid for m in members)
         for member in members:
             member.member_uid = None


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-93

All teams are cohorts but not all cohorts are teams. 
* I generalized `/api/cohort/<cohort_code>`
* the custom cohorts are always available in `current_user` object
* next step is to rework the front-end