### PR TITLE
BOAC-332 Integrate authentication with ui-router

### DIFF
--- a/boac/static/app/auth/authFactory.js
+++ b/boac/static/app/auth/authFactory.js
@@ -2,7 +2,7 @@
 
   'use strict';
 
-  angular.module('boac').factory('authFactory', function($http, $rootScope) {
+  angular.module('boac').factory('authFactory', function($http, $rootScope, $state) {
 
     var loadUserProfile = function(results) {
       // Refresh instance currently referenced in templates
@@ -18,10 +18,6 @@
       return results;
     };
 
-    var refreshStatus = function() {
-      return $http.get('/api/status').then(loadUserProfile);
-    };
-
     var casLogIn = function() {
       return $http.get('/cas/login_url').then(function(results) {
         window.location = results.data.cas_login_url;
@@ -35,12 +31,10 @@
       };
       return $http.post('/devauth/login', credentials).then(
         function successCallback() {
-          refreshStatus().then(function() {
-            $rootScope.$broadcast('userStatusChange');
-          });
+          $state.go('landing', {}, {reload: true});
         },
         function errorCallback() {
-          $rootScope.$broadcast('authenticationFailure');
+          $rootScope.$broadcast('devAuthFailure');
           $rootScope.me = null;
         });
     };

--- a/boac/static/app/auth/authService.js
+++ b/boac/static/app/auth/authService.js
@@ -2,41 +2,26 @@
 
   'use strict';
 
-  angular.module('boac').service('authService', function(authFactory, googleAnalyticsService, $http, $location, $rootScope, $state) {
+  angular.module('boac').service('authService', function(authFactory, googleAnalyticsService, $http, $location, $rootScope) {
 
     var isAuthenticatedUser = function() {
       return $rootScope.me && $rootScope.me.authenticated_as.is_authenticated;
     };
 
-    var init = function() {
-      $http.get('/api/status').then(authFactory.loadUserProfile).then(function() {
+    var reloadMe = function() {
+      return $http.get('/api/status').then(authFactory.loadUserProfile).then(function() {
         var me = $rootScope.me.authenticated_as;
         if (me.is_authenticated && $location.search().casLogin) {
           // Track CAS login event
           googleAnalyticsService.track('user', 'login', me.uid, parseInt(me.uid, 10));
         }
-        if (!$state.current.isPublic && !me.is_authenticated) {
-          $location.path('/');
-          $location.replace();
-        }
+        return me;
       });
     };
 
-    var authWrap = function(controllerMain) {
-      var decoratedFunction = function() {
-        if (isAuthenticatedUser()) {
-          controllerMain();
-        }
-      };
-      $rootScope.$on('userStatusChange', decoratedFunction);
-      return decoratedFunction;
-    };
-
-    init();
-
     return {
-      authWrap: authWrap,
-      isAuthenticatedUser: isAuthenticatedUser
+      isAuthenticatedUser: isAuthenticatedUser,
+      reloadMe: reloadMe
     };
   });
 

--- a/boac/static/app/cohort/allCohortsController.js
+++ b/boac/static/app/cohort/allCohortsController.js
@@ -2,7 +2,7 @@
 
   'use strict';
 
-  angular.module('boac').controller('AllCohortsController', function(authService, cohortFactory, $scope) {
+  angular.module('boac').controller('AllCohortsController', function(cohortFactory, $scope) {
 
     $scope.isLoading = true;
     $scope.isEmpty = _.isEmpty;
@@ -14,7 +14,7 @@
       });
     };
 
-    authService.authWrap(init)();
+    init();
   });
 
 }(window.angular));

--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -3,7 +3,6 @@
   'use strict';
 
   angular.module('boac').controller('CohortController', function(
-    authService,
     boxplotService,
     cohortFactory,
     cohortService,
@@ -450,7 +449,7 @@
      *
      * @return {void}
      */
-    var init = authService.authWrap(function() {
+    var init = function() {
       var args = _.clone($location.search());
       // Create-new-cohort mode if code='new'. Search-mode (ie, unsaved cohort) if code='search'.
       var code = $scope.cohort.code || args.c || 'search';
@@ -504,7 +503,7 @@
           }
         });
       });
-    });
+    };
 
     /**
      * Reload page with newly created cohort.

--- a/boac/static/app/cohort/manageCohortsController.js
+++ b/boac/static/app/cohort/manageCohortsController.js
@@ -101,7 +101,7 @@
       });
     });
 
-    authService.authWrap(init)();
+    init();
   });
 
 }(window.angular));

--- a/boac/static/app/landing/landing.html
+++ b/boac/static/app/landing/landing.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div data-ng-include="'/static/app/shared/header.html'"></div>
 
-  <div class="body-text" data-ng-if="me.authenticated_as.is_authenticated">
+  <div class="body-text" data-ng-if="isAuthenticated">
     <h1>My Dashboard</h1>
 
     <div class="flex-container-wrap-reverse">
@@ -45,15 +45,15 @@
       </div>
     </div>
   </div>
-  <div class="body-text" data-ng-if="!me.authenticated_as.is_authenticated">
+  <div class="body-text" data-ng-if="!isAuthenticated">
     <h1>Welcome to BOAC</h1>
     <div data-ng-bind="alertMessage || 'Please sign in.'"></div>
   </div>
 
-  <div class="loading-spinner-large" data-ng-if="me.authenticated_as.is_authenticated && isLoading">
+  <div class="loading-spinner-large" data-ng-if="isAuthenticated && isLoading">
     <i class="fa fa-refresh fa-spin fa-5x fa-fw"></i>
     <span class="sr-only">Loading...</span>
   </div>
 
-  <div data-ng-include="'/static/app/shared/footer.html'" data-ng-if="!me.authenticated_as.is_authenticated || !isLoading"></div>
+  <div data-ng-include="'/static/app/shared/footer.html'" data-ng-if="!isAuthenticated || !isLoading"></div>
 </div>

--- a/boac/static/app/landing/landingController.js
+++ b/boac/static/app/landing/landingController.js
@@ -5,23 +5,28 @@
   angular.module('boac').controller('LandingController', function(authService, cohortFactory, $rootScope, $scope) {
 
     $scope.isLoading = true;
+    $scope.isAuthenticated = authService.isAuthenticatedUser();
 
     var init = function() {
-      cohortFactory.getTeams().then(function(teamsResponse) {
-        $scope.teams = teamsResponse.data;
+      if ($scope.isAuthenticated) {
+        cohortFactory.getTeams().then(function(teamsResponse) {
+          $scope.teams = teamsResponse.data;
 
-        cohortFactory.getMyCohorts().then(function(response) {
-          $scope.myCohorts = response.data;
-          $scope.isLoading = false;
+          cohortFactory.getMyCohorts().then(function(response) {
+            $scope.myCohorts = response.data;
+            $scope.isLoading = false;
+          });
         });
-      });
+      } else {
+        $scope.isLoading = false;
+      }
     };
 
-    $rootScope.$on('authenticationFailure', function() {
+    $rootScope.$on('devAuthFailure', function() {
       $scope.alertMessage = 'Log in failed. Please try again.';
     });
 
-    authService.authWrap(init)();
+    init();
   });
 
 }(window.angular));

--- a/boac/static/app/routes.js
+++ b/boac/static/app/routes.js
@@ -2,8 +2,7 @@
 
   'use strict';
 
-  angular.module('boac').config(function($locationProvider, $stateProvider, $urlRouterProvider) {
-
+  angular.module('boac').config(function($locationProvider, $qProvider, $stateProvider, $urlRouterProvider) {
     /**
      * Use the HTML5 location provider to ensure that the $location service getters
      * and setters interact with the browser URL address through the HTML5 history API
@@ -12,6 +11,35 @@
       enabled: true,
       requireBase: false
     });
+
+    // Authentication dependency for all states, public and private; get current user if any.
+    var resolveMe = function(authService, $q) {
+      var deferred = $q.defer();
+      authService.reloadMe().then(function(me) {
+        deferred.resolve(me);
+      });
+      return deferred.promise;
+    };
+
+    // Authentication dependency for private states only; return a rejection if authenticated user not present.
+    var resolveAuthentication = function(me, $q) {
+      var deferred = $q.defer();
+      if (me.is_authenticated) {
+        deferred.resolve({});
+      } else {
+        deferred.reject({message: 'unauthenticated'});
+      }
+      return deferred.promise;
+    };
+
+    var resolvePublic = {
+      me: resolveMe
+    };
+
+    var resolvePrivate = {
+      me: resolveMe,
+      authentication: resolveAuthentication
+    };
 
     // Default route
     $urlRouterProvider.otherwise('/');
@@ -22,30 +50,41 @@
         url: '/',
         templateUrl: '/static/app/landing/landing.html',
         controller: 'LandingController',
-        isPublic: true
+        resolve: resolvePublic
       })
       .state('cohort', {
         url: '/cohort?c',
         templateUrl: '/static/app/cohort/cohort.html',
         controller: 'CohortController',
+        resolve: resolvePrivate,
         reloadOnSearch: false
       })
       .state('allCohorts', {
         url: '/cohorts/all',
         templateUrl: '/static/app/cohort/all.html',
-        controller: 'AllCohortsController'
+        controller: 'AllCohortsController',
+        resolve: resolvePrivate
       })
       .state('manageCohorts', {
         url: '/cohorts/manage',
         templateUrl: '/static/app/cohort/manageCohorts.html',
-        controller: 'ManageCohortsController'
+        controller: 'ManageCohortsController',
+        resolve: resolvePrivate
       })
       .state('user', {
         url: '/student/:uid?r',
         templateUrl: '/static/app/student/student.html',
         controller: 'StudentController',
+        resolve: resolvePrivate,
         reloadOnSearch: false
       });
+
+  }).run(function($rootScope, $state) {
+    $rootScope.$on('$stateChangeError', function(event, toState, toParams, fromState, fromParams, error) {
+      if (error.message === 'unauthenticated') {
+        $state.go('landing', {}, {reload: true});
+      }
+    });
   });
 
 }(window.angular));

--- a/boac/static/app/student/studentController.js
+++ b/boac/static/app/student/studentController.js
@@ -41,11 +41,11 @@
       }
     };
 
-    var init = authService.authWrap(function() {
+    var init = function() {
       var uid = $stateParams.uid;
       loadAnalytics(uid);
       prepareReturnUrl(uid);
-    });
+    };
 
     $scope.student = {
       canvasProfile: null,


### PR DESCRIPTION
A robust fix for https://jira.ets.berkeley.edu/jira/browse/BOAC-332 requires introducing a pattern where login status is checked on every front-end state change. The standard way of doing this in ui-router 0.x is with resolvers:

https://github.com/angular-ui/ui-router/wiki#resolve

An advantage of the resolver pattern is that it makes authentication entirely the responsibility of routes.js, so we don't have to remember to include auth wrapping in our controllers.