### PR TITLE
BOAC-370, order by group_name, not group_code

### DIFF
--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -41,6 +41,12 @@ womens_field_hockey = {
     'team_code': 'FHW',
     'team_name': 'Women\'s Field Hockey',
 }
+mens_baseball = {
+    'group_code': 'MBB-AA',
+    'group_name': 'Men\'s Baseball',
+    'team_code': 'MBB',
+    'team_name': 'Men\'s Baseball',
+}
 mens_tennis = {
     'group_code': 'MTE-AA',
     'group_name': 'Men\'s Tennis',
@@ -112,6 +118,7 @@ def create_student(sid, uid, first_name, last_name, team_groups, gpa, level, uni
 def load_student_athletes():
     fdb = create_team_group(football_defensive_backs)
     fdl = create_team_group(football_defensive_line)
+    mbb = create_team_group(mens_baseball)
     mt = create_team_group(mens_tennis)
     wfh = create_team_group(womens_field_hockey)
     wt = create_team_group(womens_tennis)
@@ -169,6 +176,17 @@ def load_student_athletes():
         level='Senior',
         units=102,
         majors=['Letters & Sci Undeclared UG'])
+    create_student(
+        uid='1049291',
+        sid='7890123456',
+        first_name='Paul',
+        last_name='Farestveit',
+        team_groups=[mbb],
+        gpa='3.90',
+        level='Senior',
+        units=110,
+        majors=['History BA'],
+        in_intensive_cohort=True)
     std_commit(allow_test_environment=True)
 
 

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -51,12 +51,13 @@ class Student(Base):
         if not only_total_student_count:
             # Next, get matching students per order_by, offset, limit
             o = 's.first_name'
-            if order_by in ['first_name', 'in_intensive_cohort', 'last_name']:
-                o = f's.{order_by}'
-            elif order_by in ['group_code']:
-                o = f'sa.{order_by}'
-            elif order_by in ['level']:
+            if order_by == 'level':
+                # Sort by an implicit value, not a column in db
                 o = 'ol.ordinal'
+            elif order_by in ['group_name']:
+                o = f'a.{order_by}'
+            elif order_by in ['first_name', 'in_intensive_cohort', 'last_name']:
+                o = f's.{order_by}'
             elif order_by in ['gpa', 'units']:
                 o = f'n.{order_by}'
             elif order_by in ['major']:
@@ -92,6 +93,7 @@ class Student(Base):
             FROM students s
                 JOIN normalized_cache_students n ON n.sid = s.sid
                 LEFT JOIN student_athletes sa ON sa.sid = s.sid
+                LEFT JOIN athletics a ON a.group_code = sa.group_code
                 LEFT JOIN normalized_cache_student_majors m ON m.sid = s.sid
                 LEFT JOIN (VALUES
                     (1, 'Freshman'),

--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -66,7 +66,7 @@
       options: [
         {value: 'first_name', label: 'First Name'},
         {value: 'last_name', label: 'Last Name'},
-        {value: 'group_code', label: 'Team'},
+        {value: 'group_name', label: 'Team'},
         {value: 'gpa', label: 'GPA'},
         {value: 'level', label: 'Level'},
         {value: 'major', label: 'Major'},

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -30,23 +30,29 @@ class TestAthletics:
         group_codes = [team_group['groupCode'] for team_group in team_groups]
         group_names = [team_group['groupName'] for team_group in team_groups]
         total_member_counts = [team_group['totalMemberCount'] for team_group in team_groups]
-        assert ['MFB-DB', 'MFB-DL', 'MTE-AA', 'WFH-AA', 'WTE-AA'] == group_codes
-        assert ['Football, Defensive Backs', 'Football, Defensive Line', 'Men\'s Tennis', 'Women\'s Field Hockey',
-                'Women\'s Tennis'] == group_names
-        assert [2, 3, 1, 1, 1] == total_member_counts
+        assert ['MFB-DB', 'MFB-DL', 'MBB-AA', 'MTE-AA', 'WFH-AA', 'WTE-AA'] == group_codes
+        assert [
+            'Football, Defensive Backs',
+            'Football, Defensive Line',
+            'Men\'s Baseball',
+            'Men\'s Tennis',
+            'Women\'s Field Hockey',
+            'Women\'s Tennis',
+        ] == group_names
+        assert [2, 3, 1, 1, 1, 1] == total_member_counts
 
     def test_get_all_teams(self, authenticated_session, client):
         """returns all teams if authenticated"""
         response = client.get('/api/teams/all')
         assert response.status_code == 200
         teams = response.json
-        assert len(teams) == 4
+        assert len(teams) == 5
         team_codes = [team['code'] for team in teams]
         team_names = [team['name'] for team in teams]
         total_member_counts = [team['totalMemberCount'] for team in teams]
-        assert ['FBM', 'TNM', 'FHW', 'TNW'] == team_codes
-        assert ['Football', 'Men\'s Tennis', 'Women\'s Field Hockey', 'Women\'s Tennis'] == team_names
-        assert [3, 1, 1, 1] == total_member_counts
+        assert ['FBM', 'MBB', 'TNM', 'FHW', 'TNW'] == team_codes
+        assert ['Football', 'Men\'s Baseball', 'Men\'s Tennis', 'Women\'s Field Hockey', 'Women\'s Tennis'] == team_names
+        assert [3, 1, 1, 1, 1] == total_member_counts
         football = teams[0]
         assert football['code'] == 'FBM'
         assert football['name'] == 'Football'
@@ -103,7 +109,7 @@ class TestAthletics:
         expected = {
             'first_name': ['2345678901', '3456789012', '5678901234'],
             'gpa': ['3456789012', '2345678901', '5678901234'],
-            'group_code': ['2345678901', '5678901234', '3456789012'],
+            'group_name': ['2345678901', '5678901234', '3456789012'],
             'last_name': ['2345678901', '5678901234', '3456789012'],
             'level': ['2345678901', '3456789012', '5678901234'],
             'major': ['3456789012', '2345678901', '5678901234'],

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -102,25 +102,25 @@ class TestCohortDetail:
         assert cohort['code'] == 'intensive'
         assert cohort['label'] == 'Intensive'
         assert 'members' in cohort
-        assert cohort['totalMemberCount'] == len(cohort['members']) == 3
+        assert cohort['totalMemberCount'] == len(cohort['members']) == 4
         assert 'teamGroups' not in cohort
 
     def test_order_by_with_intensive_cohort(self, authenticated_session, client):
         """returns the canned 'intensive' cohort, available to all authenticated users"""
         all_expected_order = {
-            'first_name': ['61889', '1022796', '242881'],
-            'gpa': ['1022796', '242881', '61889'],
-            'group_code': ['242881', '61889', '1022796'],
-            'last_name': ['1022796', '242881', '61889'],
-            'level': ['1022796', '242881', '61889'],
-            'major': ['1022796', '61889', '242881'],
-            'units': ['61889', '1022796', '242881'],
+            'first_name': ['61889', '1022796', '1049291', '242881'],
+            'gpa': ['1022796', '242881', '1049291', '61889'],
+            'group_name': ['242881', '1049291', '61889', '1022796'],
+            'last_name': ['1022796', '1049291', '242881', '61889'],
+            'level': ['1022796', '242881', '1049291', '61889'],
+            'major': ['1022796', '61889', '242881', '1049291'],
+            'units': ['61889', '1022796', '242881', '1049291'],
         }
         for order_by, expected_uid_list in all_expected_order.items():
             response = client.get(f'/api/intensive_cohort?orderBy={order_by}')
             assert response.status_code == 200, f'Non-200 response where order_by={order_by}'
             cohort = json.loads(response.data)
-            assert cohort['totalMemberCount'] == 3, f'Wrong count where order_by={order_by}'
+            assert cohort['totalMemberCount'] == 4, f'Wrong count where order_by={order_by}'
             uid_list = [s['uid'] for s in cohort['members']]
             assert uid_list == expected_uid_list, f'Unmet expectation where order_by={order_by}'
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -11,7 +11,7 @@ class TestStudents:
         response = client.get('/api/students/all')
         assert response.status_code == 200
         # We have one student not on a team
-        assert len(response.json) == 5
+        assert len(response.json) == 6
 
     def test_multiple_teams(self, client):
         """includes multiple team memberships"""

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -45,12 +45,12 @@ class TestSisProfile:
                 merge_sis_profile('11667051')
 
                 student_rows = NormalizedCacheStudent.query.all()
-                assert len(student_rows) == 5
-                assert student_rows[4].sid == '11667051'
-                assert student_rows[4].level == 'Senior'
+                assert len(student_rows) == 6
+                assert student_rows[-1].sid == '11667051'
+                assert student_rows[-1].level == 'Senior'
 
                 student_major_rows = NormalizedCacheStudentMajor.query.all()
-                assert len(student_major_rows) == 7
+                assert len(student_major_rows) == 8
                 majors = [row.major for row in student_major_rows]
                 assert 'English BA' in majors
                 assert 'Hungarian BA' in majors


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-370

Most of the diff is under `tests`.  Front-end no longer passes 'group_code'.