### PR TITLE
BOAC-275 Set service role in .ebextensions

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -26,6 +26,7 @@ option_settings:
 
   aws:elasticbeanstalk:environment:
     LoadBalancerType: application
+    ServiceRole: aws-elasticbeanstalk-service-role
 
   # Sticky sessions.
   aws:elasticbeanstalk:environment:process:default:


### PR DESCRIPTION
Managed updates seem to require this setting - see tail end of https://jira.ets.berkeley.edu/jira/browse/BOAC-275.