### PR TITLE
BOAC-322 Adapt sample cache refresh script to AWS environment

### DIFF
--- a/boac/api/admin_controller.py
+++ b/boac/api/admin_controller.py
@@ -11,16 +11,11 @@ def admin_required(func):
     def _admin_required(*args, **kw):
         auth_key = app.config['API_KEY']
         login_ok = current_user.is_authenticated and current_user.is_admin
-
-        # TODO This is a temporary diagnostic aid and needs to removed before deployment to QA or Production.
-        app.logger.warn(f'Got cachejob request with headers {repr(request.headers)}')
-        app.logger.warn('  app_key = {}'.format(request.headers.get('app_key')))
-        app.logger.warn('  App-Key = {}'.format(request.headers.get('App-Key')))
-
-        api_key_ok = auth_key and (request.headers.get('app_key') == auth_key)
+        api_key_ok = auth_key and (request.headers.get('App-Key') == auth_key)
         if login_ok or api_key_ok:
             return func(*args, **kw)
         else:
+            app.logger.warn(f'Unauthorized request to {request.path}')
             return app.login_manager.unauthorized()
     return _admin_required
 

--- a/scripts/refresh_current_term_cache.sh
+++ b/scripts/refresh_current_term_cache.sh
@@ -36,7 +36,9 @@ url="${BOAC_URL}/api/admin/cachejob/refresh"
 echo | tee -a ${log_file}
 echo "About to ping ${url}" | tee -a ${log_file}
 echo | tee -a ${log_file}
-response_metadata=$(curl -k --header "app_key: ${BOAC_API_KEY}" "${url}" 2>&1)
+# The more typical underscored "app_key" header will be stripped out by the AWS load balancer.
+# A hyphened "app-key" header passes through.
+response_metadata=$(curl -k --header "app-key: ${BOAC_API_KEY}" "${url}" 2>&1)
 echo "Got response:" | tee -a ${log_file}
 echo | tee -a ${log_file}
 echo "${response_metadata}" | tee -a ${log_file}


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-322

- Also removes temporary API request diagnostics.

@johncrossman , if this tests out on boac-dev, it would be my last change for the QA branch.