### PR TITLE
BOAC-247 BOAC-273 Show all team names in student profile and search dropdown

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -68,7 +68,7 @@ def user_analytics(uid):
     student = Student.query.filter_by(uid=uid).first()
     if student:
         sis_profile = merge_sis_profile(student.sid)
-        athletics_profile = student.to_api_json()
+        athletics_profile = student.to_expanded_api_json()
     else:
         sis_profile = False
         athletics_profile = False

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -72,12 +72,5 @@ class Student(Base):
     def to_expanded_api_json(self):
         api_json = self.to_api_json()
         if self.athletics:
-            api_json['athletics'] = {}
-            for a in self.athletics:
-                api_json.update({
-                    'groupCode': a.group_code,
-                    'groupName': a.group_name,
-                    'teamCode': a.team_code,
-                    'teamName': a.team_name,
-                })
+            api_json['athletics'] = [a.to_api_json() for a in self.athletics]
         return api_json

--- a/boac/static/app/student/findStudentDirective.js
+++ b/boac/static/app/student/findStudentDirective.js
@@ -22,7 +22,17 @@
 
         var loadOptions = function() {
           return studentFactory.getAllStudents('groupName').then(function(response) {
-            return response.data;
+            var options = [];
+            _.each(response.data, function(student) {
+              _.each(student.athletics, function(a) {
+                options.push({
+                  uid: student.uid,
+                  name: student.name,
+                  groupName: a.groupName
+                });
+              });
+            });
+            return options;
           });
         };
 

--- a/boac/static/app/student/student.css
+++ b/boac/static/app/student/student.css
@@ -260,6 +260,10 @@
   margin: 0 0 5px 0;
 }
 
+.student-profile-sidebar-header-team {
+  margin-bottom: 10px;
+}
+
 .student-profile-sidebar-icon {
   color: #999;
   padding-right: 4px;

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -24,6 +24,9 @@
     <div class="student-profile-body">
       <div class="student-profile-sidebar">
         <div class="student-profile-sidebar-box">
+          <div data-ng-repeat="membership in student.athleticsProfile.athletics">
+            <h3 class="student-profile-sidebar-header student-profile-sidebar-header-team" data-ng-bind="membership.groupName"></h3>
+          </div>
           <div data-ng-repeat="plan in student.sisProfile.plans">
             <h3 class="student-profile-sidebar-header" data-ng-bind="plan.description"></h3>
             <div class="student-profile-sidebar-details">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-247
https://jira.ets.berkeley.edu/jira/browse/BOAC-273

Note that surfacing multiple team memberships requires changing the structure of the /api/students/all feed, which in turn requires the search dropdown directive to do more work to parse multiple memberships. 

Per the design suggestion in https://jira.ets.berkeley.edu/jira/browse/BOAC-247, students on multiple teams will appear multiple times in the dropdown. If we decide we don't like this behavior, it's easy to change; the important thing is that we've decoupled this logic from the API feed structure and located it entirely in the front end.
