### PR TITLE
BOAC-95, cohort counts on landing; wrap-reverse puts myCohorts on top

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -5,7 +5,6 @@ from boac.lib.analytics import merge_analytics_for_user
 from boac.lib.berkeley import sis_term_id_for_name
 from boac.lib.http import tolerant_jsonify
 from boac.lib.merged import merge_sis_enrollments, merge_sis_profile
-from boac.models.cohort_filter import CohortFilter
 from boac.models.team_member import TeamMember
 from flask import current_app as app, request
 from flask_login import current_user, login_required
@@ -14,22 +13,14 @@ from flask_login import current_user, login_required
 @app.route('/api/profile')
 def user_profile():
     canvas_profile = False
-    cohorts = False
     if current_user.is_active:
         uid = current_user.get_id()
         canvas_profile = load_canvas_profile(uid)
-        cohorts = []
-        for cohort in CohortFilter.all_owned_by(uid):
-            cohorts.append({
-                'id': cohort.id,
-                'label': cohort.label,
-            })
     else:
         uid = False
     return tolerant_jsonify({
         'uid': uid,
         'canvasProfile': canvas_profile,
-        'myCohorts': cohorts,
     })
 
 

--- a/boac/static/app/cohort/cohortsDropdownDirective.js
+++ b/boac/static/app/cohort/cohortsDropdownDirective.js
@@ -13,11 +13,13 @@
       templateUrl: '/static/app/cohort/dropdownNav.html',
       controller: function(cohortFactory, $rootScope, $scope) {
 
+        $scope.isLoading = true;
         $scope.myCohorts = null;
 
         var init = function() {
           cohortFactory.getMyCohorts().then(function(response) {
             $scope.myCohorts = response.data;
+            $scope.isLoading = false;
           });
         };
 

--- a/boac/static/app/cohort/dropdownNav.html
+++ b/boac/static/app/cohort/dropdownNav.html
@@ -1,9 +1,18 @@
 <div uib-dropdown>
-  <button id="btn-append-to-single-button" type="button" class="btn btn-primary" uib-dropdown-toggle>
+  <button id="btn-append-to-single-button"
+          type="button"
+          class="btn btn-primary"
+          uib-dropdown-toggle>
     Cohorts <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="btn-append-to-single-button">
-    <li role="menuitem" data-ng-repeat="cohort in myCohorts" data-ng-if="myCohorts.length">
+  <ul class="dropdown-menu"
+      role="menu"
+      aria-labelledby="btn-append-to-single-button"
+      uib-dropdown-menu>
+    <li role="menuitem" aria-disabled="true" data-ng-if="isLoading"><a>Loading....</a></li>
+    <li role="menuitem"
+        data-ng-repeat="cohort in myCohorts"
+        data-ng-if="myCohorts.length && !isLoading">
       <a data-ng-bind="cohort.label" data-ng-href="/cohort/{{cohort.id}}"></a>
     </li>
     <li class="divider"></li>

--- a/boac/static/app/landing/landing.html
+++ b/boac/static/app/landing/landing.html
@@ -4,10 +4,10 @@
   <div class="body-text" data-ng-if="me.authenticated_as.is_authenticated">
     <h1>My Dashboard</h1>
 
-    <div class="flex-container flex-space-between">
-      <div class="flex-item">
+    <div class="flex-container-wrap-reverse">
+      <div class="flex-column-50">
         <h2>Teams List</h2>
-        <div class="container" data-ng-if="isLoading">
+        <div data-ng-if="isLoading">
           <div>Loading.... </div>
         </div>
         <div data-ng-if="!isLoading">
@@ -24,15 +24,18 @@
           </div>
         </div>
       </div>
-      <div class="flex-item">
+      <div class="flex-column-50">
         <h2>My Saved Cohorts</h2>
-        <div>
-          <div data-ng-if="!me.myCohorts.length">
+        <div data-ng-if="isLoading">
+          <div>Loading.... </div>
+        </div>
+        <div data-ng-if="!isLoading">
+          <div data-ng-if="!myCohorts.length">
             <div>You have no saved cohorts</div>
           </div>
-          <div data-ng-if="me.myCohorts.length">
+          <div data-ng-if="myCohorts.length">
             <ul>
-              <li data-ng-repeat="cohort in me.myCohorts">
+              <li data-ng-repeat="cohort in myCohorts">
                 <a data-ng-bind="cohort.label" data-ng-href="/cohort/{{cohort.id}}"></a>
                 (<span data-ng-bind="cohort.memberCount"></span>)
               </li>

--- a/boac/static/app/landing/landingController.js
+++ b/boac/static/app/landing/landingController.js
@@ -7,9 +7,13 @@
     $scope.isLoading = true;
 
     var init = function() {
-      cohortFactory.getTeams().then(function(response) {
-        $scope.teams = response.data;
-        $scope.isLoading = false;
+      cohortFactory.getTeams().then(function(teamsResponse) {
+        $scope.teams = teamsResponse.data;
+
+        cohortFactory.getMyCohorts().then(function(response) {
+          $scope.myCohorts = response.data;
+          $scope.isLoading = false;
+        });
       });
     };
 

--- a/boac/static/app/main.css
+++ b/boac/static/app/main.css
@@ -4,25 +4,6 @@
   line-height: 1.8em;
 }
 
-.faint-text {
-  color: grey;
-}
-
-.dev-auth-login {
-  margin-top: 10px;
-}
-
-.flex-container {
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  display: flex;
-}
-
-.flex-space-between {
-  justify-content: space-between;
-}
-
 .container-left {
   float: left;
 }
@@ -36,7 +17,39 @@
   padding-top: 10px;
 }
 
+.dev-auth-login {
+  margin-top: 10px;
+}
+
+.faint-text {
+  color: grey;
+}
+
+.flex-container {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+}
+
+.flex-container-wrap-reverse {
+  display: flex;
+  -webkit-flex-wrap: wrap-reverse;
+  flex-wrap: wrap-reverse;
+}
+
+.flex-space-between {
+  justify-content: space-between;
+}
+
+.flex-column-50 {
+  flex: 0 0 50%;
+  flex-grow: 1;
+  min-width: 350px;
+}
+
 .main {
   padding-top: 20px;
   min-height: 370px;
 }
+

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -62,6 +62,15 @@ class TestCohortDetail:
         assert response.json['members'][0]['uid'] == '61889'
         assert response.json['members'][0]['avatar_url'] == 'https://calspirit.berkeley.edu/oski/images/oskibio.jpg'
 
+    def test_my_cohorts(self, authenticated_session, client, fixture_custom_cohorts):
+        response = client.get('/api/cohorts/my')
+        assert response.status_code == 200
+
+        my_cohorts = response.json
+        assert len(my_cohorts) == 2
+        assert len(my_cohorts[0]['teams']) == 2
+        assert len(my_cohorts[1]['teams']) == 2
+
     def test_get_cohort(self, authenticated_session, client, fixture_team_members):
         """returns a well-formed response with custom cohort"""
         user = AuthorizedUser.find_by_uid(test_uid)

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -26,12 +26,6 @@ class TestUserProfile:
         response = client.get('/api/profile')
         assert response.json['canvasProfile']['sis_login_id'] == test_uid
 
-    def test_custom_cohorts(self, fixture_custom_cohorts, client, fake_auth):
-        test_uid = '53791'
-        fake_auth.login(test_uid)
-        response = client.get('/api/profile')
-        assert len(response.json['myCohorts']) >= 2
-
 
 class TestUserAnalytics:
     """User Analytics API"""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-95

* `myCohorts` is not needed in `/api/profile`
* wrap-reverse on landing puts my-cohorts on top
* isLoading for dropdown in header nav