### PR TITLE
BOAC-138 Add admin API endpoints to manage refresh jobs

### DIFF
--- a/boac/api/admin_controller.py
+++ b/boac/api/admin_controller.py
@@ -1,0 +1,48 @@
+from functools import wraps
+from boac.api import cache_utils
+from boac.lib.http import tolerant_jsonify
+from boac.models.job_progress import JobProgress
+from flask import current_app as app
+from flask_login import current_user
+
+
+def admin_required(func):
+    @wraps(func)
+    def _admin_required(*args, **kw):
+        if (not current_user.is_authenticated) or (not current_user.is_admin):
+            return app.login_manager.unauthorized()
+        return func(*args, **kw)
+    return _admin_required
+
+
+@app.route('/api/admin/refresh')
+@admin_required
+def get_refresh_status():
+    progress = JobProgress().get()
+    return tolerant_jsonify({
+        'progress': progress,
+    })
+
+
+@app.route('/api/admin/refresh/clear')
+@admin_required
+def clear_refresh():
+    progress = JobProgress().delete()
+    return tolerant_jsonify({
+        'progressDeleted': progress,
+    })
+
+
+@app.route('/api/admin/refresh/load')
+@admin_required
+def start_load_only():
+    """If a refresh has been interrupted (due to server restart, for example), this endpoint lets us continue
+    to load new data without having to erase any data which was successfully cached.
+    """
+    return tolerant_jsonify(cache_utils.refresh_request_handler(load_only=True))
+
+
+@app.route('/api/admin/refresh/start')
+@admin_required
+def start_refresh():
+    return tolerant_jsonify(cache_utils.refresh_request_handler())

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -14,6 +14,7 @@ def register_routes(app):
     import boac.auth.cas_auth
 
     # Register API routes.
+    import boac.api.admin_controller
     import boac.api.athletics_controller
     import boac.api.cohort_controller
     import boac.api.config_controller

--- a/run.py
+++ b/run.py
@@ -45,7 +45,7 @@ def load_external_data():
 @application.cli.command()
 def load_canvas_scores():
     from boac.api import cache_utils
-    cache_utils.load_canvas_scores()
+    cache_utils.load_all_canvas_scores()
 
 
 @application.cli.command()


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-138

This PR knowingly makes an utter hash of the cache_utils module. The goal is to support a non-destructive test of this background job approach on AWS. Once we have something that seems OK, I'll tidy the place up.