### PR TITLE
BOAC-153, dev_auth need only support json POST

### DIFF
--- a/boac/auth/dev_auth.py
+++ b/boac/auth/dev_auth.py
@@ -11,11 +11,11 @@ from flask_login import (
 def dev_login():
     if app.config['DEVELOPER_AUTH_ENABLED']:
         logger = app.logger
-        form = request.form or request.get_json()
-        if form.get('password') != app.config['DEVELOPER_AUTH_PASSWORD']:
+        params = request.get_json()
+        if params['password'] != app.config['DEVELOPER_AUTH_PASSWORD']:
             logger.error('Wrong password entered in Developer Auth')
             raise ForbiddenRequestError('Wrong credentials')
-        user_id = form.get('uid')
+        user_id = params['uid']
         user = app.login_manager.user_callback(user_id)
         if user is None:
             logger.error('Unauthorized user ID {} entered in Developer Auth'.format(user_id))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import boac.factory
 import pytest
@@ -16,10 +17,11 @@ class FakeAuth(object):
 
     def login(self, uid):
         self.app.config['DEVELOPER_AUTH_ENABLED'] = True
-        self.client.post(
-            '/devauth/login',
-            data={'uid': uid, 'password': self.app.config['DEVELOPER_AUTH_PASSWORD']},
-        )
+        params = {
+            'uid': uid,
+            'password': self.app.config['DEVELOPER_AUTH_PASSWORD'],
+        }
+        self.client.post('/devauth/login', data=json.dumps(params), content_type='application/json')
 
 
 # Because app and db fixtures are only created once per pytest run, individual tests

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -31,7 +31,7 @@ class TestUserAnalytics:
     """User Analytics API"""
     api_path = '/api/user/{}/analytics'
     field_hockey_star = api_path.format(61889)
-    non_student_uid = 2040
+    non_student_uid = '2040'
     non_student = api_path.format(non_student_uid)
     unknown_uid = 9999999
     unknown = api_path.format(unknown_uid)
@@ -102,7 +102,7 @@ class TestUserAnalytics:
         fake_auth.login(TestUserAnalytics.non_student_uid)
         response = client.get(TestUserAnalytics.non_student)
         assert response.status_code == 200
-        assert int(response.json['uid']) == TestUserAnalytics.non_student_uid
+        assert response.json['uid'] == TestUserAnalytics.non_student_uid
         assert not response.json['courses']
 
     def test_canvas_profile_not_found(self, authenticated_session, client):

--- a/tests/test_auth/test_dev_auth.py
+++ b/tests/test_auth/test_dev_auth.py
@@ -1,3 +1,6 @@
+import json
+
+
 class TestDevAuth:
     """DevAuth handling"""
 
@@ -8,25 +11,29 @@ class TestDevAuth:
         app.config['DEVELOPER_AUTH_ENABLED'] = False
         response = client.post('/devauth/login')
         assert response.status_code == 404
-        response = client.post('/devauth/login', data={'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']})
+        params = {'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
+        response = client.post('/devauth/login', data=json.dumps(params), content_type='application/json')
         assert response.status_code == 404
 
     def test_password_fail(self, app, client):
         """fails if no match on developer password"""
         app.config['DEVELOPER_AUTH_ENABLED'] = True
-        response = client.post('/devauth/login', data={'uid': self.authorized_uid, 'password': 'Born 2 Lose'})
+        params = {'uid': self.authorized_uid, 'password': 'Born 2 Lose'}
+        response = client.post('/devauth/login', data=json.dumps(params), content_type='application/json')
         assert response.status_code == 403
 
     def test_authorized_user_fail(self, app, client):
         """fails if the chosen UID does not match an authorized user"""
         app.config['DEVELOPER_AUTH_ENABLED'] = True
-        response = client.post('/devauth/login', data={'uid': 'A Bad Sort', 'password': app.config['DEVELOPER_AUTH_PASSWORD']})
+        params = {'uid': 'A Bad Sort', 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
+        response = client.post('/devauth/login', data=json.dumps(params), content_type='application/json')
         assert response.status_code == 403
 
     def test_known_user_with_correct_password_logs_in(self, app, client):
         """there is a happy path"""
         app.config['DEVELOPER_AUTH_ENABLED'] = True
-        response = client.post('/devauth/login', data={'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']})
+        params = {'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
+        response = client.post('/devauth/login', data=json.dumps(params), content_type='application/json')
         assert response.status_code == 302
         response = client.get('/api/status')
         assert response.status_code == 200


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-153

Why support `request.form` if we don't need it?