### PR TITLE
BOAC-116 Disallow cohort matrix CSS from romping all over the app

### DIFF
--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -183,7 +183,7 @@
     </div>
     <div id="cohort-matrix-container" class="cohort-matrix-container" data-ng-show="selectedTab === 'matrix' && !isLoading && !error">
       <!-- IMPORTANT: We use data-ng-show because d3 must populate the div before we reveal it to the user. -->
-      <div id="scatterplot"></div>
+      <div id="scatterplot" class="cohort-matrix"></div>
       <ul data-ng-if="matrix.membersWithoutData.length">
         <h4>Students without graphable data</h4>
         <li data-ng-repeat="member in matrix.membersWithoutData">

--- a/boac/static/app/cohort/cohortMatrix.css
+++ b/boac/static/app/cohort/cohortMatrix.css
@@ -1,52 +1,52 @@
-#scatterplot {
+.cohort-matrix {
   width: 910px;
   height: 500px;
   margin: 20px 20px 100px 20px;
 }
 
-rect {
+.cohort-matrix rect {
   fill: transparent;
   shape-rendering: crispEdges;
 }
 
-text {
+.cohort-matrix text {
   font: 15px sans-serif bold;
 }
 
-.dot {
+.cohort-matrix .dot {
   cursor: pointer;
   stroke: #000;
 }
 
-.axis path,
-.axis line {
+.cohort-matrix .axis path,
+.cohort-matrix .axis line {
   fill: none;
   stroke: rgba(0, 0, 0, 0.1);
   shape-rendering: crispEdges;
 }
 
-.axisLine {
+.cohort-matrix .axisLine {
   fill: none;
   shape-rendering: crispEdges;
   stroke: rgba(0, 0, 0, 0.5);
   stroke-width: 2px;
 }
 
-.label {
+.cohort-matrix .label {
   fill: #777;
 }
 
-.sample.label {
+.cohort-matrix .overlay {
+  fill: none;
+  pointer-events: all;
+  cursor: ew-resize;
+}
+
+.cohort-matrix .sample.label {
   font: 300 30px "Helvetica Neue";
   fill: #ddd;
 }
 
-.sample.label.active {
+.cohort-matrix .sample.label.active {
   fill: #aaa;
-}
-
-.overlay {
-  fill: none;
-  pointer-events: all;
-  cursor: ew-resize;
 }

--- a/boac/templates/index.html
+++ b/boac/templates/index.html
@@ -12,9 +12,9 @@
     <!-- BOAC CSS -->
     <link href="/static/app/main.css" rel="stylesheet">
     <link href="/static/app/cohort/cohort.css" rel="stylesheet">
+    <link href="/static/app/cohort/cohortMatrix.css" rel="stylesheet">
     <link href="/static/app/shared/boxplot.css" rel="stylesheet">
     <link href="/static/app/shared/header.css" rel="stylesheet">
-    <link href="/static/app/shared/scatterplot.css" rel="stylesheet">
     <link href="/static/app/student/student.css" rel="stylesheet">
   </head>
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-116

Fun fact: the letter "I" was disappearing from the Berkeley logo because it's defined as an SVG `rect`, whereas all other letters are `path` or `polygon`.