### PR TITLE
 BOAC-138 Full API support to manage cache from script

### DIFF
--- a/boac/api/admin_controller.py
+++ b/boac/api/admin_controller.py
@@ -9,9 +9,13 @@ from flask_login import current_user
 def admin_required(func):
     @wraps(func)
     def _admin_required(*args, **kw):
-        if (not current_user.is_authenticated) or (not current_user.is_admin):
+        auth_key = app.config['API_KEY']
+        login_ok = current_user.is_authenticated and current_user.is_admin
+        api_key_ok = auth_key and (request.headers['app_key'] == auth_key)
+        if login_ok or api_key_ok:
+            return func(*args, **kw)
+        else:
             return app.login_manager.unauthorized()
-        return func(*args, **kw)
     return _admin_required
 
 

--- a/boac/api/admin_controller.py
+++ b/boac/api/admin_controller.py
@@ -1,6 +1,5 @@
 from functools import wraps
 from boac.api import cache_utils
-from boac.lib import berkeley
 from boac.lib.http import tolerant_jsonify
 from boac.models.job_progress import JobProgress
 from flask import current_app as app, request
@@ -17,39 +16,38 @@ def admin_required(func):
 
 
 def term():
-    term_id = request.args.get('term') or berkeley.sis_term_id_for_name(app.config['CANVAS_CURRENT_ENROLLMENT_TERM'])
+    term_id = request.args.get('term') or cache_utils.current_term_id()
     return term_id
 
 
-@app.route('/api/admin/refresh')
+@app.route('/api/admin/cachejob')
 @admin_required
-def get_refresh_status():
+def get_cachejob_status():
     progress = JobProgress().get()
     return tolerant_jsonify({
         'progress': progress,
     })
 
 
-@app.route('/api/admin/refresh/clear')
+@app.route('/api/admin/cachejob/clear')
 @admin_required
-def clear_refresh():
+def clear_cachejob():
     progress = JobProgress().delete()
     return tolerant_jsonify({
         'progressDeleted': progress,
     })
 
 
-@app.route('/api/admin/refresh/load')
+@app.route('/api/admin/cachejob/load')
 @admin_required
 def start_load_only():
-    """If a refresh has been interrupted (due to server restart, for example), this endpoint lets us continue
-    to load new data without having to erase any data which was successfully cached.
+    """This endpoint lets us load still-uncached data without having to erase any data which was already cached.
     """
     job_state = cache_utils.refresh_request_handler(term(), load_only=True)
     return tolerant_jsonify(job_state)
 
 
-@app.route('/api/admin/refresh/start')
+@app.route('/api/admin/cachejob/refresh')
 @admin_required
 def start_refresh():
     return tolerant_jsonify(cache_utils.refresh_request_handler(term()))

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -20,6 +20,7 @@ _default_users_csv = """uid,is_admin,is_director,is_advisor
 211159,true,false,false
 242881,true,false,false
 1022796,true,false,false
+6446,false,true,true
 """
 
 football_defensive_backs = {

--- a/config/default.py
+++ b/config/default.py
@@ -32,6 +32,9 @@ PORT = 5000
 DEVELOPER_AUTH_ENABLED = False
 DEVELOPER_AUTH_PASSWORD = 'another secret'
 
+# Set to a nice long chaotic string to enable scripted access to APIs.
+API_KEY = None
+
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
 CAS_LOGOUT_URL = 'https://auth-test.berkeley.edu/cas/logout'
 

--- a/run.py
+++ b/run.py
@@ -39,19 +39,13 @@ def initdb():
 @application.cli.command()
 def load_external_data():
     from boac.api import cache_utils
-    cache_utils.load_current_term()
-
-
-@application.cli.command()
-def load_canvas_scores():
-    from boac.api import cache_utils
-    cache_utils.load_all_canvas_scores()
+    cache_utils.load_term()
 
 
 @application.cli.command()
 def refresh_external_data():
     from boac.api import cache_utils
-    cache_utils.refresh_current_term()
+    cache_utils.refresh_term()
 
 
 host = application.config['HOST']

--- a/tests/test_api/test_admin_controller.py
+++ b/tests/test_api/test_admin_controller.py
@@ -1,0 +1,41 @@
+class TestCachejobAccess:
+
+    def test_not_authenticated(self, client):
+        """requires authentication"""
+        response = client.get('/api/admin/cachejob')
+        assert response.status_code == 401
+
+    def test_not_an_admin(self, client, fake_auth):
+        """returns 403 for normal users"""
+        test_uid = '6446'
+        fake_auth.login(test_uid)
+        response = client.get('/api/admin/cachejob')
+        assert response.status_code == 401
+
+    def test_as_an_admin(self, client, fake_auth):
+        """returns success"""
+        test_uid = '2040'
+        fake_auth.login(test_uid)
+        response = client.get('/api/admin/cachejob')
+        assert response.status_code == 200
+        assert response.headers.get('Content-Type') == 'application/json'
+
+    def test_api_key_match(self, app, client):
+        api_key = 'Hey ho, seely sheepe!'
+        app.config['API_KEY'] = api_key
+        headers = {'app_key': api_key}
+        response = client.get('/api/admin/cachejob', headers=headers)
+        assert response.status_code == 200
+        assert response.headers.get('Content-Type') == 'application/json'
+
+    def test_api_key_no_match(self, app, client):
+        app.config['API_KEY'] = 'Hey ho, seely sheepe!'
+        headers = {'app_key': 'I saw the bouncing Bellibone'}
+        response = client.get('/api/admin/cachejob', headers=headers)
+        assert response.status_code == 401
+
+    def test_api_key_disabled(self, app, client):
+        app.config['API_KEY'] = None
+        headers = {'app_key': None}
+        response = client.get('/api/admin/cachejob', headers=headers)
+        assert response.status_code == 401


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-138

- Full refresh through the admin API.
- External API access by in-the-know applications (if enabled).
- New non-admin user account in development_db load.

**COOKBOOK**
* *Check caching job status* : api/admin/cachejob
* *Refresh the current term's cached data* : api/admin/cachejob/refresh
* *Load any missing data for Summer 2017* : api/admin/cachejob/load?term=2175
* *Clear the caching job tracker after an interrupted job*: api/admin/cachejob/clear
* *Continue loading current term data after an interrupted refresh* : api/admin/cachejob/load
