### PR TITLE
NOJIRA, bump python version to 3.6.3 in CodeBuild buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 eb_codebuild_settings:
   CodeBuildServiceRole: arn:aws:iam::697877139013:role/service-role/code-build-BOAC-service-role
   ComputeType: BUILD_GENERAL1_MEDIUM
-  Image: aws/codebuild/python:3.6.2
+  Image: aws/codebuild/python:3.6.3
   Timeout: 60
 
 phases:


### PR DESCRIPTION
It seems AWS has upgraded support on CodeBuild