### PR TITLE
NOJIRA Safe, sane, consistent 404 checks

### DIFF
--- a/boac/externals/cal1card_photo_api.py
+++ b/boac/externals/cal1card_photo_api.py
@@ -11,7 +11,7 @@ def get_cal1card_photo(uid):
     if response:
         return response.content
     else:
-        if hasattr(response, 'raw_response') and response.raw_response.status_code == 404:
+        if hasattr(response, 'raw_response') and hasattr(response.raw_response, 'status_code') and response.raw_response.status_code == 404:
             return False
         else:
             return None

--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -24,7 +24,7 @@ def get_user_for_uid(uid):
     if response and hasattr(response, 'json'):
         return response.json()
     else:
-        if hasattr(response, 'raw_response') and response.raw_response.status_code == 404:
+        if hasattr(response, 'raw_response') and hasattr(response.raw_response, 'status_code') and response.raw_response.status_code == 404:
             return False
         else:
             return None

--- a/boac/externals/sis_degree_progress_api.py
+++ b/boac/externals/sis_degree_progress_api.py
@@ -59,7 +59,7 @@ def get_degree_progress(cs_id):
         else:
             return False
     else:
-        if hasattr(response, 'raw_response') and response.raw_response and response.raw_response.status_code == 404:
+        if hasattr(response, 'raw_response') and hasattr(response.raw_response, 'status_code') and response.raw_response.status_code == 404:
             return False
         else:
             return None

--- a/boac/externals/sis_enrollments_api.py
+++ b/boac/externals/sis_enrollments_api.py
@@ -12,7 +12,7 @@ def get_enrollments(cs_id, term_id):
     if response and hasattr(response, 'json'):
         return response.json().get('apiResponse', {}).get('response', {})
     else:
-        if hasattr(response, 'raw_response') and response.raw_response.status_code == 404:
+        if hasattr(response, 'raw_response') and hasattr(response.raw_response, 'status_code') and response.raw_response.status_code == 404:
             return False
         else:
             return None


### PR DESCRIPTION
Our externals code needs to survive cases where `response.raw_response` is `None`. But since error responses evaluate to falsey, the simple check `response.raw_response and response.raw_response.status_code == 404` will never return true. 