### PR TITLE
BOAC-229, Intensive cohort is not a saved-search and should not pre-populate search filters

### DIFF
--- a/boac/models/team_member.py
+++ b/boac/models/team_member.py
@@ -126,12 +126,10 @@ class TeamMember(Base):
 
     @classmethod
     def get_intensive_cohort(cls, order_by=None, offset=0, limit=50):
-        athletes = cls.query.distinct(cls.asc_sport_code).filter_by(in_intensive_cohort=True).all()
-        team_groups = [athlete.team_group_summary() for athlete in athletes]
         query_filter = cls.in_intensive_cohort.is_(True)
         o = cls.get_ordering(order_by)
         athletes = cls.query.distinct(o, cls.member_uid).order_by(o, cls.member_uid).filter(query_filter).offset(offset).limit(limit).all()
-        return cls.summarize_athletes(team_groups, athletes, query_filter)
+        return cls.summarize_athletes([], athletes, query_filter)
 
     @classmethod
     def get_team(cls, code, order_by=None, offset=0, limit=50):

--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -77,7 +77,7 @@
     </div>
     <div class="cohort-filters-column flex-column-50"></div>
     <div class="cohort-filters-column flex-column-btn">
-      <button id="header-sign-in"
+      <button id="execute-search"
               class="btn btn-primary btn-nowrap"
               data-ng-disabled="!search.count.selectedTeamGroups || isLoading || isSaving"
               data-ng-click="executeSearch()">Search</button>

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -171,9 +171,7 @@ class TestCohortDetail:
         assert cohort['totalMemberCount'] == len(cohort['members']) == 2
         assert cohort['members'][0]['uid'] == '61889'
         assert cohort['members'][1]['uid'] == '242881'
-        assert cohort['teamGroups'][0]['teamGroupCode'] == 'MFB-DL'
-        assert cohort['teamGroups'][1]['teamGroupCode'] == 'WFH-AA'
-        assert cohort['teamGroups'][2]['teamGroupCode'] == 'WTE-AA'
+        assert len(cohort['teamGroups']) == 0
 
     def test_offset_and_limit(self, authenticated_session, client):
         """returns a well-formed response with custom cohort"""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-229

Bonus fix: Id of search element in cohort view.