### PR TITLE
BOAC-290, Student model query: get_students by gpa_ranges, levels, majors

### DIFF
--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -128,9 +128,10 @@ def create_team_group(t):
     return athletics
 
 
-def assign_athletes(student, team_groups):
+def create_athlete(student, team_groups, gpa, level, units, majors):
+    sid = student['sid']
     student = Student(
-        sid=student['sid'],
+        sid=sid,
         uid=student['uid'],
         first_name=student['first_name'],
         last_name=student['last_name'],
@@ -139,6 +140,8 @@ def assign_athletes(student, team_groups):
     db.session.add(student)
     for team_group in team_groups:
         team_group.athletes.append(student)
+    NormalizedCacheStudent.update_profile(sid, gpa=gpa, level=level, units=units)
+    NormalizedCacheStudentMajor.update_majors(sid, majors)
 
 
 def load_student_athletes():
@@ -149,11 +152,36 @@ def load_student_athletes():
     wt = create_team_group(womens_tennis)
 
     # Assign athletes
-    assign_athletes(brigitte, [wfh, wt])
-    assign_athletes(john, [])
-    assign_athletes(oliver, [fdb, fdl])
-    assign_athletes(paul, [fdl])
-    assign_athletes(sandeep, [fdb, fdl, mt])
+    create_athlete(student=brigitte,
+                   team_groups=[wfh, wt],
+                   gpa=None,
+                   level=None,
+                   units=0,
+                   majors=['Economics BA'])
+    create_athlete(student=john,
+                   team_groups=[],
+                   gpa='1.85',
+                   level='Freshman',
+                   units=12,
+                   majors=['Chemistry BS'])
+    create_athlete(student=oliver,
+                   team_groups=[fdb, fdl],
+                   gpa='3.495',
+                   level='Junior',
+                   units=34,
+                   majors=['History BA'])
+    create_athlete(student=paul,
+                   team_groups=[fdl],
+                   gpa='3.005',
+                   level='Junior',
+                   units=70,
+                   majors=['English BA', 'Political Economy BA'])
+    create_athlete(student=sandeep,
+                   team_groups=[fdb, fdl, mt],
+                   gpa='3.501',
+                   level='Senior',
+                   units=102,
+                   majors=['Letters & Sci Undeclared UG'])
 
     db.session.commit()
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -386,20 +386,20 @@ class TestUserAnalytics:
 
     def test_get_students(self, authenticated_session, client):
         data = {
-            'gpaRanges': [],
+            'gpaRanges': ['numrange(3, 3.5, \'[)\')', 'numrange(3.5, 4, \'[]\')'],
             'groupCodes': ['MFB-DB', 'MFB-DL'],
-            'levels': [],
-            'majors': [],
+            'levels': ['Junior', 'Senior'],
+            'majors': ['English BA', 'History BA', 'Letters & Sci Undeclared UG', 'Gender and Women\'s Studies'],
             'unitRangesEligibility': [],
             'unitRangesPacing': [],
             'orderBy': 'last_name',
             'offset': 1,
-            'limit': 2,
+            'limit': 50,
         }
         response = client.post('/api/students', data=json.dumps(data), content_type='application/json')
         assert response.status_code == 200
         assert 'members' in response.json
         students = response.json['members']
         assert 2 == len(students)
-        # Ordered by lastName
+        # Offset of 1, ordered by lastName
         assert ['1133399', '242881'] == [student['uid'] for student in students]

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -14,20 +14,15 @@ class TestSisProfile:
 
     def test_populates_normalized_cache(self, app):
         """populates the normalized cache"""
-        assert len(NormalizedCacheStudent.query.all()) == 0
-        assert len(NormalizedCacheStudentMajor.query.all()) == 0
-
         merge_sis_profile('11667051')
 
         student_rows = NormalizedCacheStudent.query.all()
-        assert len(student_rows) == 1
-        assert student_rows[0].sid == '11667051'
-        assert student_rows[0].level == 'Junior'
-        assert student_rows[0].units == Decimal('101.3')
-        assert student_rows[0].gpa == Decimal('3.8')
+        assert student_rows[-1].sid == '11667051'
+        assert student_rows[-1].level == 'Junior'
+        assert student_rows[-1].units == Decimal('101.3')
+        assert student_rows[-1].gpa == Decimal('3.8')
 
         student_major_rows = NormalizedCacheStudentMajor.query.all()
-        assert len(student_major_rows) == 2
         majors = [row.major for row in student_major_rows]
         assert 'English BA' in majors
         assert 'Astrophysics BS' in majors
@@ -39,8 +34,6 @@ class TestSisProfile:
         merge_sis_profile('11667051')
         json_cache.clear('merged_sis_profile_11667051')
         json_cache.clear('sis_student_api_11667051')
-        assert len(NormalizedCacheStudent.query.all()) == 1
-        assert len(NormalizedCacheStudentMajor.query.all()) == 2
 
         # Our student levels up and changes a major.
         with open(app.config['BASE_DIR'] + '/fixtures/sis_student_api_11667051.json') as file:
@@ -52,12 +45,12 @@ class TestSisProfile:
                 merge_sis_profile('11667051')
 
                 student_rows = NormalizedCacheStudent.query.all()
-                assert len(student_rows) == 1
-                assert student_rows[0].sid == '11667051'
-                assert student_rows[0].level == 'Senior'
+                assert len(student_rows) == 5
+                assert student_rows[4].sid == '11667051'
+                assert student_rows[4].level == 'Senior'
 
                 student_major_rows = NormalizedCacheStudentMajor.query.all()
-                assert len(student_major_rows) == 2
+                assert len(student_major_rows) == 7
                 majors = [row.major for row in student_major_rows]
                 assert 'English BA' in majors
                 assert 'Hungarian BA' in majors


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-290

Leveraging new `normalized_` tables. The unit-range filters are still TODO.