### PR TITLE
BOAC-138 Add support for cache loading and refreshing

### DIFF
--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -29,8 +29,22 @@ class JsonCache(Base):
 
 def clear(key_like):
     matches = db.session.query(JsonCache).filter(JsonCache.key.like(key_like))
-    app.logger.info('Will delete {matches.count()} entries matching {key_like}'.format(matches=matches.count(), key_like=key_like))
+    app.logger.info('Will delete {count} entries matching {key_like}'.format(count=matches.count(), key_like=key_like))
     matches.delete(synchronize_session=False)
+
+
+def clear_other(key_like):
+    matches = db.session.query(JsonCache).filter(JsonCache.key.notlike(key_like))
+    app.logger.info('Will delete {count} entries not matching {key_like}'.format(count=matches.count(), key_like=key_like))
+    matches.delete(synchronize_session=False)
+
+
+def clear_current_term():
+    # Start by deleting cache which is not term-stamped, on the assumption that those feeds may have changed.
+    clear_other('term_%')
+    db.session.commit()
+    clear('term_{}%'.format(app.config['CANVAS_CURRENT_ENROLLMENT_TERM']))
+    db.session.commit()
 
 
 def stow(key_pattern, for_term=False):

--- a/run.py
+++ b/run.py
@@ -36,6 +36,18 @@ def initdb():
     development_db.load()
 
 
+@application.cli.command()
+def load_external_data():
+    from boac.api import cache_utils
+    cache_utils.load_current_term()
+
+
+@application.cli.command()
+def refresh_external_data():
+    from boac.api import cache_utils
+    cache_utils.refresh_current_term()
+
+
 host = application.config['HOST']
 port = application.config['PORT']
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-138

Example usage:

```
# Initial load of current term's data (takes around 90 minutes currently)...
# Configure BOAC with CANVAS_CURRENT_ENROLLMENT_TERM = 'Fall 2017'

boac> flask load_external_data

# Initial load of Spring 2017 data (takes less time because the non-term-specific data is cached)...
# Configure BOAC with CANVAS_CURRENT_ENROLLMENT_TERM = 'Spring 2017'

boac> flask load_external_data

# Reconfigure BOAC with CANVAS_CURRENT_ENROLLMENT_TERM = 'Fall 2017'
# Hermetically sealed into our well-stocked bunker, a second "load" will take about a minute.

boac> flask load_external_data

# To venture into the post-apocalyptic landscape to raid fresh provisions:

boac> flask refresh_external_data
[2017-11-14 09:38:18,803] - INFO: Will delete 2472 entries not matching term_% [in /Users/raydavis/Code/ets/boac/boac/models/json_cache.py:38]
[2017-11-14 09:38:18,898] - INFO: Will delete 2578 entries matching term_Fall 2017% [in /Users/raydavis/Code/ets/boac/boac/models/json_cache.py:32]
...
Complete. Fetched 9716 external feeds.

# The Spring 2017 specific feeds should still all be cached.
```
