### PR TITLE
BOAC-149, when get_cohort_list, include member_count per cohort and exclude Canvas user profile

### DIFF
--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -41,9 +41,13 @@ def load_development_data():
     csv_reader = csv.DictReader(_default_users_csv.splitlines())
     team_codes = list(TeamMember.team_definitions.keys())
     for row in csv_reader:
-        user = AuthorizedUser(**row)
-        db.session.add(user)
-        # A subset of users get saved cohorts
+        # This script can be run more than once. Do not create user if s/he exists in BOAC db.
+        user = AuthorizedUser.find_by_uid(row['uid'])
+        if not user:
+            user = AuthorizedUser(**row)
+            db.session.add(user)
+
+        # Random UIDs get test data (saved cohorts)
         if '1' in user.uid:
             create_cohort(team_codes.pop(), team_codes.pop(), user.uid)
             create_cohort(team_codes.pop(), team_codes.pop(), user.uid)

--- a/boac/static/app/cohort/manage.html
+++ b/boac/static/app/cohort/manage.html
@@ -7,6 +7,9 @@
     <div>Loading.... </div>
   </div>
   <div data-ng-if="!isLoading">
+    <div data-ng-if="!myCohorts">
+      You have no saved cohorts.
+    </div>
     <div data-ng-repeat="cohort in myCohorts">
       <hr class="cohort-manage-row-separator"/>
       <div class="flex-container flex-space-between" data-ng-if="!cohort.editMode">

--- a/boac/static/app/cohort/manageCohortsController.js
+++ b/boac/static/app/cohort/manageCohortsController.js
@@ -37,8 +37,6 @@
     $scope.deleteCohort = cohortFactory.deleteCohort;
 
     var init = function() {
-      $scope.isLoading = true;
-
       cohortFactory.getMyCohorts().then(function(response) {
         $scope.myCohorts = response.data;
         resetPageView(angular.noop);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-149

Furthermore, do not cache team data if load_canvas_profile=False. (The change in `development_db.py` allows use to load test-cohort-data when test-user-data is already present in the db – e.g., boac-dev)
 