### PR TITLE
BOAC-355, install node before npm install > gulp dist

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -2,7 +2,13 @@
 # Apache configuration files and keys.
 #
 commands:
-  01_static_assets:
+  01_install_npm:
+    cwd: /tmp
+    # Do nothing if node is already installed
+    test: '[ ! -f /usr/bin/node ] && echo "node not installed"'
+    command: 'yum install -y nodejs npm --enablerepo=epel'
+
+  02_static_assets:
     command: |
       sudo npm install
       sudo ./node_modules/.bin/gulp dist


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-355

I've added same snippet used in bower_install step.

See failed deploy due to 'node not found': https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/boac-dev