### PR TITLE
BOAC-146 Eliminate Pandas warning

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -71,7 +71,7 @@ def analytics_for_column(df, student_row, column_name):
     # and we've also seen some Canvas feeds which mix nulls and zeroes.
     # Setting non-numbers to zero works acceptably for the current analyzed feeds.
     dfcol.fillna(0, inplace=True)
-    student_row.fillna(0, inplace=True)
+    student_row = student_row.fillna(0)
 
     nunique = dfcol.nunique()
     if nunique == 0 or (nunique == 1 and dfcol.max() == 0.0):

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -170,7 +170,7 @@ class TestAnalyticsFromSummaryFeed:
             {
                 'id': self.canvas_user_id,
                 'max_page_views': 1218, 'max_participations': 11,
-                'page_views': 0, 'page_views_level': 3,
+                'page_views': None, 'page_views_level': 3,
                 'participations': 0, 'participations_level': 2,
                 'tardiness_breakdown': {'floating': 3, 'late': 6, 'missing': 7, 'on_time': 0, 'total': 16},
             },


### PR DESCRIPTION
```
=================================================== warnings summary ===================================================
None
  pytest-catchlog plugin has been merged into the core, please remove it from your requirements.

TeamMember detail API returns a well-formed response on a valid code if authenticated
  /Users/raydavis/Code/ets/boac/.venv/lib/python3.6/site-packages/pandas/core/frame.py:3035: SettingWithCopyWarning: 
  A value is trying to be set on a copy of a slice from a DataFrame
  
  See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
    downcast=downcast, **kwargs)
...
```