### PR TITLE
BOAC-227, '/api/teams/all' is in athletics_controller; development_db.py loads old and new tables

### DIFF
--- a/boac/api/athletics_controller.py
+++ b/boac/api/athletics_controller.py
@@ -1,0 +1,15 @@
+from boac.models.athletics import Athletics
+from flask import current_app as app, jsonify
+from flask_login import login_required
+
+
+@app.route('/api/team_groups/all')
+@login_required
+def get_all_team_groups():
+    return jsonify(Athletics.all_team_groups())
+
+
+@app.route('/api/teams/all')
+@login_required
+def get_all_teams():
+    return jsonify(Athletics.all_teams())

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -1,4 +1,5 @@
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
+import boac.api.util as api_util
 from boac.lib.http import tolerant_jsonify
 from boac.merged import member_details
 from boac.models.cohort_filter import CohortFilter
@@ -10,9 +11,9 @@ from flask_login import current_user, login_required
 @app.route('/api/team/<code>')
 @login_required
 def get_team(code):
-    order_by = get_param(request.args, 'orderBy', None)
-    offset = get_param(request.args, 'offset', 0)
-    limit = get_param(request.args, 'limit', 50)
+    order_by = api_util.get(request.args, 'orderBy', None)
+    offset = api_util.get(request.args, 'offset', 0)
+    limit = api_util.get(request.args, 'limit', 50)
     team = TeamMember.get_team(code, order_by, offset, limit)
     if team is None:
         raise ResourceNotFoundError('No team found with code ' + code)
@@ -20,25 +21,13 @@ def get_team(code):
     return tolerant_jsonify(team)
 
 
-@app.route('/api/teams/all')
-@login_required
-def get_all_teams():
-    return jsonify(TeamMember.all_teams())
-
-
-@app.route('/api/team_groups/all')
-@login_required
-def get_all_team_groups():
-    return jsonify(TeamMember.all_team_groups())
-
-
 @app.route('/api/team_groups/members')
 @login_required
 def get_team_groups_members():
     team_group_codes = request.args.getlist('teamGroupCodes')
-    order_by = get_param(request.args, 'orderBy', None)
-    offset = get_param(request.args, 'offset', 0)
-    limit = get_param(request.args, 'limit', 50)
+    order_by = api_util.get(request.args, 'orderBy', None)
+    offset = api_util.get(request.args, 'offset', 0)
+    limit = api_util.get(request.args, 'limit', 50)
     members = TeamMember.get_athletes(team_group_codes, order_by, offset, limit)
     member_details.merge_all(members['members'])
     return jsonify(members)
@@ -65,18 +54,18 @@ def my_cohorts():
 @app.route('/api/intensive_cohort')
 @login_required
 def get_intensive_cohort():
-    order_by = get_param(request.args, 'orderBy', None)
-    offset = get_param(request.args, 'offset', 0)
-    limit = get_param(request.args, 'limit', 50)
+    order_by = api_util.get(request.args, 'orderBy', None)
+    offset = api_util.get(request.args, 'offset', 0)
+    limit = api_util.get(request.args, 'limit', 50)
     return tolerant_jsonify(CohortFilter.get_intensive_cohort(order_by=order_by, offset=offset, limit=limit))
 
 
 @app.route('/api/cohort/<cohort_id>')
 @login_required
 def get_cohort(cohort_id):
-    order_by = get_param(request.args, 'orderBy', None)
-    offset = get_param(request.args, 'offset', 0)
-    limit = get_param(request.args, 'limit', 50)
+    order_by = api_util.get(request.args, 'orderBy', None)
+    offset = api_util.get(request.args, 'offset', 0)
+    limit = api_util.get(request.args, 'limit', 50)
     cohort = CohortFilter.find_by_id(int(cohort_id), order_by, int(offset), int(limit))
     if not cohort:
         raise ResourceNotFoundError('No cohort found with identifier: {}'.format(cohort_id))
@@ -132,7 +121,3 @@ def delete_cohort(cohort_id):
 
 def get_cohort_owned_by(cohort_filter_id, uid):
     return next((c for c in CohortFilter.all_owned_by(uid) if c['id'] == cohort_filter_id), None)
-
-
-def get_param(params, key, default_value=None):
-    return (params and key in params and params[key]) or default_value

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -16,10 +16,10 @@ def canvas_courses_api_feed(courses):
 
 
 def sis_enrollment_class_feed(enrollment):
-    classData = enrollment.get('classSection', {}).get('class', {})
+    class_data = enrollment.get('classSection', {}).get('class', {})
     return {
-        'displayName': classData.get('course', {}).get('displayName'),
-        'title': classData.get('course', {}).get('title'),
+        'displayName': class_data.get('course', {}).get('displayName'),
+        'title': class_data.get('course', {}).get('title'),
         'canvasSites': [],
         'sections': [],
     }
@@ -38,3 +38,8 @@ def sis_enrollment_section_feed(enrollment):
         'grade': next((grade.get('mark') for grade in grades if grade.get('type', {}).get('code') == 'OFFL'), None),
         'midtermGrade': next((grade.get('mark') for grade in grades if grade.get('type', {}).get('code') == 'MID'), None),
     }
+
+
+def get(_dict, key, default_value=None):
+    value = _dict and key in _dict and _dict[key]
+    return value or default_value

--- a/boac/externals/import_asc_athletes.py
+++ b/boac/externals/import_asc_athletes.py
@@ -48,7 +48,7 @@ def load_csv(app, csv_file='tmp/FilteredAscStudents.csv'):
                         db.session.add(team_group)
                         athletics[group_code] = team_group
 
-                    team_group.members.append(student)
+                    team_group.athletes.append(student)
                     db.session.commit()
                 else:
                     app.logger.error('Unmapped asc_sport_code_core {} has SportActiveYN for sid {}'.format(

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -1,5 +1,4 @@
 from boac import db
-from boac.models.athletics import student_athletes
 from boac.models.base import Base
 
 
@@ -11,7 +10,6 @@ class Student(Base):
     first_name = db.Column(db.String(255), nullable=False)
     last_name = db.Column(db.String(255), nullable=False)
     in_intensive_cohort = db.Column(db.Boolean, nullable=False, default=False)
-    teams = db.relationship('Athletics', secondary=student_athletes, back_populates='members')
 
     def __repr__(self):
         return '<Athlete {} {}, uid={}, sid={}, team_groups={}, in_intensive_cohort={}, updated={}, created={}>'.format(
@@ -24,3 +22,12 @@ class Student(Base):
             self.updated_at,
             self.created_at,
         )
+
+    def to_api_json(self):
+        return {
+            'sid': self.sid,
+            'uid': self.uid,
+            'firstName': self.first_name,
+            'lastName': self.last_name,
+            'inIntensiveCohort': self.in_intensive_cohort,
+        }

--- a/boac/models/team_member.py
+++ b/boac/models/team_member.py
@@ -2,7 +2,7 @@
 
 from boac import db
 from boac.models.base import Base
-from sqlalchemy import func, UniqueConstraint
+from sqlalchemy import UniqueConstraint
 
 
 class TeamMember(Base):
@@ -75,45 +75,6 @@ class TeamMember(Base):
         'WPM': 'Water Polo - Men',
         'WPW': 'Water Polo - Women',
     }
-
-    @classmethod
-    def all_teams(cls):
-        results = db.session.query(cls.code,
-                                   cls.asc_sport_core,
-                                   func.count(func.distinct(cls.member_uid))).order_by(cls.asc_sport_core).group_by(cls.code,
-                                                                                                                    cls.asc_sport_core).all()
-
-        def translate_row(row):
-            return {
-                'code': row[0],
-                'name': row[1],
-                'totalMemberCount': row[2],
-            }
-        return [translate_row(row) for row in results]
-
-    @classmethod
-    def all_team_groups(cls):
-        results = db.session.query(cls.code,
-                                   cls.asc_sport_code_core,
-                                   cls.asc_sport_core,
-                                   cls.asc_sport_code,
-                                   cls.asc_sport,
-                                   func.count(cls.member_uid)).order_by(cls.asc_sport).group_by(cls.asc_sport_code,
-                                                                                                cls.code,
-                                                                                                cls.asc_sport_code_core,
-                                                                                                cls.asc_sport_core,
-                                                                                                cls.asc_sport).all()
-
-        def translate_row(row):
-            return {
-                'teamCode': row[0],
-                'sportCode': row[1],
-                'sportName': row[2],
-                'teamGroupCode': row[3],
-                'teamGroupName': row[4],
-                'totalMemberCount': row[5],
-            }
-        return [translate_row(row) for row in results]
 
     @classmethod
     def get_all_athletes(cls, order_by=None):

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -14,6 +14,7 @@ def register_routes(app):
     import boac.auth.cas_auth
 
     # Register API routes.
+    import boac.api.athletics_controller
     import boac.api.cohort_controller
     import boac.api.config_controller
     import boac.api.status_controller

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -1,0 +1,43 @@
+import pytest
+
+test_uid = '1133399'
+
+
+@pytest.fixture()
+def authenticated_session(fake_auth):
+    fake_auth.login(test_uid)
+
+
+class TestTeams:
+    """Athletics API"""
+
+    def test_not_authenticated(self, client):
+        """returns 401 if not authenticated"""
+        response = client.get('/api/teams/all')
+        assert response.status_code == 401
+
+    def test_get_all_team_groups(self, authenticated_session, client):
+        """returns all team-groups if authenticated"""
+        response = client.get('/api/team_groups/all')
+        assert response.status_code == 200
+        team_groups = response.json
+        group_codes = [team_group['teamGroupCode'] for team_group in team_groups]
+        group_names = [team_group['teamGroupName'] for team_group in team_groups]
+        total_member_counts = [team_group['totalMemberCount'] for team_group in team_groups]
+        assert ['MFB-DB', 'MFB-DL', 'MTE-AA', 'WFH-AA', 'WTE-AA'] == group_codes
+        assert ['Football, Defensive Backs', 'Football, Defensive Line', 'Men\'s Tennis', 'Women\'s Field Hockey',
+                'Women\'s Tennis'] == group_names
+        assert [2, 3, 1, 1, 1] == total_member_counts
+
+    def test_get_all_teams(self, authenticated_session, client):
+        """returns all teams if authenticated"""
+        response = client.get('/api/teams/all')
+        assert response.status_code == 200
+        teams = response.json
+        assert len(teams) == 4
+        team_codes = [team['code'] for team in teams]
+        team_names = [team['name'] for team in teams]
+        total_member_counts = [team['totalMemberCount'] for team in teams]
+        assert ['FBM', 'TNM', 'FHW', 'TNW'] == team_codes
+        assert ['Football', 'Men\'s Tennis', 'Women\'s Field Hockey', 'Women\'s Tennis'] == team_names
+        assert [3, 1, 1, 1] == total_member_counts

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -11,33 +11,6 @@ def authenticated_session(fake_auth):
     fake_auth.login(test_uid)
 
 
-class TestTeamsList:
-    """Cohorts list API"""
-
-    api_path = '/api/teams/all'
-
-    def test_not_authenticated(self, client):
-        """returns 401 if not authenticated"""
-        response = client.get(TestTeamsList.api_path)
-        assert response.status_code == 401
-
-    def test_authenticated(self, authenticated_session, client):
-        """returns a well-formed response if authenticated"""
-        response = client.get(TestTeamsList.api_path)
-        assert response.status_code == 200
-        teams = response.json
-        assert len(teams) == 4
-        team_codes = [team['code'] for team in teams]
-        team_names = [team['name'] for team in teams]
-        assert ['FBM', 'TNM', 'FHW', 'TNW'] == team_codes
-        assert ['Football', 'Men\'s Tennis', 'Women\'s Field Hockey', 'Women\'s Tennis'] == team_names
-        assert teams[0]['name'] == 'Football'
-        assert teams[0]['totalMemberCount'] == 3
-        assert teams[1]['totalMemberCount'] == 1
-        assert teams[2]['totalMemberCount'] == 1
-        assert teams[3]['totalMemberCount'] == 1
-
-
 class TestCohortDetail:
     """TeamMember detail API"""
 
@@ -97,14 +70,6 @@ class TestCohortDetail:
         assert len(my_cohorts) == 2
         assert len(my_cohorts[0]['teamGroups']) == 2
         assert len(my_cohorts[1]['teamGroups']) == 1
-
-    def test_get_all_team_groups(self, authenticated_session, client):
-        response = client.get('/api/team_groups/all')
-        assert response.status_code == 200
-        team_groups = response.json
-        assert 5 == len(team_groups)
-        team_group_codes = [team_group['teamGroupCode'] for team_group in team_groups]
-        assert ['MFB-DB', 'MFB-DL', 'MTE-AA', 'WFH-AA', 'WTE-AA'] == team_group_codes
 
     def test_team_groups_members(self, authenticated_session, client):
         response = client.get('/api/team_groups/members?teamGroupCodes=MFB-DB&teamGroupCodes=MFB-DL')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-227

Incremental cutover continues.  The `athletics_controller` serves  '/api/team_groups/all' and '/api/teams/all' in a backwards compatible way. Plus, development_db loads test data in old and new schemas. 