### PR TITLE
BOAC-334 Skip concurrent-enrollment academic status

### DIFF
--- a/boac/merged/sis_profile.py
+++ b/boac/merged/sis_profile.py
@@ -26,10 +26,15 @@ def merge_sis_profile(csid):
 
 
 def merge_sis_profile_academic_status(sis_response, sis_profile):
-    academic_statuses = sis_response.get('academicStatuses', [])
-    if len(academic_statuses):
-        academic_status = academic_statuses[0]
-    else:
+    # The Hub may return multiple academic statuses. We'll select the first status with a well-formed academic
+    # career that is not a concurrent enrollment.
+    academic_status = None
+    for status in sis_response.get('academicStatuses', []):
+        career_code = status.get('currentRegistration', {}).get('academicCareer', {}).get('code')
+        if career_code and career_code != 'UCBX':
+            academic_status = status
+            break
+    if not academic_status:
         return
 
     sis_profile['cumulativeGPA'] = academic_status.get('cumulativeGPA', {}).get('average')

--- a/fixtures/sis_student_api_11667051.json
+++ b/fixtures/sis_student_api_11667051.json
@@ -8,6 +8,212 @@
             "academicStatuses": [
               {
                 "cumulativeGPA": {
+                  "average": 0,
+                  "source": "UCB",
+                  "type": {
+                    "code": "Cumulative"
+                  }
+                },
+                "cumulativeUnits": [
+                  {
+                    "type": {
+                      "code": "Total"
+                    },
+                    "unitsCumulative": 0,
+                    "unitsEnrolled": 4,
+                    "unitsIncomplete": 0,
+                    "unitsOther": 0,
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTest": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsWaitlisted": 0
+                  },
+                  {
+                    "type": {
+                      "code": "For GPA"
+                    },
+                    "unitsEnrolled": 4,
+                    "unitsIncomplete": 0,
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsWaitlisted": 0
+                  },
+                  {
+                    "type": {
+                      "code": "Not For GPA"
+                    },
+                    "unitsEnrolled": 0,
+                    "unitsIncomplete": 0,
+                    "unitsPassed": 0,
+                    "unitsTaken": 0,
+                    "unitsTransferAccepted": 0,
+                    "unitsTransferEarned": 0,
+                    "unitsWaitlisted": 0
+                  }
+                ],
+                "currentRegistration": {
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UC Berkeley Extension"
+                  },
+                  "academicLevel": {
+                    "level": {
+                      "code": "00",
+                      "description": "Not Set"
+                    },
+                    "type": {
+                      "code": "Begining of Term"
+                    }
+                  },
+                  "athlete": true,
+                  "disabled": false,
+                  "eligibleToRegister": true,
+                  "intendsToGraduate": false,
+                  "new": true,
+                  "registered": false,
+                  "specialStudyPrograms": [],
+                  "term": {
+                    "id": "2182",
+                    "name": "2018 Spring"
+                  },
+                  "termGPA": {
+                    "average": 0,
+                    "type": {
+                      "code": "Term GPA",
+                      "description": "Term GPA"
+                    }
+                  },
+                  "termUnits": [
+                    {
+                      "type": {
+                        "code": "Total",
+                        "description": "Total"
+                      },
+                      "unitsEnrolled": 4,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsOther": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTest": 0,
+                      "unitsTransferAccepted": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "code": "For GPA",
+                        "description": "For GPA"
+                      },
+                      "unitsEnrolled": 4,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    },
+                    {
+                      "type": {
+                        "code": "Not For GPA",
+                        "description": "Not For GPA"
+                      },
+                      "unitsEnrolled": 0,
+                      "unitsIncomplete": 0,
+                      "unitsMax": 0,
+                      "unitsMin": 0,
+                      "unitsPassed": 0,
+                      "unitsTaken": 0,
+                      "unitsTransferEarned": 0,
+                      "unitsWaitlisted": 0
+                    }
+                  ],
+                  "withdrawalCancel": {}
+                },
+                "studentCareer": {
+                  "academicCareer": {
+                    "code": "UCBX",
+                    "description": "UCB Ext",
+                    "formalDescription": "UC Berkeley Extension",
+                    "fromDate": "2018-01-09"
+                  },
+                  "fromDate": "2018-01-09",
+                  "matriculation": {
+                    "term": {
+                      "id": "2182",
+                      "name": "2018 Spring"
+                    },
+                    "type": {
+                      "code": "NON",
+                      "description": "Non Degree/Course Work Only"
+                    }
+                  }
+                },
+                "studentPlans": [
+                  {
+                    "academicPlan": {
+                      "academicProgram": {
+                        "academicCareer": {
+                          "code": "UCBX",
+                          "description": "UCB Ext",
+                          "formalDescription": "UC Berkeley Extension",
+                          "fromDate": "2018-01-09"
+                        },
+                        "program": {
+                          "code": "XCCRT",
+                          "description": "UCBX Concurrent Enrollment"
+                        }
+                      },
+                      "cipCode": "",
+                      "hegisCode": "",
+                      "ownedBy": {
+                        "administrativeOwners": [
+                          {
+                            "organization": {
+                              "code": "UCB01",
+                              "description": "UC Berkeley"
+                            },
+                            "percentage": 100
+                          }
+                        ]
+                      },
+                      "plan": {
+                        "code": "30XCECCENX",
+                        "description": "UCBX Concurrent Enrollment",
+                        "fromDate": "2017-12-06"
+                      },
+                      "targetDegree": {},
+                      "type": {
+                        "code": "SS",
+                        "description": "Major - Self-Supporting"
+                      }
+                    },
+                    "primary": true,
+                    "statusInPlan": {
+                      "action": {
+                        "code": "MATR",
+                        "description": "Matriculation"
+                      },
+                      "reason": {
+                        "code": "NEW",
+                        "description": "New Admits"
+                      },
+                      "status": {
+                        "code": "AC",
+                        "description": "Active in Program"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "cumulativeGPA": {
                   "average": 3.7999999999999998,
                   "source": "UCB",
                   "type": {

--- a/tests/test_externals/test_sis_student_api.py
+++ b/tests/test_externals/test_sis_student_api.py
@@ -9,11 +9,13 @@ class TestSisStudentApi:
     def test_get_student(self, app):
         """returns unwrapped data"""
         student = student_api.get_student(11667051)
-        assert student['academicStatuses'][0]['cumulativeGPA']['average'] == pytest.approx(3.8, 0.01)
-        assert student['academicStatuses'][0]['currentRegistration']['academicLevel']['level']['description'] == 'Junior'
-        assert student['academicStatuses'][0]['currentRegistration']['athlete'] is True
-        assert student['academicStatuses'][0]['studentPlans'][0]['academicPlan']['plan']['description'] == 'English BA'
-        assert student['academicStatuses'][0]['termsInAttendance'] == 5
+        assert len(student['academicStatuses']) == 2
+        assert student['academicStatuses'][0]['currentRegistration']['academicCareer']['code'] == 'UCBX'
+        assert student['academicStatuses'][1]['cumulativeGPA']['average'] == pytest.approx(3.8, 0.01)
+        assert student['academicStatuses'][1]['currentRegistration']['academicLevel']['level']['description'] == 'Junior'
+        assert student['academicStatuses'][1]['currentRegistration']['athlete'] is True
+        assert student['academicStatuses'][1]['studentPlans'][0]['academicPlan']['plan']['description'] == 'English BA'
+        assert student['academicStatuses'][1]['termsInAttendance'] == 5
         assert student['emails'][0]['emailAddress'] == 'oski@berkeley.edu'
 
     def test_inner_get_student(self, app):

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -54,3 +54,8 @@ class TestSisProfile:
                 majors = [row.major for row in student_major_rows]
                 assert 'English BA' in majors
                 assert 'Hungarian BA' in majors
+
+    def test_skips_concurrent_academic_status(self, app):
+        """skips concurrent academic status"""
+        profile = merge_sis_profile('11667051')
+        assert profile['academicCareer'] == 'UGRD'


### PR DESCRIPTION
See https://jira.ets.berkeley.edu/jira/browse/BOAC-334 for rationale on why skipping this part of the feed is probably better than trying to fold it in.
