### PR TITLE
BOAC-264 Update Manage Cohorts sort order on rename

### DIFF
--- a/boac/static/app/cohort/manageCohorts.html
+++ b/boac/static/app/cohort/manageCohorts.html
@@ -17,7 +17,7 @@
     <div data-ng-if="!myCohorts.length">
       You have no saved cohorts.
     </div>
-    <div data-ng-repeat="cohort in myCohorts">
+    <div data-ng-repeat="cohort in myCohorts | orderBy:'labelOriginal'">
       <hr class="flex-row-wrap-separator"/>
       <div class="flex-container flex-space-between" data-ng-if="!cohort.editMode">
         <div class="cohort-manage-label wrap-hard">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-264

Ordering by `labelOriginal` rather than `label` ensures that resorting happens only once the 'Rename' button is clicked, not while the user is typing.