### PR TITLE
[python36] BOAC-193, bump python-path (in 01_create_apache_conf.config) to python3.6

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -33,7 +33,7 @@ files:
         </Directory>
 
         WSGIDaemonProcess wsgi-ssl processes=1 threads=15 display-name=%{GROUP} \
-          python-path=/opt/python/current/app:/opt/python/run/venv/lib/python3.4/site-packages:/opt/python/run/venv/lib64/python3.4/site-packages \
+          python-path=/opt/python/current/app:/opt/python/run/venv/lib/python3.6/site-packages:/opt/python/run/venv/lib64/python3.6/site-packages \
           home=/opt/python/current/app \
           user=wsgi \
           group=wsgi


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-193
