### PR TITLE
BOAC-274 Performance improvements to student search dropdown

### DIFF
--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -2,6 +2,7 @@ from boac import db
 import boac.api.util as api_util
 from boac.models.base import Base
 from boac.models.db_relationships import student_athletes
+from sqlalchemy.orm import joinedload
 
 
 class Student(Base):
@@ -54,7 +55,7 @@ class Student(Base):
 
     @classmethod
     def get_all(cls, order_by=None):
-        students = Student.query.outerjoin(Student.athletics).all()
+        students = Student.query.options(joinedload('athletics')).all()
         if order_by and len(students) > 0:
             # For now, only one order_by value is supported
             if order_by == 'groupName':

--- a/boac/static/app/student/findStudentDirective.js
+++ b/boac/static/app/student/findStudentDirective.js
@@ -26,14 +26,19 @@
           });
         };
 
+        var studentOptions = null;
+
         $scope.lazyLoadOptions = function() {
-          var deferred = $q.defer();
+          if (!studentOptions) {
+            var deferred = $q.defer();
+            studentOptions = deferred.promise;
 
-          $timeout(function() {
-            loadOptions().then(deferred.resolve);
-          }, 1000);
+            $timeout(function() {
+              loadOptions().then(deferred.resolve);
+            }, 1000);
+          }
 
-          return deferred.promise;
+          return studentOptions;
         };
       }
     };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-274

The front-end fix ensures that the full list of students is fetched only once, instead of on every change to search text.

The back-end fix forces SQLAlchemy to eager load athletics associations. Specifically, it changes the underlying SQL query from:
```
SELECT students.created_at AS students_created_at, students.updated_at AS students_updated_at, students.sid AS students_sid, students.uid AS students_uid, students.first_name AS students_first_name, students.last_name AS students_last_name, students.in_intensive_cohort AS students_in_intensive_cohort 
FROM students LEFT OUTER JOIN (student_athletes AS student_athletes_1 JOIN athletics ON athletics.group_code = student_athletes_1.group_code) ON students.sid = student_athletes_1.sid
```
to:
```
SELECT students.created_at AS students_created_at, students.updated_at AS students_updated_at, students.sid AS students_sid, students.uid AS students_uid, students.first_name AS students_first_name, students.last_name AS students_last_name, students.in_intensive_cohort AS students_in_intensive_cohort, athletics_1.created_at AS athletics_1_created_at, athletics_1.updated_at AS athletics_1_updated_at, athletics_1.group_code AS athletics_1_group_code, athletics_1.group_name AS athletics_1_group_name, athletics_1.team_code AS athletics_1_team_code, athletics_1.team_name AS athletics_1_team_name 
FROM students LEFT OUTER JOIN (student_athletes AS student_athletes_1 JOIN athletics AS athletics_1 ON athletics_1.group_code = student_athletes_1.group_code) ON students.sid = student_athletes_1.sid
```

Who knew, right? ORMs! Official unclear documentation at http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html