### PR TITLE
BOAC-156, cohort view must have totalMemberCount for all cohorts, incl. teams

### DIFF
--- a/boac/models/team_member.py
+++ b/boac/models/team_member.py
@@ -100,6 +100,7 @@ class TeamMember(Base):
             'code': code,
             'members': [member.to_api_json() for member in members],
             'name': cls.team_definitions.get(code, code),
+            'totalMemberCount': TeamMember.query.filter_by(code=code).count(),
         }
 
     @classmethod

--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -14,6 +14,9 @@
         <label for="search-teams" class="sr-only">Select team</label>
         <oi-select id="search-teams"
                    oi-options="team.code as team.name for team in search.options.teams"
+                   oi-select-options="{
+                    cleanModel: true
+                   }"
                    ng-model="search.watch.teamCode"
                    placeholder="Team"
                    tabindex="-1"></oi-select>

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -60,6 +60,7 @@ class TestCohortDetail:
         assert response.json['members'][0]['name'] == 'Brigitte Lin'
         assert response.json['members'][0]['uid'] == '61889'
         assert response.json['members'][0]['avatar_url'] == 'https://calspirit.berkeley.edu/oski/images/oskibio.jpg'
+        assert response.json['totalMemberCount'] == len(response.json['members'])
 
     def test_my_cohorts(self, authenticated_session, client):
         response = client.get('/api/cohorts/my')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-156

The importance of `totalMemberCount` on cohort view:
* if equals 0 or more then you're viewing search results or saved cohort
* if null then you're starting from scratch (ie, 'create a cohort') 