### PR TITLE
BOAC-148, fix db.Table def of cohort_filter_owners

### DIFF
--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -12,7 +12,7 @@ cohort_filter_owners = db.Table(
     'cohort_filter_owners',
     Base.metadata,
     db.Column('cohort_filter_id', db.Integer, db.ForeignKey('cohort_filters.id'), primary_key=True),
-    db.Column('user_id', db.String(255), db.ForeignKey('authorized_users.uid'), primary_key=True),
+    db.Column('user_id', db.Integer, db.ForeignKey('authorized_users.id'), primary_key=True),
 )
 
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-148

This matches the intention, as seen in [scripts/db/migrate/20171107-BOAC-92/create_cohort_filters_table.sql](https://github.com/ets-berkeley-edu/boac/blob/master/scripts/db/migrate/20171107-BOAC-92/create_cohort_filters_table.sql).

On localhost, a stale schema (in which `cohort_filter_owners.user_id` was varchar) was masking the problem.  Once I refreshed my local schema I could reproduce (then fix) the bug. 