### PR TITLE
BOAC-147 Bring Canvas scores APIs in line with BOAC-127 terms handling

### DIFF
--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -77,7 +77,7 @@ def _get_student_summaries(course_id, mock=None):
 
 
 @stow('canvas_course_assignments_analytics_{course_id}_{uid}', for_term=True)
-def get_assignments_analytics(course_id, uid):
+def get_assignments_analytics(course_id, uid, term_id):
     return _get_assignments_analytics(course_id, uid)
 
 
@@ -88,7 +88,7 @@ def _get_assignments_analytics(course_id, uid, mock=None):
 
 
 @stow('canvas_course_enrollments_{course_id}', for_term=True)
-def get_course_enrollments(course_id):
+def get_course_enrollments(course_id, term_id):
     return _get_course_enrollments(course_id)
 
 

--- a/tests/test_externals/test_canvas.py
+++ b/tests/test_externals/test_canvas.py
@@ -162,7 +162,7 @@ class TestCanvasGrades:
 
     def test_course_enrollments(self, app):
         """returns course enrollments"""
-        feed = canvas.get_course_enrollments(7654321)
+        feed = canvas._get_course_enrollments(7654321)
         assert feed
         assert len(feed) == 43
         assert feed[0]['user_id'] == 9000100
@@ -172,7 +172,7 @@ class TestCanvasGrades:
 
     def test_assignments_analytics(self, app):
         """returns course assignments analytics"""
-        feed = canvas.get_assignments_analytics(7654321, 61889)
+        feed = canvas._get_assignments_analytics(7654321, 61889)
         assert feed
         assert len(feed) == 6
         assignment = feed[0]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-147

For a while on Thursday, these expensive feeds were being cached with a "term_None" prefix.