### PR TITLE
BOAC-204 Merge Canvas site "current score" stats into cohort-wide means

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -22,7 +22,7 @@ def merge_analytics_for_user(user_courses, canvas_user_id, term_id):
 def mean_course_analytics_for_user(user_courses, canvas_user_id, term_id):
     merge_analytics_for_user(user_courses, canvas_user_id, term_id)
     meanValues = {}
-    for metric in ['assignmentsOnTime', 'pageViews', 'participations']:
+    for metric in ['assignmentsOnTime', 'pageViews', 'participations', 'courseCurrentScore']:
         percentiles = []
         for course in user_courses:
             if course['analytics'].get(metric):

--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -8,6 +8,7 @@
     cohortFactory,
     cohortService,
     googleAnalyticsService,
+    $location,
     $rootScope,
     $scope,
     $state,
@@ -108,12 +109,14 @@
       var goToUserPage = function(uid) {
         $state.go('user', {uid: uid});
       };
+      var yAxisMeasure = $location.search().yAxis || 'analytics.assignmentsOnTime';
+
       // Render graph
       $scope.matrix = {
         membersWithData: partitionedMembers[0],
         membersWithoutData: partitionedMembers[1]
       };
-      cohortService.drawScatterplot($scope.matrix.membersWithData, goToUserPage);
+      cohortService.drawScatterplot($scope.matrix.membersWithData, goToUserPage, yAxisMeasure);
     };
 
     var matrixViewRefresh = function() {

--- a/boac/static/app/cohort/cohortService.js
+++ b/boac/static/app/cohort/cohortService.js
@@ -4,16 +4,21 @@
 
   angular.module('boac').service('cohortService', function() {
 
-    var drawScatterplot = function(students, goToUserPage) {
+    var drawScatterplot = function(students, goToUserPage, yAxisMeasure) {
       var svg;
 
       function x(d) { return d.analytics.pageViews; }
       function y(d) {
-        var assignmentsOnTime = _.get(d, 'analytics.assignmentsOnTime');
+        var yValues = _.get(d, yAxisMeasure);
         // Points with no y-axis data are plotted below the x-axis.
-        return _.isFinite(assignmentsOnTime) ? assignmentsOnTime : -10;
+        return _.isFinite(yValues) ? yValues : -10;
       }
       function key(d) { return d.uid; }
+
+      var yAxisName = 'Assignments on time';
+      if (yAxisMeasure === 'analytics.courseCurrentScore') {
+        yAxisName = 'Assignment grades';
+      }
 
       var width = 910;
       var height = 500;
@@ -82,7 +87,7 @@
         .attr('y', 6)
         .attr('dy', '.75em')
         .attr('transform', 'rotate(-90)')
-        .text('Assignments on time');
+        .text(yAxisName);
 
       var defs = svg.append('svg:defs');
 
@@ -173,8 +178,8 @@
             ' ', d.last_name,
             '\nPage views: ',
             displayValue(d, 'analytics.pageViews'),
-            '\nAssignments on time: ',
-            displayValue(d, 'analytics.assignmentsOnTime')
+            '\n', yAxisName, ': ',
+            displayValue(d, yAxisMeasure)
           );
         });
 

--- a/boac/static/app/student/courseSiteMetrics.html
+++ b/boac/static/app/student/courseSiteMetrics.html
@@ -9,7 +9,7 @@
     </div>
   </li>
   <li>
-    Total score:
+    Assignment grades:
     <span data-ng-bind="canvasSite.analytics.courseCurrentScore.summary"></span>
     <div class="boxplot-container" data-ng-if="canvasSite.analytics.courseCurrentScore.boxPlottable">
       <div id="boxplot-{{canvasSite.canvasCourseId}}-courseCurrentScore"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-204

Currently only shows on the scatterplot matrix via "?yAxis=analytics.courseCurrentScore".
Changed display name to "Assignment grades" to avoid confusion with other "score" labels.