### PR TITLE
BOAC-287 Redefine 'primary section' as 'section with a grading basis'

### DIFF
--- a/boac/merged/sis_enrollments.py
+++ b/boac/merged/sis_enrollments.py
@@ -124,7 +124,7 @@ def collect_dropped_sections(term_feed):
 
 
 def is_primary_section(section_feed):
-    return section_feed['units'] > 0 and section_feed['enrollmentStatus'] == 'E'
+    return section_feed['gradingBasis'] != 'NON' and section_feed['enrollmentStatus'] == 'E'
 
 
 def merge_canvas_course_site(term_feed, site):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-287

The Hub doesn't explicitly tell us which sections are primary. We've been using "nonzero unit count" as a proxy, but it looks like the occasional zero-unit primary section is a thing. Let's try a different metric! Fundamental as this change is, I haven't found any issues in spot checks on various students.