### PR TITLE
BOAC-278 Normalized database cache for SIS profile

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -1,6 +1,7 @@
 from threading import Thread
 from boac import db
 from boac.lib import berkeley
+from boac.merged.sis_profile import merge_sis_profile
 from boac.models.job_progress import JobProgress
 from boac.models.json_cache import JsonCache
 from flask import current_app as app
@@ -229,3 +230,20 @@ def load_current_term():
 def refresh_current_term():
     clear_current_term()
     load_current_term()
+
+
+def load_merged_sis_profiles():
+    """TODO For now, pending a general refresh strategy for merged models, this sits to the side of other
+    cache loading methods."""
+    from boac.models.student import Student
+
+    success_count = 0
+    failures = []
+
+    for (sid,) in db.session.query(Student.sid).distinct():
+        sis_profile = merge_sis_profile(sid)
+        if sis_profile:
+            success_count += 1
+        else:
+            failures.append('merge_sis_profile failed for SID {}'.format(sid))
+    return success_count, failures

--- a/boac/merged/sis_profile.py
+++ b/boac/merged/sis_profile.py
@@ -1,9 +1,12 @@
 import re
-
 from boac.externals import sis_degree_progress_api
 from boac.externals import sis_student_api
+from boac.models.json_cache import stow
+from boac.models.normalized_cache_student import NormalizedCacheStudent
+from boac.models.normalized_cache_student_major import NormalizedCacheStudentMajor
 
 
+@stow('merged_sis_profile_{csid}')
 def merge_sis_profile(csid):
     sis_response = sis_student_api.get_student(csid)
     if not sis_response:
@@ -16,6 +19,9 @@ def merge_sis_profile(csid):
     merge_sis_profile_phones(sis_response, sis_profile)
     if sis_profile['academicCareer'] == 'UGRD':
         sis_profile['degreeProgress'] = sis_degree_progress_api.parsed_degree_progress(csid)
+
+    store_normalized_profile(csid, sis_profile)
+
     return sis_profile
 
 
@@ -87,3 +93,13 @@ def merge_sis_profile_phones(sis_response, sis_profile):
         for phone in sis_response.get('phones', [])
     }
     sis_profile['phoneNumber'] = phones_by_code.get('CELL') or phones_by_code.get('LOCL') or phones_by_code.get('HOME')
+
+
+def store_normalized_profile(csid, sis_profile):
+    gpa = sis_profile.get('cumulativeGPA')
+    level = sis_profile.get('level', {}).get('description')
+    units = sis_profile.get('cumulativeUnits')
+    NormalizedCacheStudent.update_profile(csid, gpa=gpa, level=level, units=units)
+
+    majors = [plan['description'] for plan in sis_profile.get('plans', [])]
+    NormalizedCacheStudentMajor.update_majors(csid, majors)

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -3,10 +3,13 @@ from boac import db
 from boac.models.athletics import Athletics
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
-# Needed for db.create_all to find the model.
-from boac.models.json_cache import JsonCache # noqa
 from boac.models.student import Student
-
+# Models below are included so that db.create_all will find them.
+from boac.models.db_relationships import cohort_filter_owners, student_athletes # noqa
+from boac.models.job_progress import JobProgress # noqa
+from boac.models.json_cache import JsonCache # noqa
+from boac.models.normalized_cache_student import NormalizedCacheStudent # noqa
+from boac.models.normalized_cache_student_major import NormalizedCacheStudentMajor # noqa
 
 _default_users_csv = """uid,is_admin,is_director,is_advisor
 2040,true,false,false

--- a/boac/models/normalized_cache_student.py
+++ b/boac/models/normalized_cache_student.py
@@ -1,0 +1,34 @@
+from boac import db
+from boac.models.base import Base
+from flask import current_app as app
+
+
+class NormalizedCacheStudent(Base):
+    __tablename__ = 'normalized_cache_students'
+
+    sid = db.Column(db.String(80), nullable=False, primary_key=True)
+    gpa = db.Column(db.Numeric, nullable=True, index=True)
+    level = db.Column(db.String(9), nullable=True, index=True)
+    units = db.Column(db.Numeric, nullable=True, index=True)
+
+    def __repr__(self):
+        return '<NormalizedCacheStudent sid={}, gpa={}, level={}, units={}, created={}>'.format(
+            self.sid,
+            self.gpa,
+            self.level,
+            self.updated_at,
+            self.created_at,
+        )
+
+    @classmethod
+    def update_profile(cls, sid, gpa=None, level=None, units=None):
+        row = cls.query.filter_by(sid=sid).first()
+        if row:
+            row.gpa = gpa
+            row.level = level
+            row.units = units
+        else:
+            row = cls(sid=sid, gpa=gpa, level=level, units=units)
+            db.session.add(row)
+        if not app.config['TESTING']:
+            db.session.commit()

--- a/scripts/db/migrate/20171221-BOAC-278/create_normalized_cache_tables.sql
+++ b/scripts/db/migrate/20171221-BOAC-278/create_normalized_cache_tables.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+CREATE TABLE normalized_cache_students (
+  sid VARCHAR(80) PRIMARY KEY REFERENCES students (sid) ON DELETE CASCADE,
+  gpa DECIMAL,
+  level VARCHAR(9),
+  units DECIMAL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX normalized_cache_students_gpa_idx ON normalized_cache_students (gpa);
+CREATE INDEX normalized_cache_students_level_idx ON normalized_cache_students (level);
+CREATE INDEX normalized_cache_students_units_idx ON normalized_cache_students (units);
+
+CREATE TABLE normalized_cache_student_majors (
+  sid VARCHAR(80) NOT NULL REFERENCES students (sid) ON DELETE CASCADE,
+  major VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  PRIMARY KEY (sid, major)
+);
+
+CREATE INDEX normalized_cache_student_majors_sid_idx ON normalized_cache_student_majors (sid);
+CREATE INDEX normalized_cache_student_majors_major_idx ON normalized_cache_student_majors (major);
+
+COMMIT;

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -1,0 +1,63 @@
+from decimal import Decimal
+from boac.externals import sis_student_api
+from boac.lib.mockingbird import MockResponse, register_mock
+from boac.merged.sis_profile import merge_sis_profile
+from boac.models import json_cache
+from boac.models.normalized_cache_student import NormalizedCacheStudent
+from boac.models.normalized_cache_student_major import NormalizedCacheStudentMajor
+import pytest
+
+
+@pytest.mark.usefixtures('db_session')
+class TestSisProfile:
+    """TestSisProfile"""
+
+    def test_populates_normalized_cache(self, app):
+        """populates the normalized cache"""
+        assert len(NormalizedCacheStudent.query.all()) == 0
+        assert len(NormalizedCacheStudentMajor.query.all()) == 0
+
+        merge_sis_profile('11667051')
+
+        student_rows = NormalizedCacheStudent.query.all()
+        assert len(student_rows) == 1
+        assert student_rows[0].sid == '11667051'
+        assert student_rows[0].level == 'Junior'
+        assert student_rows[0].units == Decimal('101.3')
+        assert student_rows[0].gpa == Decimal('3.8')
+
+        student_major_rows = NormalizedCacheStudentMajor.query.all()
+        assert len(student_major_rows) == 2
+        majors = [row.major for row in student_major_rows]
+        assert 'English BA' in majors
+        assert 'Astrophysics BS' in majors
+
+    def test_updates_normalized_cache(self, app):
+        """updates the normalized cache"""
+
+        # Load default fixture data, clear the JSON cache.
+        merge_sis_profile('11667051')
+        json_cache.clear('merged_sis_profile_11667051')
+        json_cache.clear('sis_student_api_11667051')
+        assert len(NormalizedCacheStudent.query.all()) == 1
+        assert len(NormalizedCacheStudentMajor.query.all()) == 2
+
+        # Our student levels up and changes a major.
+        with open(app.config['BASE_DIR'] + '/fixtures/sis_student_api_11667051.json') as file:
+            modified_response_body = file.read().replace('Junior', 'Senior').replace('Astrophysics BS', 'Hungarian BA')
+            modified_response = MockResponse(200, {}, modified_response_body)
+            with register_mock(sis_student_api._get_student, modified_response):
+
+                # The normalized cache keeps pace.
+                merge_sis_profile('11667051')
+
+                student_rows = NormalizedCacheStudent.query.all()
+                assert len(student_rows) == 1
+                assert student_rows[0].sid == '11667051'
+                assert student_rows[0].level == 'Senior'
+
+                student_major_rows = NormalizedCacheStudentMajor.query.all()
+                assert len(student_major_rows) == 2
+                majors = [row.major for row in student_major_rows]
+                assert 'English BA' in majors
+                assert 'Hungarian BA' in majors


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-278

Before deploy, the included SQL script should be run on boac-shared to create new tables.

After deploy, the `load_merged_sis_profiles` method can be used to fill the tables. Since it will be running off cached JSON, it should go quickly.