### PR TITLE
BOAC-223 BOAC-225 Show enrollments for students with no current-term course sites

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -48,8 +48,8 @@ def user_analytics(uid):
         sis_profile = False
         athletics_profile = False
 
-    user_courses = canvas.get_student_courses(uid)
-    if team_member and sis_profile and len(user_courses):
+    user_courses = canvas.get_student_courses(uid) or []
+    if team_member and sis_profile:
         canvas_courses_feed = api_util.canvas_courses_api_feed(user_courses)
         enrollment_terms = merge_sis_enrollments(canvas_courses_feed, team_member.member_csid, sis_profile['matriculation'])
     else:

--- a/boac/models/team_member.py
+++ b/boac/models/team_member.py
@@ -223,21 +223,19 @@ class TeamMember(Base):
 
         if canvas_profile:
             feed['avatar_url'] = canvas_profile['avatar_url']
-            student_courses = canvas.get_student_courses(uid)
+            student_courses = canvas.get_student_courses(uid) or []
             current_term = app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM')
-            if student_courses:
-                student_courses_in_current_term = [course for course in student_courses if
-                                                   course.get('term', {}).get('name') == current_term]
-                canvas_courses = canvas_courses_api_feed(student_courses_in_current_term)
-                if canvas_courses:
-                    feed['analytics'] = mean_course_analytics_for_user(canvas_courses,
-                                                                       canvas_profile['id'],
-                                                                       current_term)
-                    # The call to mean_course_analytics_for_user, above, has enriched the canvas_courses
-                    # list with per-course statistics. Next, associate those course sites with enrollments.
-                    feed['currentTerm'] = merge_sis_enrollments_for_term(canvas_courses,
-                                                                         feed['sid'],
-                                                                         current_term)
+            student_courses_in_current_term = [course for course in student_courses if
+                                               course.get('term', {}).get('name') == current_term]
+            canvas_courses = canvas_courses_api_feed(student_courses_in_current_term)
+            feed['analytics'] = mean_course_analytics_for_user(canvas_courses,
+                                                               canvas_profile['id'],
+                                                               current_term)
+            # The call to mean_course_analytics_for_user, above, has enriched the canvas_courses
+            # list with per-course statistics. Next, associate those course sites with enrollments.
+            feed['currentTerm'] = merge_sis_enrollments_for_term(canvas_courses,
+                                                                 feed['sid'],
+                                                                 current_term)
 
     def team_group_summary(self):
         return {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-223
https://jira.ets.berkeley.edu/jira/browse/BOAC-225

Short-circuiting on an empty Canvas feed is a holdover from the demo.