### PR TITLE
BOAC-159 BOAC-171 BOAC-195 Secondary section handling

### DIFF
--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -15,18 +15,25 @@ def canvas_courses_api_feed(courses):
     return [course_api_values(course) for course in courses]
 
 
-def sis_enrollment_api_feed(enrollment):
+def sis_enrollment_class_feed(enrollment):
+    classData = enrollment.get('classSection', {}).get('class', {})
+    return {
+        'displayName': classData.get('course', {}).get('displayName'),
+        'title': classData.get('course', {}).get('title'),
+        'canvasSites': [],
+        'sections': [],
+    }
+
+
+def sis_enrollment_section_feed(enrollment):
     sectionData = enrollment.get('classSection', {})
-    classData = sectionData.get('class', {})
     grades = enrollment.get('grades', [])
     return {
         'ccn': sectionData.get('id'),
-        'displayName': classData.get('course', {}).get('displayName'),
-        'title': classData.get('course', {}).get('title'),
-        'sectionNumber': classData.get('number'),
+        'component': sectionData.get('component', {}).get('code'),
+        'sectionNumber': sectionData.get('number'),
         'enrollmentStatus': enrollment.get('enrollmentStatus', {}).get('status', {}).get('code'),
         'units': enrollment.get('enrolledUnits', {}).get('taken'),
         'gradingBasis': enrollment.get('gradingBasis', {}).get('code'),
         'grade': next((grade.get('mark') for grade in grades if grade.get('type', {}).get('code') == 'OFFL'), None),
-        'canvasSites': [],
     }

--- a/boac/externals/sis_enrollments_api.py
+++ b/boac/externals/sis_enrollments_api.py
@@ -22,7 +22,6 @@ def get_enrollments(cs_id, term_id):
 def _get_enrollments(cs_id, term_id, mock=None):
     query = {
         'term-id': term_id,
-        'primary-only': 'true',
         'page-size': 50,
     }
     url = http.build_url(app.config['ENROLLMENTS_API_URL'] + '/' + str(cs_id), query)

--- a/boac/static/app/student/courseSiteMetrics.html
+++ b/boac/static/app/student/courseSiteMetrics.html
@@ -5,7 +5,7 @@
     <div class="boxplot-container" data-ng-if="!canvasSite.analytics.assignmentsOnTime.insufficientData">
       <div id="boxplot-{{canvasSite.canvasCourseId}}-assignmentsOnTime"
            class="boxplot"
-           data-ng-init="drawBoxplot(termId, ccn, canvasSite.canvasCourseId, 'assignmentsOnTime')"></div>
+           data-ng-init="drawBoxplot(termId, courseName, canvasSite.canvasCourseId, 'assignmentsOnTime')"></div>
     </div>
   </li>
   <li>
@@ -14,7 +14,7 @@
     <div class="boxplot-container" data-ng-if="!canvasSite.analytics.pageViews.insufficientData">
       <div id="boxplot-{{canvasSite.canvasCourseId}}-pageViews"
            class="boxplot"
-           data-ng-init="drawBoxplot(termId, ccn, canvasSite.canvasCourseId, 'pageViews')"></div>
+           data-ng-init="drawBoxplot(termId, courseName, canvasSite.canvasCourseId, 'pageViews')"></div>
     </div>
   </li>
   <li>
@@ -23,7 +23,7 @@
     <div class="boxplot-container" data-ng-if="!canvasSite.analytics.participations.insufficientData">
       <div id="boxplot-{{canvasSite.canvasCourseId}}-participations"
            class="boxplot"
-           data-ng-init="drawBoxplot(termId, ccn, canvasSite.canvasCourseId, 'participations')"></div>
+           data-ng-init="drawBoxplot(termId, courseName, canvasSite.canvasCourseId, 'participations')"></div>
     </div>
   </li>
 </ul>

--- a/boac/static/app/student/courseSiteMetricsDirective.js
+++ b/boac/static/app/student/courseSiteMetricsDirective.js
@@ -7,7 +7,7 @@
       restrict: 'E',
       scope: {
         canvasSite: '=',
-        ccn: '=',
+        courseName: '=',
         drawBoxplot: '=',
         percentile: '=',
         termId: '='

--- a/boac/static/app/student/student.css
+++ b/boac/static/app/student/student.css
@@ -16,6 +16,10 @@
   display: flex;
 }
 
+.student-profile-class-sections {
+  margin: 10px 0;
+}
+
 .student-profile-class-title {
   font-size: 18px;
 }

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -99,21 +99,24 @@
             <div data-ng-repeat="course in term.enrollments">
               <h3 class="student-profile-class-title" data-ng-bind="course.displayName"></h3>
               <h4 class="student-profile-class-title" data-ng-bind="course.title"></h4>
-              <span data-ng-switch="course.enrollmentStatus">
-                <span data-ng-switch-when="E">Enrolled in</span>
-                <span data-ng-switch-when="W">Waitlisted in</span>
-                <span data-ng-switch-when="D">Dropped</span>
-              </span>
-              section <span data-ng-bind="course.sectionNumber"></span>
-              (<span data-ng-bind="course.units"></span> units,
-              <span data-ng-bind="course.gradingBasis"></span> grading basis)
-              <div data-ng-if="course.grade">
-                <strong>Grade: <span data-ng-bind="course.grade"></span></strong>
+              <div class="student-profile-class-sections">
+                <div data-ng-repeat="section in course.sections | orderBy:'units':true">
+                  <span data-ng-if="section.enrollmentStatus === 'W'">Waitlisted in</span>
+                  <span data-ng-if="section.enrollmentStatus === 'D'">Dropped</span>
+                  <span data-ng-bind="section.component"></span>
+                  <span data-ng-bind="section.sectionNumber"></span>
+                  <span data-ng-if="section.units">
+                    (<span data-ng-bind="section.units"></span> units,
+                    <span data-ng-bind="section.gradingBasis"></span>)
+                  </span>
+                  <strong data-ng-if="section.grade">Grade: <span data-ng-bind="section.grade"></span></strong>
+                </div>
               </div>
               <div data-ng-repeat="canvasSite in course.canvasSites">
+                <strong data-ng-bind="canvasSite.courseCode"></strong>
                 <course-site-metrics
                   data-canvas-site="canvasSite"
-                  data-ccn="course.ccn"
+                  data-course-name="course.displayName"
                   data-draw-boxplot="drawBoxplot"
                   data-percentile="percentile"
                   data-term-id="term.termId">
@@ -126,7 +129,7 @@
               <h3 class="student-profile-class-title" data-ng-bind="canvasSite.courseName"></h3>
               <course-site-metrics
                 data-canvas-site="canvasSite"
-                data-ccn="'unmatchedCanvasSites'"
+                data-course-name="'unmatchedCanvasSites'"
                 data-draw-boxplot="drawBoxplot"
                 data-percentile="percentile"
                 data-term-id="term.termId">

--- a/boac/static/app/student/studentController.js
+++ b/boac/static/app/student/studentController.js
@@ -30,19 +30,19 @@
      * Render a box plot for a given course and metric
      *
      * @param  {String}  termId        SIS term id for the course
-     * @param  {Number}  ccn           SIS CCN for the course
+     * @param  {Number}  displayName   Display name for the course
      * @param  {Number}  courseId      Canvas course ID for the course
      * @param  {String}  metric        Metric to draw the boxplot for
      * @return {void}
      */
-    $scope.drawBoxplot = function(termId, ccn, courseId, metric) {
+    $scope.drawBoxplot = function(termId, displayName, courseId, metric) {
 
       var term = _.find($scope.student.enrollmentTerms, {termId: termId});
       var courseSites;
-      if (ccn === 'unmatchedCanvasSites') {
+      if (displayName === 'unmatchedCanvasSites') {
         courseSites = term.unmatchedCanvasSites;
       } else {
-        var enrollment = _.find(term.enrollments, {ccn: ccn});
+        var enrollment = _.find(term.enrollments, {displayName: displayName});
         courseSites = enrollment.canvasSites;
       }
       var course = _.find(courseSites, {canvasCourseId: courseId});

--- a/fixtures/sis_enrollments_api_11667051_2178.json
+++ b/fixtures/sis_enrollments_api_11667051_2178.json
@@ -299,7 +299,7 @@
           },
           "classSection": {
             "id": 90200,
-            "number": "205",
+            "number": "001",
             "component": {
               "code": "SEM",
               "description": "Seminar"
@@ -747,6 +747,215 @@
                   },
                   {
                     "assignmentNumber": 2,
+                    "instructor": {
+                      "identifiers": [
+                        {
+                          "type": "student-id",
+                          "id": "3334445554",
+                          "disclose": false
+                        },
+                        {
+                          "type": "campus-uid",
+                          "id": "1122334",
+                          "disclose": true
+                        },
+                        {
+                          "type": "Social Security Number",
+                          "id": "***-**-****",
+                          "disclose": false
+                        },
+                        {
+                          "type": "DB2",
+                          "id": "20000001",
+                          "disclose": false
+                        },
+                        {
+                          "type": "HCM System",
+                          "id": "012345674",
+                          "disclose": false
+                        }
+                      ],
+                      "names": [
+                        {
+                          "type": {
+                            "code": "PRF",
+                            "description": "Preferred"
+                          },
+                          "familyName": "Gell-Mann",
+                          "givenName": "Murray",
+                          "formattedName": "Murray Gell-Mann",
+                          "disclose": false,
+                          "uiControl": {
+                            "code": "U",
+                            "description": "Edit - No Delete"
+                          },
+                          "fromDate": "1902-02-01"
+                        },
+                        {
+                          "type": {
+                            "code": "PRI",
+                            "description": "Primary"
+                          },
+                          "familyName": "Gell-Mann",
+                          "givenName": "Murray",
+                          "formattedName": "Murray Gell-Mann",
+                          "disclose": false,
+                          "uiControl": {
+                            "code": "D",
+                            "description": "Display Only"
+                          },
+                          "fromDate": "2016-08-24"
+                        }
+                      ],
+                      "emails": [
+                        {
+                          "type": {
+                            "code": "CAMP",
+                            "description": "Campus"
+                          },
+                          "emailAddress": "threequarks@berkeley.edu",
+                          "primary": true,
+                          "disclose": false,
+                          "uiControl": {
+                            "code": "D",
+                            "description": "Display Only"
+                          }
+                        }
+                      ]
+                    },
+                    "role": {
+                      "code": "TNIC",
+                      "description": "2-TNIC",
+                      "formalDescription": "Teaching but Not In Charge"
+                    },
+                    "printInScheduleOfClasses": true,
+                    "gradeRosterAccess": {
+                      "code": "G",
+                      "description": "Grade",
+                      "formalDescription": "Grade"
+                    }
+                  }
+                ],
+                "startDate": "2017-08-23",
+                "endDate": "2017-12-08",
+                "meetingTopic": {
+                }
+              }
+            ],
+            "class": {
+              "course": {
+                "identifiers": [
+                  {
+                    "type": "cs-course-id",
+                    "id": "105000"
+                  }
+                ],
+                "subjectArea": {
+                  "code": "NUC ENG",
+                  "description": "Nuclear Engineering"
+                },
+                "catalogNumber": {
+                  "number": "124",
+                  "formatted": "124"
+                },
+                "displayName": "NUC ENG 124",
+                "title": "Radioactive Waste Management",
+                "transcriptTitle": "RADIO WSTE MGMT"
+              },
+              "offeringNumber": 1,
+              "session": {
+                "term": {
+                  "id": "2178",
+                  "name": "2017 Fall"
+                },
+                "id": "1",
+                "name": "Regular Academic Session"
+              },
+              "number": "002",
+              "displayName": "2017 Fall NUC ENG 124 002",
+              "allowedUnits": {
+                "minimum": 3,
+                "maximum": 3,
+                "forAcademicProgress": 3,
+                "forFinancialAid": 3
+              },
+              "status": {
+              }
+            }
+          }
+        },
+        {
+          "enrollmentStatus": {
+            "status": {
+              "code": "E",
+              "description": "Enrolled"
+            },
+            "reason": {
+              "code": "ENRL",
+              "description": "Enrolled"
+            },
+            "fromDate": "2017-08-22"
+          },
+          "enrolledUnits": {
+            "taken": 0,
+            "forAcademicProgress": 0,
+            "forFinancialAid": 0,
+            "forBilling": 0
+          },
+          "gradingBasis": {
+            "code": "NON",
+            "description": "Non-Graded Component"
+          },
+          "classSection": {
+            "id": 90301,
+            "number": "201",
+            "component": {
+              "code": "DIS",
+              "description": "Discussion"
+            },
+            "displayName": "2017 Fall NUC ENG 124 002 DIS 201",
+            "association": {
+              "primary": false,
+              "primaryAssociatedComponent": {
+              }
+            },
+            "enrollmentStatus": {
+              "status": {
+              }
+            },
+            "printInScheduleOfClasses": false,
+            "addConsentRequired": {
+              "code": "N",
+              "description": "No Special Consent Required"
+            },
+            "dropConsentRequired": {
+              "code": "N",
+              "description": "No Special Consent Required"
+            },
+            "meetings": [
+              {
+                "number": 1,
+                "meetsDays": "Fr",
+                "meetsMonday": false,
+                "meetsTuesday": false,
+                "meetsWednesday": false,
+                "meetsThursday": false,
+                "meetsFriday": true,
+                "meetsSaturday": false,
+                "meetsSunday": false,
+                "startTime": "18:00:00",
+                "endTime": "19:59:00",
+                "location": {
+                  "code": "LBL2001",
+                  "description": "Lawrence Berkeley Lab 2001"
+                },
+                "building": {
+                  "code": "123",
+                  "description": "Lawrence Berkeley Lab"
+                },
+                "assignedInstructors": [
+                  {
+                    "assignmentNumber": 1,
                     "instructor": {
                       "identifiers": [
                         {

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -156,44 +156,54 @@ class TestUserAnalytics:
     def test_sis_enrollment_merge(self, authenticated_response):
         """merges SIS enrollment data"""
         burmese = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'BURMESE 1A')
-        assert burmese['ccn'] == 90100
         assert burmese['displayName'] == 'BURMESE 1A'
         assert burmese['title'] == 'Introductory Burmese'
-        assert burmese['sectionNumber'] == '001'
-        assert burmese['enrollmentStatus'] == 'E'
-        assert burmese['units'] == 4
-        assert burmese['gradingBasis'] == 'GRD'
-        assert burmese['grade'] == 'B+'
+        assert len(burmese['sections']) == 1
+        assert burmese['sections'][0]['ccn'] == 90100
+        assert burmese['sections'][0]['sectionNumber'] == '001'
+        assert burmese['sections'][0]['enrollmentStatus'] == 'E'
+        assert burmese['sections'][0]['units'] == 4
+        assert burmese['sections'][0]['gradingBasis'] == 'GRD'
+        assert burmese['sections'][0]['grade'] == 'B+'
 
         medieval = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'MED ST 205')
-        assert medieval['ccn'] == 90200
         assert medieval['displayName'] == 'MED ST 205'
         assert medieval['title'] == 'Medieval Manuscripts as Primary Sources'
-        assert medieval['sectionNumber'] == '001'
-        assert medieval['enrollmentStatus'] == 'D'
-        assert medieval['units'] == 5
-        assert medieval['gradingBasis'] == 'GRD'
-        assert not medieval['grade']
+        assert len(medieval['sections']) == 1
+        assert medieval['sections'][0]['ccn'] == 90200
+        assert medieval['sections'][0]['sectionNumber'] == '001'
+        assert medieval['sections'][0]['enrollmentStatus'] == 'D'
+        assert medieval['sections'][0]['units'] == 5
+        assert medieval['sections'][0]['gradingBasis'] == 'GRD'
+        assert not medieval['sections'][0]['grade']
 
         nuclear = TestUserAnalytics.get_course_for_code(authenticated_response, '2178', 'NUC ENG 124')
-        assert nuclear['ccn'] == 90300
         assert nuclear['displayName'] == 'NUC ENG 124'
         assert nuclear['title'] == 'Radioactive Waste Management'
-        assert nuclear['sectionNumber'] == '002'
-        assert nuclear['enrollmentStatus'] == 'E'
-        assert nuclear['units'] == 3
-        assert nuclear['gradingBasis'] == 'PNP'
-        assert nuclear['grade'] == 'P'
+        assert len(nuclear['sections']) == 2
+        assert nuclear['sections'][0]['ccn'] == 90300
+        assert nuclear['sections'][0]['sectionNumber'] == '002'
+        assert nuclear['sections'][0]['enrollmentStatus'] == 'E'
+        assert nuclear['sections'][0]['units'] == 3
+        assert nuclear['sections'][0]['gradingBasis'] == 'PNP'
+        assert nuclear['sections'][0]['grade'] == 'P'
+        assert nuclear['sections'][1]['ccn'] == 90301
+        assert nuclear['sections'][1]['sectionNumber'] == '201'
+        assert nuclear['sections'][1]['enrollmentStatus'] == 'E'
+        assert nuclear['sections'][1]['units'] == 0
+        assert nuclear['sections'][1]['gradingBasis'] == 'NON'
+        assert not nuclear['sections'][1]['grade']
 
         music = TestUserAnalytics.get_course_for_code(authenticated_response, '2172', 'MUSIC 41C')
-        assert music['ccn'] == 80100
         assert music['displayName'] == 'MUSIC 41C'
         assert music['title'] == 'Private Carillon Lessons for Advanced Students'
-        assert music['sectionNumber'] == '001'
-        assert music['enrollmentStatus'] == 'E'
-        assert music['units'] == 2
-        assert music['gradingBasis'] == 'GRD'
-        assert music['grade'] == 'A-'
+        assert len(music['sections']) == 1
+        assert music['sections'][0]['ccn'] == 80100
+        assert music['sections'][0]['sectionNumber'] == '001'
+        assert music['sections'][0]['enrollmentStatus'] == 'E'
+        assert music['sections'][0]['units'] == 2
+        assert music['sections'][0]['gradingBasis'] == 'GRD'
+        assert music['sections'][0]['grade'] == 'A-'
 
     def test_sis_enrollment_not_found(self, authenticated_session, client):
         """gracefully handles missing SIS enrollments"""

--- a/tests/test_externals/test_sis_enrollments_api.py
+++ b/tests/test_externals/test_sis_enrollments_api.py
@@ -13,34 +13,41 @@ class TestSisEnrollmentsApi:
         assert student['emails'][0]['emailAddress'] == 'oski@berkeley.edu'
 
         enrollments = oski_response['studentEnrollments']
-        assert len(enrollments) == 4
+        assert len(enrollments) == 5
 
         assert enrollments[0]['classSection']['class']['course']['displayName'] == 'BURMESE 1A'
-        assert enrollments[0]['classSection']['class']['number'] == '001'
+        assert enrollments[0]['classSection']['number'] == '001'
         assert enrollments[0]['enrollmentStatus']['status']['code'] == 'E'
         assert enrollments[0]['enrolledUnits']['taken'] == 4
         assert enrollments[0]['gradingBasis']['code'] == 'GRD'
         assert enrollments[0]['grades'][0]['mark'] == 'B+'
 
         assert enrollments[1]['classSection']['class']['course']['displayName'] == 'MED ST 205'
-        assert enrollments[1]['classSection']['class']['number'] == '001'
+        assert enrollments[1]['classSection']['number'] == '001'
         assert enrollments[1]['enrollmentStatus']['status']['code'] == 'D'
         assert enrollments[1]['enrolledUnits']['taken'] == 5
         assert enrollments[1]['gradingBasis']['code'] == 'GRD'
 
         assert enrollments[2]['classSection']['class']['course']['displayName'] == 'NUC ENG 124'
-        assert enrollments[2]['classSection']['class']['number'] == '002'
+        assert enrollments[2]['classSection']['number'] == '002'
         assert enrollments[2]['enrollmentStatus']['status']['code'] == 'E'
         assert enrollments[2]['enrolledUnits']['taken'] == 3
         assert enrollments[2]['gradingBasis']['code'] == 'PNP'
         assert enrollments[2]['grades'][0]['mark'] == 'P'
 
-        assert enrollments[3]['classSection']['class']['course']['displayName'] == 'PHYSED 11'
-        assert enrollments[3]['classSection']['class']['number'] == '001'
+        assert enrollments[3]['classSection']['class']['course']['displayName'] == 'NUC ENG 124'
+        assert enrollments[3]['classSection']['number'] == '201'
         assert enrollments[3]['enrollmentStatus']['status']['code'] == 'E'
-        assert enrollments[3]['enrolledUnits']['taken'] == 0.5
-        assert enrollments[3]['gradingBasis']['code'] == 'PNP'
-        assert enrollments[3]['grades'][0]['mark'] == 'P'
+        assert enrollments[3]['enrolledUnits']['taken'] == 0
+        assert enrollments[3]['gradingBasis']['code'] == 'NON'
+        assert 'grades' not in enrollments[3]
+
+        assert enrollments[4]['classSection']['class']['course']['displayName'] == 'PHYSED 11'
+        assert enrollments[4]['classSection']['number'] == '001'
+        assert enrollments[4]['enrollmentStatus']['status']['code'] == 'E'
+        assert enrollments[4]['enrolledUnits']['taken'] == 0.5
+        assert enrollments[4]['gradingBasis']['code'] == 'PNP'
+        assert enrollments[4]['grades'][0]['mark'] == 'P'
 
     def test_inner_get_enrollments(self, app):
         """returns fixture data"""
@@ -53,34 +60,41 @@ class TestSisEnrollmentsApi:
         assert student['emails'][0]['emailAddress'] == 'oski@berkeley.edu'
 
         enrollments = oski_response.json()['apiResponse']['response']['studentEnrollments']
-        assert len(enrollments) == 4
+        assert len(enrollments) == 5
 
         assert enrollments[0]['classSection']['class']['course']['displayName'] == 'BURMESE 1A'
-        assert enrollments[0]['classSection']['class']['number'] == '001'
+        assert enrollments[0]['classSection']['number'] == '001'
         assert enrollments[0]['enrollmentStatus']['status']['code'] == 'E'
         assert enrollments[0]['enrolledUnits']['taken'] == 4
         assert enrollments[0]['gradingBasis']['code'] == 'GRD'
         assert enrollments[0]['grades'][0]['mark'] == 'B+'
 
         assert enrollments[1]['classSection']['class']['course']['displayName'] == 'MED ST 205'
-        assert enrollments[1]['classSection']['class']['number'] == '001'
+        assert enrollments[1]['classSection']['number'] == '001'
         assert enrollments[1]['enrollmentStatus']['status']['code'] == 'D'
         assert enrollments[1]['enrolledUnits']['taken'] == 5
         assert enrollments[1]['gradingBasis']['code'] == 'GRD'
 
         assert enrollments[2]['classSection']['class']['course']['displayName'] == 'NUC ENG 124'
-        assert enrollments[2]['classSection']['class']['number'] == '002'
+        assert enrollments[2]['classSection']['number'] == '002'
         assert enrollments[2]['enrollmentStatus']['status']['code'] == 'E'
         assert enrollments[2]['enrolledUnits']['taken'] == 3
         assert enrollments[2]['gradingBasis']['code'] == 'PNP'
         assert enrollments[2]['grades'][0]['mark'] == 'P'
 
-        assert enrollments[3]['classSection']['class']['course']['displayName'] == 'PHYSED 11'
-        assert enrollments[3]['classSection']['class']['number'] == '001'
+        assert enrollments[3]['classSection']['class']['course']['displayName'] == 'NUC ENG 124'
+        assert enrollments[3]['classSection']['number'] == '201'
         assert enrollments[3]['enrollmentStatus']['status']['code'] == 'E'
-        assert enrollments[3]['enrolledUnits']['taken'] == 0.5
-        assert enrollments[3]['gradingBasis']['code'] == 'PNP'
-        assert enrollments[3]['grades'][0]['mark'] == 'P'
+        assert enrollments[3]['enrolledUnits']['taken'] == 0
+        assert enrollments[3]['gradingBasis']['code'] == 'NON'
+        assert 'grades' not in enrollments[3]
+
+        assert enrollments[4]['classSection']['class']['course']['displayName'] == 'PHYSED 11'
+        assert enrollments[4]['classSection']['number'] == '001'
+        assert enrollments[4]['enrollmentStatus']['status']['code'] == 'E'
+        assert enrollments[4]['enrolledUnits']['taken'] == 0.5
+        assert enrollments[4]['gradingBasis']['code'] == 'PNP'
+        assert enrollments[4]['grades'][0]['mark'] == 'P'
 
     def test_user_not_found(self, app, caplog):
         """logs 404 for unknown user and returns informative message"""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-159
https://jira.ets.berkeley.edu/jira/browse/BOAC-171

Since this change will result in more courses with multiple sites attached, per-site headings are added to address https://jira.ets.berkeley.edu/jira/browse/BOAC-195.

It appears that the SIS enrollments API returns secondary sections only back to Fall 2016.

While the page structure will change following deployment of this PR, the underlying data will not show on boac-dev until the enrollments API cache is refreshed.