### PR TITLE
BOAC-184, athletics_controller serves /api/team*; get_students() moves to new schema

### DIFF
--- a/boac/api/athletics_controller.py
+++ b/boac/api/athletics_controller.py
@@ -1,6 +1,37 @@
+from boac.api.errors import ResourceNotFoundError
+import boac.api.util as api_util
+from boac.lib.http import tolerant_jsonify
+from boac.merged import member_details
 from boac.models.athletics import Athletics
-from flask import current_app as app, jsonify
+from boac.models.student import Student
+from flask import current_app as app, jsonify, request
 from flask_login import login_required
+
+
+@app.route('/api/team/<code>')
+@login_required
+def get_team(code):
+    order_by = api_util.get(request.args, 'orderBy', 'first_name')
+    team = Athletics.get_team(code, order_by)
+    if team is None:
+        raise ResourceNotFoundError('No team found with code ' + code)
+    member_details.merge_all(team['members'])
+    return tolerant_jsonify(team)
+
+
+@app.route('/api/team_groups/members')
+@login_required
+def get_team_groups_members():
+    team_group_codes = request.args.getlist('teamGroupCodes')
+    order_by = api_util.get(request.args, 'orderBy', None)
+    offset = api_util.get(request.args, 'offset', 0)
+    limit = api_util.get(request.args, 'limit', 50)
+    results = Student.get_students({'team_group_codes': team_group_codes}, order_by, offset, limit)
+    member_details.merge_all(results['students'])
+    return jsonify({
+        'members': results['students'],
+        'totalMemberCount': results['totalStudentCount'],
+    })
 
 
 @app.route('/api/team_groups/all')

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -3,34 +3,9 @@ import boac.api.util as api_util
 from boac.lib.http import tolerant_jsonify
 from boac.merged import member_details
 from boac.models.cohort_filter import CohortFilter
-from boac.models.team_member import TeamMember
+from boac.models.student import Student
 from flask import current_app as app, jsonify, request
 from flask_login import current_user, login_required
-
-
-@app.route('/api/team/<code>')
-@login_required
-def get_team(code):
-    order_by = api_util.get(request.args, 'orderBy', None)
-    offset = api_util.get(request.args, 'offset', 0)
-    limit = api_util.get(request.args, 'limit', 50)
-    team = TeamMember.get_team(code, order_by, offset, limit)
-    if team is None:
-        raise ResourceNotFoundError('No team found with code ' + code)
-    member_details.merge_all(team['members'])
-    return tolerant_jsonify(team)
-
-
-@app.route('/api/team_groups/members')
-@login_required
-def get_team_groups_members():
-    team_group_codes = request.args.getlist('teamGroupCodes')
-    order_by = api_util.get(request.args, 'orderBy', None)
-    offset = api_util.get(request.args, 'offset', 0)
-    limit = api_util.get(request.args, 'limit', 50)
-    members = TeamMember.get_athletes(team_group_codes, order_by, offset, limit)
-    member_details.merge_all(members['members'])
-    return jsonify(members)
 
 
 @app.route('/api/cohorts/all')
@@ -57,7 +32,13 @@ def get_intensive_cohort():
     order_by = api_util.get(request.args, 'orderBy', None)
     offset = api_util.get(request.args, 'offset', 0)
     limit = api_util.get(request.args, 'limit', 50)
-    return tolerant_jsonify(CohortFilter.get_intensive_cohort(order_by=order_by, offset=offset, limit=limit))
+    results = Student.in_intensive(order_by=order_by, offset=offset, limit=limit)
+    return tolerant_jsonify({
+        'code': 'intensive',
+        'label': 'Intensive',
+        'members': results['students'],
+        'totalMemberCount': results['totalStudentCount'],
+    })
 
 
 @app.route('/api/cohort/<cohort_id>')

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -40,6 +40,16 @@ def sis_enrollment_section_feed(enrollment):
     }
 
 
+def student_to_json(student):
+    return {
+        'sid': student.sid,
+        'uid': student.uid,
+        'firstName': student.first_name,
+        'lastName': student.last_name,
+        'inIntensiveCohort': student.in_intensive_cohort,
+    }
+
+
 def get(_dict, key, default_value=None):
     value = _dict and key in _dict and _dict[key]
     return value or default_value

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -6,14 +6,8 @@ simply mocked-out a la "demo mode" for now.
 
 from boac import db
 from boac.models.base import Base
+from boac.models.db_relationships import cohort_filter_owners
 from flask_login import UserMixin
-
-cohort_filter_owners = db.Table(
-    'cohort_filter_owners',
-    Base.metadata,
-    db.Column('cohort_filter_id', db.Integer, db.ForeignKey('cohort_filters.id'), primary_key=True),
-    db.Column('user_id', db.Integer, db.ForeignKey('authorized_users.id'), primary_key=True),
-)
 
 
 class AuthorizedUser(Base, UserMixin):

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -1,0 +1,18 @@
+from boac import db
+from boac.models.base import Base
+
+
+student_athletes = db.Table(
+    'student_athletes',
+    Base.metadata,
+    db.Column('group_code', db.String(80), db.ForeignKey('athletics.group_code'), primary_key=True),
+    db.Column('sid', db.String(80), db.ForeignKey('students.sid'), primary_key=True),
+)
+
+
+cohort_filter_owners = db.Table(
+    'cohort_filter_owners',
+    Base.metadata,
+    db.Column('cohort_filter_id', db.Integer, db.ForeignKey('cohort_filters.id'), primary_key=True),
+    db.Column('user_id', db.Integer, db.ForeignKey('authorized_users.id'), primary_key=True),
+)

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -128,6 +128,7 @@ def create_team_group(t):
 def assign_athletes(student, team_groups):
     student = Student(
         sid=student['sid'],
+        uid=student['uid'],
         first_name=student['first_name'],
         last_name=student['last_name'],
         in_intensive_cohort=student['in_intensive_cohort'],

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -1,5 +1,7 @@
 from boac import db
+import boac.api.util as api_util
 from boac.models.base import Base
+from boac.models.db_relationships import student_athletes
 
 
 class Student(Base):
@@ -10,24 +12,46 @@ class Student(Base):
     first_name = db.Column(db.String(255), nullable=False)
     last_name = db.Column(db.String(255), nullable=False)
     in_intensive_cohort = db.Column(db.Boolean, nullable=False, default=False)
+    athletics = db.relationship('Athletics', secondary=student_athletes, back_populates='athletes')
 
     def __repr__(self):
-        return '<Athlete {} {}, uid={}, sid={}, team_groups={}, in_intensive_cohort={}, updated={}, created={}>'.format(
+        return '<Athlete sid={}, uid={}, first_name={}, last_name={}, in_intensive_cohort={}, updated={}, created={}>'.format(
+            self.sid,
+            self.uid,
             self.first_name,
             self.last_name,
-            self.uid,
-            self.sid,
-            self.team_groups,
             self.in_intensive_cohort,
             self.updated_at,
             self.created_at,
         )
 
-    def to_api_json(self):
+    @classmethod
+    def in_intensive(cls, order_by=None, offset=0, limit=50):
+        o = cls.get_ordering(order_by)
+        query_filter = cls.in_intensive_cohort.is_(True)
+        students = cls.query.order_by(o).filter(query_filter).offset(offset).limit(limit).all()
         return {
-            'sid': self.sid,
-            'uid': self.uid,
-            'firstName': self.first_name,
-            'lastName': self.last_name,
-            'inIntensiveCohort': self.in_intensive_cohort,
+            'students': [student.to_api_json() for student in students],
+            'totalStudentCount': cls.query.filter(query_filter).count(),
         }
+
+    @classmethod
+    def get_students(cls, criteria, order_by=None, offset=0, limit=50):
+        group_codes = criteria['team_group_codes'] if 'team_group_codes' in criteria else None
+        o = cls.get_ordering(order_by)
+        sid_list = db.session.query(student_athletes.c.sid).filter(student_athletes.c.group_code.in_(group_codes)).all()
+        if sid_list:
+            students = cls.query.order_by(o).filter(cls.sid.in_(sid_list)).offset(offset).limit(limit).all()
+        else:
+            students = []
+        return {
+            'students': [student.to_api_json() for student in students],
+            'totalStudentCount': len(sid_list),
+        }
+
+    @classmethod
+    def get_ordering(cls, order_by):
+        return cls.last_name if order_by == 'last_name' else cls.first_name
+
+    def to_api_json(self):
+        return api_util.student_to_json(self)

--- a/boac/static/app/cohort/cohortFactory.js
+++ b/boac/static/app/cohort/cohortFactory.js
@@ -57,15 +57,12 @@
       return $http.get('/api/cohorts/my');
     };
 
-    var getTeam = function(code, orderBy, offset, limit) {
+    var getTeam = function(code, orderBy) {
       var params = {
-        api: code === 'intensive' ? '/api/intensive_cohort' : '/api/team/${code}',
         code: code,
-        offset: offset || 0,
-        limit: limit || 50,
         orderBy: orderBy || 'first_name'
       };
-      var apiPath = utilService.format('${api}?offset=${offset}&limit=${limit}&orderBy=${orderBy}', params);
+      var apiPath = utilService.format('/api/team/${code}?orderBy=${orderBy}', params);
       return $http.get(apiPath);
     };
 

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -1,4 +1,5 @@
 import pytest
+import simplejson as json
 
 test_uid = '1133399'
 
@@ -11,7 +12,12 @@ def authenticated_session(fake_auth):
 class TestTeams:
     """Athletics API"""
 
-    def test_not_authenticated(self, client):
+    def test_team_not_authenticated(self, client):
+        """returns 401 if not authenticated"""
+        response = client.get('/api/team/FHW')
+        assert response.status_code == 401
+
+    def test_teams_not_authenticated(self, client):
         """returns 401 if not authenticated"""
         response = client.get('/api/teams/all')
         assert response.status_code == 401
@@ -41,3 +47,62 @@ class TestTeams:
         assert ['FBM', 'TNM', 'FHW', 'TNW'] == team_codes
         assert ['Football', 'Men\'s Tennis', 'Women\'s Field Hockey', 'Women\'s Tennis'] == team_names
         assert [3, 1, 1, 1] == total_member_counts
+        football = teams[0]
+        assert football['code'] == 'FBM'
+        assert football['name'] == 'Football'
+        assert football['totalMemberCount'] == 3
+
+    def test_team_not_found(self, authenticated_session, client):
+        """returns code as name when no code-to-name translation exists"""
+        response = client.get('/api/team/XYZ')
+        assert response.status_code == 404
+        assert 'code' not in response.json
+        assert 'No team found' in json.loads(response.data)['message']
+
+    def test_team_with_athletes_in_multiple_groups(self, authenticated_session, client):
+        """returns a well-formed response on a valid code if authenticated"""
+        response = client.get('/api/team/FBM?orderBy=last_name')
+        assert response.status_code == 200
+        team = response.json
+        assert team['code'] == 'FBM'
+        assert team['name'] == 'Football'
+        assert 'teamGroups' in team
+        team_group_codes = [team_group['teamGroupCode'] for team_group in team['teamGroups']]
+        assert ['MFB-DB', 'MFB-DL'] == team_group_codes
+        assert team['totalMemberCount'] == 3
+        members = team['members']
+        assert len(members) == 3
+        sid_list = [member['sid'] for member in members]
+        assert ['2345678901', '5678901234', '3456789012'] == sid_list
+        athlete = members[0]
+        assert athlete['firstName'] == 'Oliver'
+        assert athlete['lastName'] == 'Heyer'
+        assert athlete['uid'] == '2040'
+        assert athlete['inIntensiveCohort'] is False
+        assert athlete['avatar_url'].startswith('http')
+
+    def test_team_groups_members(self, authenticated_session, client):
+        response = client.get('/api/team_groups/members?teamGroupCodes=MFB-DB&teamGroupCodes=MFB-DL')
+        assert response.status_code == 200
+        assert 'members' in response.json
+        member_uid_list = [member['uid'] for member in response.json['members']]
+        assert ['2040', '242881', '1133399'] == member_uid_list
+
+    def test_includes_team_member_sis_data(self, authenticated_session, client):
+        """includes SIS data for team members"""
+        response = client.get('/api/team/FHW')
+        athlete = response.json['members'][0]
+        assert athlete['cumulativeGPA'] == 3.8
+        assert athlete['cumulativeUnits'] == 101.3
+        assert athlete['level'] == 'Junior'
+        assert athlete['majors'] == ['English BA', 'Astrophysics BS']
+
+    def test_includes_team_member_current_enrollments(self, authenticated_session, client):
+        """includes current-term active enrollments and analytics for team members"""
+        response = client.get('/api/team/FHW')
+        athlete = response.json['members'][0]
+        assert athlete['currentTerm']['termName'] == 'Fall 2017'
+        assert athlete['currentTerm']['enrolledUnits'] == 7.5
+        assert len(athlete['currentTerm']['enrollments']) == 2
+        assert athlete['currentTerm']['enrollments'][0]['displayName'] == 'BURMESE 1A'
+        assert len(athlete['currentTerm']['enrollments'][0]['canvasSites']) == 1


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-227

This PR leaves TeamMember with one remaining function: `get_all_athletes()`. The trickier `get_students()` has been moved to new schema.