### PR TITLE
BOAC-355, 'npm install -g gulp' to avoid command not found

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -11,7 +11,8 @@ commands:
   02_static_assets:
     command: |
       sudo npm install
-      sudo ./node_modules/.bin/gulp dist
+      sudo npm install -g gulp
+      sudo gulp dist
 
 files:
   # Proxy SSL connections to port 80


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-355

Follow up to PR #298  
See [latest CP deploy failure](https://us-west-2.console.aws.amazon.com/codepipeline/home?region=us-west-2#/view/boac-dev)

If this does not fix the problem then I intend to revert the commits to unblock boac-dev.