### PR TITLE
BOAC-355, gulp dist --allow-root in same block as other npm installs

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -1,19 +1,6 @@
 #
 # Apache configuration files and keys.
 #
-commands:
-  01_install_npm:
-    cwd: /tmp
-    # Do nothing if node is already installed
-    test: '[ ! -f /usr/bin/node ] && echo "node not installed"'
-    command: 'yum install -y nodejs npm --enablerepo=epel'
-
-  02_static_assets:
-    command: |
-      sudo npm install
-      sudo npm install -g gulp
-      sudo gulp dist
-
 files:
   # Proxy SSL connections to port 80
   /etc/httpd/conf.d/ssl.conf:

--- a/.ebextensions/12_bower_install.config
+++ b/.ebextensions/12_bower_install.config
@@ -13,3 +13,9 @@ container_commands:
       sudo npm install -g bower
       sudo bower cache clean --allow-root
       sudo bower install --allow-root
+
+  03_gulp_dist:
+    command: |
+      sudo npm install
+      sudo npm install -g gulp
+      sudo gulp dist --allow-root

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,6 +30,7 @@ artifacts:
   - 'bower.json'
   - 'config/**/*'
   - 'fixtures/**/*'
+  - 'gulpfile.js'
   - 'package.json'
   - 'requirements.txt'
   - 'run.py'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-355

Okay, one last try – I'm hoping `--allow-root` is the secret sauce. And, I neglected to include necessary `gulpfile.js` in buildspec.

If does not work, I'll revert, set up my own pipeline, get it right and then submit proper PR.