### PR TITLE
BOAC-375 Keep db connection open while iterating through results

### DIFF
--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -48,7 +48,9 @@ class Student(Base):
         summary = {
             'totalStudentCount': result.fetchone()[0],
         }
-        if not only_total_student_count:
+        if only_total_student_count:
+            connection.close()
+        else:
             # Next, get matching students per order_by, offset, limit
             o = 's.first_name'
             if order_by == 'level':
@@ -67,9 +69,9 @@ class Student(Base):
             sql += f' LIMIT {limit}' if limit else ''
             # SQLAlchemy will escape parameter values
             result = connection.execute(text(sql), **all_bindings)
-            connection.close()
             # Model query using list of SIDs
             sid_list = util.get_distinct_with_order([row['sid'] for row in result])
+            connection.close()
             students = cls.query.filter(cls.sid.in_(sid_list)).all() if sid_list else []
             # Order of students from query (above) might not match order of sid_list.
             students = [next(s for s in students if s.sid == sid) for sid in sid_list]


### PR DESCRIPTION
Hard to be sure this will address https://jira.ets.berkeley.edu/jira/browse/BOAC-375, but let's give it a shot. The best guide I've found on the rather confusing SQLAlchemy connection interface is here:

https://stackoverflow.com/questions/34322471/sqlalchemy-engine-connection-and-session-difference

and the rule of thumb seems to be that the connection should stay open as long as you're directly interacting with the result set, but no longer.