### PR TITLE
BOAC-121 BOAC-127 Show enrollments from all terms with best-effort Canvas site association

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -2,7 +2,7 @@ from boac import db
 from flask import current_app as app
 
 
-def load_canvas_externals(uid):
+def load_canvas_externals(uid, sis_term_id):
     from boac.externals import canvas
 
     success_count = 0
@@ -15,19 +15,19 @@ def load_canvas_externals(uid):
         ))
     elif canvas_user_profile:
         success_count += 1
-        sites = canvas.get_student_courses_in_term(uid)
+        sites = canvas.get_student_courses(uid)
         if sites:
             success_count += 1
             for site in sites:
                 site_id = site['id']
-                if not canvas.get_course_sections(site_id):
+                if not canvas.get_course_sections(site_id, sis_term_id):
                     failures.append('canvas.get_course_sections failed for UID {}, site_id {}'.format(
                         uid,
                         site_id,
                     ))
                     continue
                 success_count += 1
-                if not canvas.get_student_summaries(site_id):
+                if not canvas.get_student_summaries(site_id, sis_term_id):
                     failures.append('canvas.get_student_summaries failed for site_id {}'.format(
                         site_id,
                     ))
@@ -73,7 +73,7 @@ def load_current_term():
     # Currently, all external data is loaded starting from the individuals who belong
     # to one or more Cohorts.
     for csid, uid in db.session.query(TeamMember.member_csid, TeamMember.member_uid).distinct():
-        s, f = load_canvas_externals(uid)
+        s, f = load_canvas_externals(uid, sis_term_id)
         success_count += s
         failures += f
         db.session.commit()

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -128,9 +128,12 @@ def load_member_profiles(team):
 
         if canvas_profile:
             member['avatar_url'] = canvas_profile['avatar_url']
-            canvas_courses = canvas_courses_api_feed(canvas.get_student_courses_in_term(uid))
+            student_courses = canvas.get_student_courses(uid)
+            current_term = app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM')
+            student_courses_in_current_term = [course for course in student_courses if course.get('term', {}).get('name') == current_term]
+            canvas_courses = canvas_courses_api_feed(student_courses_in_current_term)
             if canvas_courses:
-                member['analytics'] = mean_course_analytics_for_user(canvas_courses, canvas_profile['id'])
+                member['analytics'] = mean_course_analytics_for_user(canvas_courses, canvas_profile['id'], current_term)
 
 
 def get_param(params, key, default_value=None):

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -2,7 +2,6 @@ from boac.api import errors
 import boac.api.util as api_util
 from boac.externals import canvas
 from boac.lib.analytics import merge_analytics_for_user
-from boac.lib.berkeley import sis_term_id_for_name
 from boac.lib.http import tolerant_jsonify
 from boac.lib.merged import merge_sis_enrollments, merge_sis_profile
 from boac.models.team_member import TeamMember
@@ -40,28 +39,32 @@ def user_analytics(uid):
         raise errors.InternalServerError('Unable to reach bCourses')
     canvas_id = canvas_profile['id']
 
-    user_courses = canvas.get_student_courses_in_term(uid)
-    courses_api_feed = api_util.canvas_courses_api_feed(user_courses)
-
-    cohort_data = TeamMember.query.filter_by(member_uid=uid).first()
-    if cohort_data and len(user_courses):
-        term_id = sis_term_id_for_name(user_courses[0].get('term', {}).get('name'))
-        merge_sis_enrollments(courses_api_feed, cohort_data.member_csid, term_id)
-
-    merge_analytics_for_user(courses_api_feed, canvas_id)
-
-    if cohort_data:
-        sis_profile = merge_sis_profile(cohort_data.member_csid)
-        cohort_data = cohort_data.to_api_json()
+    team_member = TeamMember.query.filter_by(member_uid=uid).first()
+    if team_member:
+        sis_profile = merge_sis_profile(team_member.member_csid)
+        athletics_profile = team_member.to_api_json()
     else:
         sis_profile = False
+        athletics_profile = False
+
+    user_courses = canvas.get_student_courses(uid)
+    if team_member and sis_profile and len(user_courses):
+        canvas_courses_feed = api_util.canvas_courses_api_feed(user_courses)
+        enrollment_terms = merge_sis_enrollments(canvas_courses_feed, team_member.member_csid, sis_profile['matriculation'])
+    else:
+        enrollment_terms = []
+
+    for term in enrollment_terms:
+        for enrollment in term['enrollments']:
+            merge_analytics_for_user(enrollment['canvasSites'], canvas_id, term['termName'])
+        merge_analytics_for_user(term['unmatchedCanvasSites'], canvas_id, term['termName'])
 
     return tolerant_jsonify({
         'uid': uid,
+        'athleticsProfile': athletics_profile,
         'canvasProfile': canvas_profile,
-        'cohortData': cohort_data,
-        'courses': courses_api_feed,
         'sisProfile': sis_profile,
+        'enrollmentTerms': enrollment_terms,
     })
 
 

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -10,6 +10,7 @@ def canvas_courses_api_feed(courses):
             'canvasCourseId': course.get('id'),
             'courseName': course.get('name'),
             'courseCode': course.get('course_code'),
+            'courseTerm': course.get('term', {}).get('name'),
         }
     return [course_api_values(course) for course in courses]
 
@@ -21,9 +22,11 @@ def sis_enrollment_api_feed(enrollment):
     return {
         'ccn': sectionData.get('id'),
         'displayName': classData.get('course', {}).get('displayName'),
+        'title': classData.get('course', {}).get('title'),
         'sectionNumber': classData.get('number'),
         'enrollmentStatus': enrollment.get('enrollmentStatus', {}).get('status', {}).get('code'),
         'units': enrollment.get('enrolledUnits', {}).get('taken'),
         'gradingBasis': enrollment.get('gradingBasis', {}).get('code'),
         'grade': next((grade.get('mark') for grade in grades if grade.get('type', {}).get('code') == 'OFFL'), None),
+        'canvasSites': [],
     }

--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -5,7 +5,7 @@ from flask import current_app as app
 
 
 @stow('canvas_course_sections_{course_id}', for_term=True)
-def get_course_sections(course_id):
+def get_course_sections(course_id, term_id):
     return _get_course_sections(course_id)
 
 
@@ -37,8 +37,7 @@ def _get_user_for_uid(uid, mock=None):
         return authorized_request(url)
 
 
-def get_student_courses_in_term(uid):
-    term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
+def get_student_courses(uid):
     all_canvas_courses = get_all_user_courses(uid)
     # The paged_request wrapper returns either a list of course sites or None to signal HTTP request failure.
     # An empty list should be handled by higher-level logic even though it's falsey.
@@ -46,7 +45,7 @@ def get_student_courses_in_term(uid):
         return None
 
     def include_course(course):
-        if course.get('term', {}).get('name') == term_name and course['enrollments']:
+        if course.get('enrollments'):
             if next((e for e in course['enrollments'] if e['type'] == 'student'), None):
                 return True
         return False
@@ -67,7 +66,7 @@ def _get_all_user_courses(uid, mock=None):
 
 
 @stow('canvas_student_summaries_for_course_{course_id}', for_term=True)
-def get_student_summaries(course_id):
+def get_student_summaries(course_id, term_id):
     return _get_student_summaries(course_id)
 
 

--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -1,22 +1,24 @@
 import math
 from statistics import mean
 from boac.externals import canvas
+from boac.lib.berkeley import sis_term_id_for_name
 from flask import current_app as app
 import pandas
 
 
-def merge_analytics_for_user(user_courses, canvas_user_id):
+def merge_analytics_for_user(user_courses, canvas_user_id, term_name):
+    term_id = sis_term_id_for_name(term_name)
     if user_courses:
         for course in user_courses:
-            student_summaries = canvas.get_student_summaries(course['canvasCourseId'])
+            student_summaries = canvas.get_student_summaries(course['canvasCourseId'], term_id)
             if not student_summaries:
                 course['analytics'] = {'error': 'Unable to retrieve analytics'}
             else:
                 course['analytics'] = analytics_from_summary_feed(student_summaries, canvas_user_id, course)
 
 
-def mean_course_analytics_for_user(user_courses, canvas_user_id):
-    merge_analytics_for_user(user_courses, canvas_user_id)
+def mean_course_analytics_for_user(user_courses, canvas_user_id, term_name):
+    merge_analytics_for_user(user_courses, canvas_user_id, term_name)
     meanValues = {}
     for metric in ['assignmentsOnTime', 'pageViews', 'participations']:
         percentiles = []

--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -14,3 +14,14 @@ def sis_term_id_for_name(term_name=None):
                 'Fall': '8',
             }
             return '2' + match.group(2) + season_codes[match.group(1)]
+
+
+def term_name_for_sis_id(sis_id=None):
+    if sis_id:
+        sis_id = str(sis_id)
+        season_codes = {
+            '2': 'Spring',
+            '5': 'Summer',
+            '8': 'Fall',
+        }
+        return season_codes[sis_id[3:4]] + ' 20' + sis_id[1:3]

--- a/boac/static/app/student/courseSiteMetrics.html
+++ b/boac/static/app/student/courseSiteMetrics.html
@@ -1,0 +1,29 @@
+<ul>
+  <li>
+    Assignments on time:
+    <span data-ng-bind="percentile(canvasSite.analytics.assignmentsOnTime)"></span>
+    <div class="boxplot-container" data-ng-if="!canvasSite.analytics.assignmentsOnTime.insufficientData">
+      <div id="boxplot-{{canvasSite.canvasCourseId}}-assignmentsOnTime"
+           class="boxplot"
+           data-ng-init="drawBoxplot(termId, ccn, canvasSite.canvasCourseId, 'assignmentsOnTime')"></div>
+    </div>
+  </li>
+  <li>
+    Page views:
+    <span data-ng-bind="percentile(canvasSite.analytics.pageViews)"></span>
+    <div class="boxplot-container" data-ng-if="!canvasSite.analytics.pageViews.insufficientData">
+      <div id="boxplot-{{canvasSite.canvasCourseId}}-pageViews"
+           class="boxplot"
+           data-ng-init="drawBoxplot(termId, ccn, canvasSite.canvasCourseId, 'pageViews')"></div>
+    </div>
+  </li>
+  <li>
+    Participations:
+    <span data-ng-bind="percentile(canvasSite.analytics.participations)"></span>
+    <div class="boxplot-container" data-ng-if="!canvasSite.analytics.participations.insufficientData">
+      <div id="boxplot-{{canvasSite.canvasCourseId}}-participations"
+           class="boxplot"
+           data-ng-init="drawBoxplot(termId, ccn, canvasSite.canvasCourseId, 'participations')"></div>
+    </div>
+  </li>
+</ul>

--- a/boac/static/app/student/courseSiteMetricsDirective.js
+++ b/boac/static/app/student/courseSiteMetricsDirective.js
@@ -1,0 +1,19 @@
+(function(angular) {
+
+  'use strict';
+
+  angular.module('boac').directive('courseSiteMetrics', function() {
+    return {
+      restrict: 'E',
+      scope: {
+        canvasSite: '=',
+        ccn: '=',
+        drawBoxplot: '=',
+        percentile: '=',
+        termId: '='
+      },
+      templateUrl: '/static/app/student/courseSiteMetrics.html'
+    };
+  });
+
+}(window.angular));

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -92,56 +92,51 @@
           </table>
         </div>
       </div>
-      <div class="student-profile-classes" data-ng-if="student.courses.length">
-        <h2 class="student-profile-classes-header">Classes</h2>
-        <div data-ng-repeat="course in student.courses">
-          <h3 class="student-profile-class-title" data-ng-bind="course.courseCode"></h3>
-          <div class="student-enrollment-details" data-ng-repeat="enrolledSection in course.sisEnrollments">
-            <span data-ng-switch="enrolledSection.enrollmentStatus">
-              <span data-ng-switch-when="E">Enrolled in</span>
-              <span data-ng-switch-when="W">Waitlisted in</span>
-              <span data-ng-switch-when="D">Dropped</span>
-            </span>
-            section <span data-ng-bind="enrolledSection.sectionNumber"></span>
-            (<span data-ng-bind="enrolledSection.units"></span> units,
-            <span data-ng-bind="enrolledSection.gradingBasis"></span> grading basis)
-            <div data-ng-if="enrolledSection.grade">
-              <strong>Grade: <span data-ng-bind="enrolledSection.grade"></span></strong>
+      <div>
+        <div class="student-profile-terms" data-ng-repeat="term in student.enrollmentTerms">
+          <h2 class="student-profile-classes-header" data-ng-bind="term.termName"></h2>
+          <div class="student-profile-classes" data-ng-if="term.enrollments.length">
+            <div data-ng-repeat="course in term.enrollments">
+              <h3 class="student-profile-class-title" data-ng-bind="course.displayName"></h3>
+              <h4 class="student-profile-class-title" data-ng-bind="course.title"></h4>
+              <span data-ng-switch="course.enrollmentStatus">
+                <span data-ng-switch-when="E">Enrolled in</span>
+                <span data-ng-switch-when="W">Waitlisted in</span>
+                <span data-ng-switch-when="D">Dropped</span>
+              </span>
+              section <span data-ng-bind="course.sectionNumber"></span>
+              (<span data-ng-bind="course.units"></span> units,
+              <span data-ng-bind="course.gradingBasis"></span> grading basis)
+              <div data-ng-if="course.grade">
+                <strong>Grade: <span data-ng-bind="course.grade"></span></strong>
+              </div>
+              <div data-ng-repeat="canvasSite in course.canvasSites">
+                <course-site-metrics
+                  data-canvas-site="canvasSite"
+                  data-ccn="course.ccn"
+                  data-draw-boxplot="drawBoxplot"
+                  data-percentile="percentile"
+                  data-term-id="term.termId">
+                </course-site-metrics>
+              </div>
             </div>
           </div>
-          <ul>
-            <li>
-              Assignments on time:
-              <span data-ng-bind="percentile(course.analytics.assignmentsOnTime)"></span>
-              <div class="boxplot-container" data-ng-if="!course.analytics.assignmentsOnTime.insufficientData">
-                <div id="boxplot-{{course.canvasCourseId}}-assignmentsOnTime"
-                     class="boxplot"
-                     data-ng-init="drawBoxplot(course.canvasCourseId, 'assignmentsOnTime')"></div>
-              </div>
-            </li>
-            <li>
-              Page views:
-              <span data-ng-bind="percentile(course.analytics.pageViews)"></span>
-              <div class="boxplot-container" data-ng-if="!course.analytics.pageViews.insufficientData">
-                <div id="boxplot-{{course.canvasCourseId}}-pageViews"
-                     class="boxplot"
-                     data-ng-init="drawBoxplot(course.canvasCourseId, 'pageViews')"></div>
-              </div>
-            </li>
-            <li>
-              Participations:
-              <span data-ng-bind="percentile(course.analytics.participations)"></span>
-              <div class="boxplot-container" data-ng-if="!course.analytics.participations.insufficientData">
-                <div id="boxplot-{{course.canvasCourseId}}-participations"
-                     class="boxplot"
-                     data-ng-init="drawBoxplot(course.canvasCourseId, 'participations')"></div>
-              </div>
-            </li>
-          </ul>
+          <div class="student-profile-classes" data-ng-if="term.unmatchedCanvasSites.length">
+            <div data-ng-repeat="canvasSite in term.unmatchedCanvasSites">
+              <h3 class="student-profile-class-title" data-ng-bind="canvasSite.courseName"></h3>
+              <course-site-metrics
+                data-canvas-site="canvasSite"
+                data-ccn="'unmatchedCanvasSites'"
+                data-draw-boxplot="drawBoxplot"
+                data-percentile="percentile"
+                data-term-id="term.termId">
+              </course-site-metrics>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="student-profile-classes" data-ng-if="!student.courses.length">
-        No courses
+        <div class="student-profile-classes" data-ng-if="!student.enrollmentTerms.length">
+          No courses
+        </div>
       </div>
     </div>
   </div>

--- a/boac/static/app/student/studentController.js
+++ b/boac/static/app/student/studentController.js
@@ -17,20 +17,30 @@
 
     $scope.student = {
       canvasProfile: null,
-      courses: null,
+      enrollmentTerms: null,
       isLoading: true
     };
 
     /**
      * Render a box plot for a given course and metric
      *
+     * @param  {String}  termId        SIS term id for the course
+     * @param  {Number}  ccn           SIS CCN for the course
      * @param  {Number}  courseId      Canvas course ID for the course
      * @param  {String}  metric        Metric to draw the boxplot for
      * @return {void}
      */
-    $scope.drawBoxplot = function(courseId, metric) {
+    $scope.drawBoxplot = function(termId, ccn, courseId, metric) {
 
-      var course = _.find($scope.student.courses, {canvasCourseId: courseId});
+      var term = _.find($scope.student.enrollmentTerms, {termId: termId});
+      var courseSites;
+      if (ccn === 'unmatchedCanvasSites') {
+        courseSites = term.unmatchedCanvasSites;
+      } else {
+        var enrollment = _.find(term.enrollments, {ccn: ccn});
+        courseSites = enrollment.canvasSites;
+      }
+      var course = _.find(courseSites, {canvasCourseId: courseId});
 
       setTimeout(function() {
         // Render the box plot using highcharts

--- a/boac/templates/index.html
+++ b/boac/templates/index.html
@@ -43,6 +43,7 @@
     <script src="/static/app/cohort/deleteCohortController.js"></script>
     <script src="/static/app/cohort/manageCohortsController.js"></script>
     <script src="/static/app/landing/landingController.js"></script>
+    <script src="/static/app/student/courseSiteMetricsDirective.js"></script>
     <script src="/static/app/student/findStudentDirective.js"></script>
     <script src="/static/app/student/studentController.js"></script>
     <script src="/static/app/student/studentFactory.js"></script>

--- a/fixtures/canvas_course_sections_7654325.json
+++ b/fixtures/canvas_course_sections_7654325.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": 4000001,
+    "course_id": 7654325,
+    "name": "STAT 154 LEC 001",
+    "start_at": null,
+    "end_at": null,
+    "restrict_enrollments_to_section_dates": false,
+    "nonxlist_course_id": null,
+    "sis_section_id": "SEC:2017-B-50299",
+    "sis_course_id": "CRS:STAT-124-2017-B",
+    "integration_id": null,
+    "sis_import_id": 700000
+  },
+  {
+    "id": 4000002,
+    "course_id": 7654325,
+    "name": "STAT 154 DIS 001",
+    "start_at": null,
+    "end_at": null,
+    "restrict_enrollments_to_section_dates": false,
+    "nonxlist_course_id": null,
+    "sis_section_id": "SEC:2017-B-50300",
+    "sis_course_id": "CRS:STAT-124-2017-B",
+    "integration_id": null,
+    "sis_import_id": 700000
+  }
+]

--- a/fixtures/canvas_course_sections_7654330.json
+++ b/fixtures/canvas_course_sections_7654330.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": 5000004,
+    "course_id": 7654323,
+    "name": "NUC ENG 124 LAB 002",
+    "start_at": null,
+    "end_at": null,
+    "restrict_enrollments_to_section_dates": false,
+    "nonxlist_course_id": null,
+    "sis_section_id": "SEC:2017-D-90300",
+    "sis_course_id": "CRS:NUCENG-124-2017-D",
+    "integration_id": null,
+    "sis_import_id": 700000
+  }
+]

--- a/fixtures/canvas_user_courses_61889.json
+++ b/fixtures/canvas_user_courses_61889.json
@@ -157,6 +157,45 @@
     "restrict_enrollments_to_course_dates": false
   },
   {
+    "id": 7654330,
+    "name": "Optional Friday Night Radioactivity Group",
+    "account_id": 1,
+    "uuid": "qwertyuiop4",
+    "start_at": "2017-08-18T18:17:59Z",
+    "grading_standard_id": null,
+    "is_public": null,
+    "course_code": "NUC ENG 124",
+    "default_view": "feed",
+    "root_account_id": 90242,
+    "enrollment_term_id": 5493,
+    "end_at": null,
+    "public_syllabus": false,
+    "public_syllabus_to_auth": false,
+    "storage_quota_mb": 2048,
+    "is_public_to_auth_users": false,
+    "term": {
+      "id": 5493,
+      "name": "Fall 2017"
+    },
+    "apply_assignment_group_weights": false,
+    "calendar": {
+      "ics": "https://ucberkeley.beta.instructure.com/feeds/calendars/course_qwertyuiop4.ics"
+    },
+    "time_zone": "America/Los_Angeles",
+    "enrollments": [
+      {
+        "type": "student",
+        "role": "StudentEnrollment",
+        "role_id": 1772,
+        "user_id": 123456,
+        "enrollment_state": "active"
+      }
+    ],
+    "hide_final_grades": false,
+    "workflow_state": "available",
+    "restrict_enrollments_to_course_dates": false
+  },
+  {
     "id": 7654324,
     "name": "Fungi, History, and Society",
     "account_id": 102643,
@@ -206,15 +245,15 @@
     "course_code": "STAT 154",
     "default_view": "feed",
     "root_account_id": 90242,
-    "enrollment_term_id": 1818,
+    "enrollment_term_id": 5491,
     "end_at": null,
     "public_syllabus": false,
     "public_syllabus_to_auth": false,
     "storage_quota_mb": 2048,
     "is_public_to_auth_users": false,
     "term": {
-      "id": 1818,
-      "name": "Default Term"
+      "id": 5491,
+      "name": "Spring 2017"
     },
     "apply_assignment_group_weights": false,
     "calendar": {

--- a/fixtures/sis_enrollments_api_11667051_2172.json
+++ b/fixtures/sis_enrollments_api_11667051_2172.json
@@ -1,0 +1,281 @@
+{
+  "apiResponse": {
+    "httpStatus": {
+      "code": "200",
+      "description": "OK"
+    },
+    "responseType": "namespaceURI=\"http://bmeta.berkeley.edu/student/enrollmentV0.xsd\" element=\"enrollmentsByStudent\"",
+    "response": {
+      "student": {
+        "identifiers": [
+          {
+            "type": "student-id",
+            "id": "11667051",
+            "disclose": true
+          },
+          {
+            "type": "campus-uid",
+            "id": "61889",
+            "disclose": true
+          },
+          {
+            "type": "Social Security Number",
+            "id": "***-**-****",
+            "disclose": false
+          }
+        ],
+        "names": [
+          {
+            "type": {
+              "code": "PRI",
+              "description": "Primary"
+            },
+            "familyName": "Bear",
+            "givenName": "Oski",
+            "formattedName": "Oski Bear",
+            "disclose": true,
+            "uiControl": {
+              "code": "D",
+              "description": "Display Only"
+            },
+            "fromDate": "2017-01-31"
+          }
+        ],
+        "emails": [
+          {
+            "type": {
+              "code": "CAMP",
+              "description": "Campus"
+            },
+            "emailAddress": "oski@berkeley.edu",
+            "primary": true,
+            "disclose": true,
+            "uiControl": {
+              "code": "D",
+              "description": "Display Only"
+            }
+          }
+        ],
+        "confidential": false
+      },
+      "studentEnrollments": [
+        {
+          "enrollmentStatus": {
+            "status": {
+              "code": "E",
+              "description": "Enrolled"
+            },
+            "reason": {
+              "code": "ENRL",
+              "description": "Enrolled"
+            },
+            "fromDate": "2016-12-11"
+          },
+          "enrolledUnits": {
+            "taken": 2,
+            "forAcademicProgress": 2,
+            "forFinancialAid": 2,
+            "forBilling": 2
+          },
+          "gradingBasis": {
+            "code": "GRD",
+            "description": "Standard Grading Basis"
+          },
+          "grades": [
+            {
+              "type": {
+                "code": "OFFL",
+                "description": "Official Grade"
+              },
+              "mark": "A-",
+              "status": {},
+              "uiControl": {}
+            }
+          ],
+          "classSection": {
+            "id": 80100,
+            "number": "001",
+            "component": {
+              "code": "TUT",
+              "description": "Tutorial"
+            },
+            "displayName": "2017 Spring MUSIC 41C 001 TUT 001",
+            "association": {
+              "primary": false,
+              "primaryAssociatedComponent": {
+              }
+            },
+            "enrollmentStatus": {
+              "status": {
+              }
+            },
+            "printInScheduleOfClasses": false,
+            "addConsentRequired": {
+              "code": "N",
+              "description": "No Special Consent Required"
+            },
+            "dropConsentRequired": {
+              "code": "N",
+              "description": "No Special Consent Required"
+            },
+            "meetings": [
+              {
+                "number": 1,
+                "meetsDays": "Mo",
+                "meetsMonday": true,
+                "meetsTuesday": false,
+                "meetsWednesday": false,
+                "meetsThursday": false,
+                "meetsFriday": false,
+                "meetsSaturday": false,
+                "meetsSunday": false,
+                "startTime": "12:00:00",
+                "endTime": "12:59:00",
+                "location": {
+                  "code": "SATHTOWER",
+                  "description": "Sather Tower"
+                },
+                "building": {
+                  "code": "8000",
+                  "description": "Sather Tower"
+                },
+                "assignedInstructors": [
+                  {
+                    "assignmentNumber": 1,
+                    "instructor": {
+                      "identifiers": [
+                        {
+                          "type": "student-id",
+                          "id": "3334445550",
+                          "disclose": true
+                        },
+                        {
+                          "type": "campus-uid",
+                          "id": "1122330",
+                          "disclose": true
+                        },
+                        {
+                          "type": "Social Security Number",
+                          "id": "***-**-****",
+                          "disclose": false
+                        },
+                        {
+                          "type": "HCM System",
+                          "id": "012345670",
+                          "disclose": false
+                        }
+                      ],
+                      "names": [
+                        {
+                          "type": {
+                            "code": "PRF",
+                            "description": "Preferred"
+                          },
+                          "familyName": "van Eyck",
+                          "givenName": "Jakob",
+                          "formattedName": "Jakob van Eyck",
+                          "disclose": true,
+                          "uiControl": {
+                            "code": "U",
+                            "description": "Edit - No Delete"
+                          },
+                          "fromDate": "2003-12-03"
+                        },
+                        {
+                          "type": {
+                            "code": "PRI",
+                            "description": "Primary"
+                          },
+                          "familyName": "van Eyck",
+                          "givenName": "Jakob",
+                          "formattedName": "Jakob van Eyck",
+                          "disclose": true,
+                          "uiControl": {
+                            "code": "D",
+                            "description": "Display Only"
+                          },
+                          "fromDate": "2003-12-03"
+                        }
+                      ],
+                      "emails": [
+                        {
+                          "type": {
+                            "code": "CAMP",
+                            "description": "Campus"
+                          },
+                          "emailAddress": "jve@berkeley.edu",
+                          "primary": true,
+                          "disclose": true,
+                          "uiControl": {
+                            "code": "D",
+                            "description": "Display Only"
+                          }
+                        }
+                      ]
+                    },
+                    "role": {
+                      "code": "PI",
+                      "description": "1-TIC",
+                      "formalDescription": "Teaching and In Charge"
+                    },
+                    "printInScheduleOfClasses": true,
+                    "gradeRosterAccess": {
+                      "code": "A",
+                      "description": "Approve",
+                      "formalDescription": "Approve"
+                    }
+                  }
+                ],
+                "startDate": "2017-01-05",
+                "endDate": "2017-05-08",
+                "meetingTopic": {
+                }
+              }
+            ],
+            "class": {
+              "course": {
+                "identifiers": [
+                  {
+                    "type": "cs-course-id",
+                    "id": "22345"
+                  }
+                ],
+                "subjectArea": {
+                  "code": "MUSIC",
+                  "description": "Music"
+                },
+                "catalogNumber": {
+                  "number": "41",
+                  "suffix": "C",
+                  "formatted": "41C"
+                },
+                "displayName": "MUSIC 41C",
+                "title": "Private Carillon Lessons for Advanced Students",
+                "transcriptTitle": "PRIV CARILLON"
+              },
+              "offeringNumber": 1,
+              "session": {
+                "term": {
+                  "id": "2172",
+                  "name": "2017 Spring"
+                },
+                "id": "1",
+                "name": "Regular Academic Session"
+              },
+              "number": "001",
+              "displayName": "2017 Spring MUSIC 41C 001",
+              "allowedUnits": {
+                "minimum": 4,
+                "maximum": 4,
+                "forAcademicProgress": 4,
+                "forFinancialAid": 4
+              },
+              "status": {
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -47,8 +47,10 @@ class TestUserAnalytics:
         return client.get(TestUserAnalytics.field_hockey_star)
 
     @staticmethod
-    def get_course_for_code(response, code):
-        return next((course for course in response.json['courses'] if course['courseCode'] == code), None)
+    def get_course_for_code(response, term_id, code):
+        term = next((term for term in response.json['enrollmentTerms'] if term['termId'] == term_id), None)
+        if term:
+            return next((course for course in term['enrollments'] if course['displayName'] == code), None)
 
     def test_user_analytics_not_authenticated(self, client):
         """returns 401 if not authenticated"""
@@ -60,43 +62,77 @@ class TestUserAnalytics:
         assert authenticated_response.status_code == 200
         assert authenticated_response.json['uid'] == '61889'
         assert authenticated_response.json['canvasProfile']['id'] == 9000100
-        assert len(authenticated_response.json['courses']) == 3
-        for course in authenticated_response.json['courses']:
-            assert course['courseCode']
-            assert course['canvasCourseId']
-            assert course['courseName']
-            assert course['analytics']
-            assert course['sisEnrollments']
+        assert len(authenticated_response.json['enrollmentTerms']) > 0
+        for term in authenticated_response.json['enrollmentTerms']:
+            assert len(term['enrollments']) > 0
+            for course in term['enrollments']:
+                for canvasSite in course['canvasSites']:
+                    assert canvasSite['canvasCourseId']
+                    assert canvasSite['courseCode']
+                    assert canvasSite['courseTerm']
+                    assert canvasSite['courseCode']
+                    assert canvasSite['analytics']
 
-    def test_course_without_enrollment(self, authenticated_response):
-        """returns a graceful error if the expected enrollment is not found"""
-        course_without_enrollment = TestUserAnalytics.get_course_for_code(authenticated_response, 'BURMESE 1A')
-        assert course_without_enrollment['analytics']['error'] == 'Unable to retrieve analytics'
+    def test_user_analytics_multiple_terms(self, authenticated_response):
+        """returns all terms with enrollment data in reverse order"""
+        assert len(authenticated_response.json['enrollmentTerms']) == 2
+        assert authenticated_response.json['enrollmentTerms'][0]['termName'] == 'Fall 2017'
+        assert len(authenticated_response.json['enrollmentTerms'][0]['enrollments']) == 3
+        assert authenticated_response.json['enrollmentTerms'][1]['termName'] == 'Spring 2017'
+        assert len(authenticated_response.json['enrollmentTerms'][1]['enrollments']) == 1
 
-    def test_course_with_enrollment(self, authenticated_response):
-        """returns sensible data if the expected enrollment is found"""
-        course_with_enrollment = TestUserAnalytics.get_course_for_code(authenticated_response, 'MED ST 205')
+    def test_enrollment_without_course_site(self, authenticated_response):
+        """returns enrollments with no associated course sites"""
+        enrollment_without_site = TestUserAnalytics.get_course_for_code(authenticated_response, '2172', 'MUSIC 41C')
+        assert enrollment_without_site['title'] == 'Private Carillon Lessons for Advanced Students'
+        assert enrollment_without_site['canvasSites'] == []
 
-        assert course_with_enrollment['analytics']['assignmentsOnTime']['student']['raw'] == 5
-        assert course_with_enrollment['analytics']['assignmentsOnTime']['student']['percentile'] == 92.9
-        assert course_with_enrollment['analytics']['assignmentsOnTime']['student']['zscore'] == pytest.approx(1.469, 0.01)
-        assert course_with_enrollment['analytics']['assignmentsOnTime']['courseDeciles'][0] == 0.0
-        assert course_with_enrollment['analytics']['assignmentsOnTime']['courseDeciles'][9] == 5.0
-        assert course_with_enrollment['analytics']['assignmentsOnTime']['courseDeciles'][10] == 6.0
+    def test_enrollment_with_multiple_course_sites(self, authenticated_response):
+        """returns multiple course sites associated with an enrollment"""
+        enrollment_with_multiple_sites = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'NUC ENG 124')
+        assert len(enrollment_with_multiple_sites['canvasSites']) == 2
+        assert enrollment_with_multiple_sites['canvasSites'][0]['courseName'] == 'Radioactive Waste Management'
+        assert enrollment_with_multiple_sites['canvasSites'][1]['courseName'] == 'Optional Friday Night Radioactivity Group'
 
-        assert course_with_enrollment['analytics']['pageViews']['student']['raw'] == 768
-        assert course_with_enrollment['analytics']['pageViews']['student']['percentile'] == 54.3
-        assert course_with_enrollment['analytics']['pageViews']['student']['zscore'] == pytest.approx(0.108, 0.01)
-        assert course_with_enrollment['analytics']['pageViews']['courseDeciles'][0] == 9.0
-        assert course_with_enrollment['analytics']['pageViews']['courseDeciles'][9] == 917.0
-        assert course_with_enrollment['analytics']['pageViews']['courseDeciles'][10] == 31983.0
+    def test_course_site_without_enrollment(self, authenticated_response):
+        """returns course sites with no associated enrollments"""
+        assert len(authenticated_response.json['enrollmentTerms'][0]['unmatchedCanvasSites']) == 0
+        assert len(authenticated_response.json['enrollmentTerms'][1]['unmatchedCanvasSites']) == 1
+        unmatched_site = authenticated_response.json['enrollmentTerms'][1]['unmatchedCanvasSites'][0]
+        assert unmatched_site['courseCode'] == 'STAT 154'
+        assert unmatched_site['courseName'] == 'Modern Statistical Prediction and Machine Learning'
+        assert unmatched_site['analytics']
 
-        assert course_with_enrollment['analytics']['participations']['student']['raw'] == 5
-        assert course_with_enrollment['analytics']['participations']['student']['percentile'] == 82.6
-        assert course_with_enrollment['analytics']['participations']['student']['zscore'] == pytest.approx(0.941, 0.01)
-        assert course_with_enrollment['analytics']['participations']['courseDeciles'][0] == 0.0
-        assert course_with_enrollment['analytics']['participations']['courseDeciles'][9] == 6.0
-        assert course_with_enrollment['analytics']['participations']['courseDeciles'][10] == 12.0
+    def test_course_site_without_membership(self, authenticated_response):
+        """returns a graceful error if the expected membership is not found in the course site"""
+        course_without_membership = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'BURMESE 1A')
+        assert course_without_membership['canvasSites'][0]['analytics']['error'] == 'Unable to retrieve analytics'
+
+    def test_course_site_with_enrollment(self, authenticated_response):
+        """returns sensible data if the expected enrollment is found in the course site"""
+        course_with_enrollment = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'MED ST 205')
+        analytics = course_with_enrollment['canvasSites'][0]['analytics']
+
+        assert analytics['assignmentsOnTime']['student']['raw'] == 5
+        assert analytics['assignmentsOnTime']['student']['percentile'] == 92.9
+        assert analytics['assignmentsOnTime']['student']['zscore'] == pytest.approx(1.469, 0.01)
+        assert analytics['assignmentsOnTime']['courseDeciles'][0] == 0.0
+        assert analytics['assignmentsOnTime']['courseDeciles'][9] == 5.0
+        assert analytics['assignmentsOnTime']['courseDeciles'][10] == 6.0
+
+        assert analytics['pageViews']['student']['raw'] == 768
+        assert analytics['pageViews']['student']['percentile'] == 54.3
+        assert analytics['pageViews']['student']['zscore'] == pytest.approx(0.108, 0.01)
+        assert analytics['pageViews']['courseDeciles'][0] == 9.0
+        assert analytics['pageViews']['courseDeciles'][9] == 917.0
+        assert analytics['pageViews']['courseDeciles'][10] == 31983.0
+
+        assert analytics['participations']['student']['raw'] == 5
+        assert analytics['participations']['student']['percentile'] == 82.6
+        assert analytics['participations']['student']['zscore'] == pytest.approx(0.941, 0.01)
+        assert analytics['participations']['courseDeciles'][0] == 0.0
+        assert analytics['participations']['courseDeciles'][9] == 6.0
+        assert analytics['participations']['courseDeciles'][10] == 12.0
 
     def test_empty_canvas_course_feed(self, client, fake_auth):
         """returns 200 if user is found and Canvas course feed is empty"""
@@ -104,7 +140,7 @@ class TestUserAnalytics:
         response = client.get(TestUserAnalytics.non_student)
         assert response.status_code == 200
         assert response.json['uid'] == TestUserAnalytics.non_student_uid
-        assert not response.json['courses']
+        assert not response.json['enrollmentTerms']
 
     def test_canvas_profile_not_found(self, authenticated_session, client):
         """returns 404 if Canvas profile not found"""
@@ -114,35 +150,45 @@ class TestUserAnalytics:
 
     def test_sis_enrollment_merge(self, authenticated_response):
         """merges SIS enrollment data"""
-        burmese = TestUserAnalytics.get_course_for_code(authenticated_response, 'BURMESE 1A')
-        assert len(burmese['sisEnrollments']) == 1
-        assert burmese['sisEnrollments'][0]['ccn'] == 90100
-        assert burmese['sisEnrollments'][0]['displayName'] == 'BURMESE 1A'
-        assert burmese['sisEnrollments'][0]['sectionNumber'] == '001'
-        assert burmese['sisEnrollments'][0]['enrollmentStatus'] == 'E'
-        assert burmese['sisEnrollments'][0]['units'] == 4
-        assert burmese['sisEnrollments'][0]['gradingBasis'] == 'GRD'
-        assert burmese['sisEnrollments'][0]['grade'] == 'B+'
+        burmese = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'BURMESE 1A')
+        assert burmese['ccn'] == 90100
+        assert burmese['displayName'] == 'BURMESE 1A'
+        assert burmese['title'] == 'Introductory Burmese'
+        assert burmese['sectionNumber'] == '001'
+        assert burmese['enrollmentStatus'] == 'E'
+        assert burmese['units'] == 4
+        assert burmese['gradingBasis'] == 'GRD'
+        assert burmese['grade'] == 'B+'
 
-        medieval = TestUserAnalytics.get_course_for_code(authenticated_response, 'MED ST 205')
-        assert len(medieval['sisEnrollments']) == 1
-        assert medieval['sisEnrollments'][0]['ccn'] == 90200
-        assert medieval['sisEnrollments'][0]['displayName'] == 'MED ST 205'
-        assert medieval['sisEnrollments'][0]['sectionNumber'] == '001'
-        assert medieval['sisEnrollments'][0]['enrollmentStatus'] == 'D'
-        assert medieval['sisEnrollments'][0]['units'] == 5
-        assert medieval['sisEnrollments'][0]['gradingBasis'] == 'GRD'
-        assert not medieval['sisEnrollments'][0]['grade']
+        medieval = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'MED ST 205')
+        assert medieval['ccn'] == 90200
+        assert medieval['displayName'] == 'MED ST 205'
+        assert medieval['title'] == 'Medieval Manuscripts as Primary Sources'
+        assert medieval['sectionNumber'] == '001'
+        assert medieval['enrollmentStatus'] == 'D'
+        assert medieval['units'] == 5
+        assert medieval['gradingBasis'] == 'GRD'
+        assert not medieval['grade']
 
-        nuclear = TestUserAnalytics.get_course_for_code(authenticated_response, 'NUC ENG 124')
-        assert len(nuclear['sisEnrollments']) == 1
-        assert nuclear['sisEnrollments'][0]['ccn'] == 90300
-        assert nuclear['sisEnrollments'][0]['displayName'] == 'NUC ENG 124'
-        assert nuclear['sisEnrollments'][0]['sectionNumber'] == '002'
-        assert nuclear['sisEnrollments'][0]['enrollmentStatus'] == 'E'
-        assert nuclear['sisEnrollments'][0]['units'] == 3
-        assert nuclear['sisEnrollments'][0]['gradingBasis'] == 'PNP'
-        assert nuclear['sisEnrollments'][0]['grade'] == 'P'
+        nuclear = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'NUC ENG 124')
+        assert nuclear['ccn'] == 90300
+        assert nuclear['displayName'] == 'NUC ENG 124'
+        assert nuclear['title'] == 'Radioactive Waste Management'
+        assert nuclear['sectionNumber'] == '002'
+        assert nuclear['enrollmentStatus'] == 'E'
+        assert nuclear['units'] == 3
+        assert nuclear['gradingBasis'] == 'PNP'
+        assert nuclear['grade'] == 'P'
+
+        music = TestUserAnalytics.get_course_for_code(authenticated_response, '2172', 'MUSIC 41C')
+        assert music['ccn'] == 80100
+        assert music['displayName'] == 'MUSIC 41C'
+        assert music['title'] == 'Private Carillon Lessons for Advanced Students'
+        assert music['sectionNumber'] == '001'
+        assert music['enrollmentStatus'] == 'E'
+        assert music['units'] == 2
+        assert music['gradingBasis'] == 'GRD'
+        assert music['grade'] == 'A-'
 
     def test_sis_enrollment_not_found(self, authenticated_session, client):
         """gracefully handles missing SIS enrollments"""
@@ -150,9 +196,9 @@ class TestUserAnalytics:
         with register_mock(sis_enrollments_api._get_enrollments, sis_error):
             response = client.get(TestUserAnalytics.field_hockey_star)
             assert response.status_code == 200
-            assert len(response.json['courses']) == 3
-            for course in response.json['courses']:
-                assert not course.get('sisEnrollments')
+            assert len(response.json['enrollmentTerms']) > 0
+            for term in response.json['enrollmentTerms']:
+                assert term['enrollments'] == []
 
     def test_sis_profile(self, authenticated_response):
         """provides SIS profile data"""

--- a/tests/test_externals/test_canvas.py
+++ b/tests/test_externals/test_canvas.py
@@ -7,18 +7,18 @@ class TestCanvasGetCourseSections:
 
     def test_get_course_sections(self, app):
         """returns fixture data"""
-        burmese_sections = canvas.get_course_sections(7654320)
+        burmese_sections = canvas._get_course_sections(7654320)
         assert burmese_sections
         assert len(burmese_sections) == 3
         assert burmese_sections[0]['sis_section_id'] == 'SEC:2017-D-90100'
         assert burmese_sections[1]['sis_section_id'] == 'SEC:2017-D-90101'
 
-        medieval_sections = canvas.get_course_sections(7654321)
+        medieval_sections = canvas._get_course_sections(7654321)
         assert medieval_sections
         assert len(medieval_sections) == 1
         assert medieval_sections[0]['sis_section_id'] == 'SEC:2017-D-90200-88CA51BE'
 
-        nuclear_sections = canvas.get_course_sections(7654323)
+        nuclear_sections = canvas._get_course_sections(7654323)
         assert nuclear_sections
         assert len(nuclear_sections) == 2
         assert nuclear_sections[0]['sis_section_id'] == 'SEC:2017-D-90299'
@@ -26,7 +26,7 @@ class TestCanvasGetCourseSections:
 
     def test_course_not_found(self, app, caplog):
         """logs 404 for unknown course"""
-        response = canvas.get_course_sections(9999999)
+        response = canvas._get_course_sections(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
 
@@ -83,35 +83,40 @@ class TestCanvasGetUserCourses:
     """Canvas API query (get courses for user)"""
 
     def test_get_courses(self, app):
-        """returns a well-formed response"""
-        courses = canvas.get_student_courses_in_term(61889)
+        """returns a well-formed response from multiple terms"""
+        courses = canvas.get_student_courses(61889)
         assert courses
-        assert len(courses) == 3
+        assert len(courses) == 5
         assert courses[0]['id'] == 7654320
         assert courses[0]['name'] == 'Introductory Burmese'
         assert courses[0]['course_code'] == 'BURMESE 1A'
+        assert courses[0]['term']['name'] == 'Fall 2017'
         assert courses[1]['id'] == 7654321
         assert courses[1]['name'] == 'Medieval Manuscripts as Primary Sources'
         assert courses[1]['course_code'] == 'MED ST 205'
+        assert courses[1]['term']['name'] == 'Fall 2017'
         assert courses[2]['id'] == 7654323
         assert courses[2]['name'] == 'Radioactive Waste Management'
         assert courses[2]['course_code'] == 'NUC ENG 124'
+        assert courses[2]['term']['name'] == 'Fall 2017'
+        assert courses[3]['id'] == 7654330
+        assert courses[3]['name'] == 'Optional Friday Night Radioactivity Group'
+        assert courses[3]['course_code'] == 'NUC ENG 124'
+        assert courses[3]['term']['name'] == 'Fall 2017'
+        assert courses[4]['id'] == 7654325
+        assert courses[4]['name'] == 'Modern Statistical Prediction and Machine Learning'
+        assert courses[4]['course_code'] == 'STAT 154'
+        assert courses[4]['term']['name'] == 'Spring 2017'
 
     def test_student_enrollments(self, app):
         """returns only enrollments of type 'student'"""
-        courses = canvas.get_student_courses_in_term(61889)
+        courses = canvas.get_student_courses(61889)
         for course in courses:
             assert course['enrollments'][0]['type'] == 'student'
 
-    def test_current_term(self, app):
-        """returns only enrollments in current term"""
-        courses = canvas.get_student_courses_in_term(61889)
-        for course in courses:
-            assert course['term']['name'] == app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM')
-
     def test_user_not_found(self, app, caplog):
         """logs 404 for unknown user"""
-        courses = canvas.get_student_courses_in_term(9999999)
+        courses = canvas.get_student_courses(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not courses
 
@@ -129,7 +134,7 @@ class TestCanvasGetStudentSummariesForCourse:
 
     def test_student_summaries(self, app):
         """returns a large result set from paged Canvas API"""
-        student_summaries = canvas.get_student_summaries(7654321)
+        student_summaries = canvas._get_student_summaries(7654321)
         assert student_summaries
         assert len(student_summaries) == 730
         assert student_summaries[0]['id'] == 9000000
@@ -139,7 +144,7 @@ class TestCanvasGetStudentSummariesForCourse:
 
     def test_course_not_found(self, app, caplog):
         """logs 404 for unknown course"""
-        student_summaries = canvas.get_student_summaries(9999999)
+        student_summaries = canvas._get_student_summaries(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not student_summaries
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-121
https://jira.ets.berkeley.edu/jira/browse/BOAC-127

Apologies for the large PR, but these two wanted to come together.

A few UX topics:
- Unmatched Canvas sites from a given term appear immediately after courses for that term. This means that prior to Fall 2016, we show a bunch of courses with no sites and then a bunch of sites with no courses. Suppress some or all of this?
- Our current enrollments-fetching code only looks at primary sections, so Canvas sites associated with secondary sections only will remain unmatched.
- Phys Ed courses taken by athletes now appear in the mix. Suppress these, even if (as occasionally happens) there's a Canvas site associated? Should any other enrollments be considered noise? 
- Dropped enrollments are included back to the beginning of time. Probably we should suppress these for prior terms? For the current term, are they more useful?
- This list of sites plus courses-with-whiskers is still a far cry from the last elaborated design for the student page. How to reconcile?