### PR TITLE
BOAC-282 Do not lose Canvas data after a course site has been concluded

### DIFF
--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -95,7 +95,11 @@ def get_course_enrollments(course_id, term_id):
 @fixture('canvas_course_enrollments_{course_id}')
 def _get_course_enrollments(course_id, mock=None):
     path = '/api/v1/courses/{course_id}/enrollments'.format(course_id=course_id)
-    return paged_request(path=path, mock=mock, query={'type[]': 'StudentEnrollment'})
+    return paged_request(path=path, mock=mock, query={
+        'type[]': 'StudentEnrollment',
+        # By default, Canvas will not return any students at all for completed course sites.
+        'state[]': ['active', 'completed', 'inactive'],
+    })
 
 
 def build_url(path, query=None):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-282

Without this, we run a high risk of 500 errors due to enrollment list mismatches between Canvas APIs, as well as losing important analytics.