### PR TITLE
BOAC-232, put 'name' in the all_students feed

### DIFF
--- a/boac/models/team_member.py
+++ b/boac/models/team_member.py
@@ -182,6 +182,7 @@ class TeamMember(Base):
             'id': self.id,
             'first_name': self.first_name,
             'last_name': self.last_name,
+            'name': self.first_name + ' ' + self.last_name,
             'sid': self.member_csid,
             'inAdvisorWatchGroup': self.in_intensive_cohort,
             'sportCode': self.asc_sport_code_core,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-232

I'll remove front-end ref to `name` when normalizing `team_member` data. For now, let's go for the easy fix. 