### PR TITLE
BOAC-360, Angular ui-bootstrap needs menu-options in DOM for auto-close=outsideClick to work

### DIFF
--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -64,7 +64,7 @@
             class="cohort-filter-list dropdown-menu"
             role="menu"
             uib-dropdown-menu
-            data-ng-if="!isLoading && !isSaving">
+            data-ng-show="!isLoading && !isSaving">
           <li class="cohort-filter-list-item"
               role="menuitem"
               data-ng-repeat="teamGroup in search.options.teamGroups">
@@ -105,7 +105,7 @@
             class="cohort-filter-list dropdown-menu"
             role="menu"
             uib-dropdown-menu
-            data-ng-if="!isLoading && !isSaving">
+            data-ng-show="!isLoading && !isSaving">
           <li class="cohort-filter-list-item"
               role="menuitem"
               data-ng-repeat="level in search.options.levels">
@@ -146,7 +146,7 @@
             class="cohort-filter-list dropdown-menu"
             role="menu"
             uib-dropdown-menu
-            data-ng-if="!isLoading && !isSaving">
+            data-ng-show="!isLoading && !isSaving">
           <li class="cohort-filter-list-item"
               role="menuitem"
               data-ng-repeat="major in search.options.majors">
@@ -187,7 +187,7 @@
             class="cohort-filter-list dropdown-menu"
             role="menu"
             uib-dropdown-menu
-            data-ng-if="!isLoading && !isSaving">
+            data-ng-show="!isLoading && !isSaving">
           <li class="cohort-filter-list-item"
               role="menuitem"
               data-ng-repeat="gpaRange in search.options.gpaRanges">
@@ -228,7 +228,7 @@
             class="cohort-filter-list dropdown-menu"
             role="menu"
             uib-dropdown-menu
-            data-ng-if="!isLoading && !isSaving">
+            data-ng-show="!isLoading && !isSaving">
           <!-- Pacing units -->
           <li class="cohort-filter-list-section-label" role="menuitem">Pacing (Total)</li>
           <li class="cohort-filter-list-item"

--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -20,9 +20,9 @@
   ) {
 
     /**
-     * Used to collapse all dropdown menus (e.g., if user clicks 'Search').
+     * Control show/hide of dropdowns: true -> show, false -> hide
      *
-     * @return {Object}      One entry per dropdown/filter.
+     * @return {Object}                Each filter dropdown (unique key) has state (true/false)
      */
     var defaultDropdownState = function() {
       return {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-360

`auto-close=outsideClick` works on initial page load cuz DOM is in order. But, due to `ng-if`, the DOM is tweaked post-search and a click on menu-options is seen as an "outsideClick".