### PR TITLE
BOAC-377, get_calnet_user_for_uid used by '/api/cohorts/all' and '/api/profile'

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -1,6 +1,7 @@
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
+from boac.merged import calnet
 from boac.merged import member_details
 from boac.models.cohort_filter import CohortFilter
 from boac.models.student import Student
@@ -17,7 +18,14 @@ def all_cohorts():
             if uid not in cohorts:
                 cohorts[uid] = []
             cohorts[uid].append(cohort)
-    return tolerant_jsonify(cohorts)
+    owners = []
+    for uid in cohorts.keys():
+        owner = calnet.get_calnet_user_for_uid(app, uid)
+        owner.update({
+            'cohorts': sorted(cohorts[uid], key=lambda c: c['name']),
+        })
+        owners.append(owner)
+    return tolerant_jsonify(owners)
 
 
 @app.route('/api/cohorts/my')

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -6,6 +6,7 @@ from boac.lib import util
 from boac.lib.analytics import merge_analytics_for_user
 from boac.lib.berkeley import sis_term_id_for_name
 from boac.lib.http import tolerant_jsonify
+from boac.merged import calnet
 from boac.merged import member_details
 from boac.merged.sis_enrollments import merge_sis_enrollments
 from boac.merged.sis_profile import merge_sis_profile
@@ -17,16 +18,12 @@ from flask_login import current_user, login_required
 
 @app.route('/api/profile')
 def user_profile():
-    canvas_profile = False
+    profile = {
+        'uid': False,
+    }
     if current_user.is_active:
-        uid = current_user.get_id()
-        canvas_profile = load_canvas_profile(uid)
-    else:
-        uid = False
-    return tolerant_jsonify({
-        'uid': uid,
-        'canvasProfile': canvas_profile,
-    })
+        profile = calnet.get_calnet_user_for_uid(app, current_user.get_id())
+    return tolerant_jsonify(profile)
 
 
 @app.route('/api/students/all')

--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -1,6 +1,18 @@
 from boac import std_commit
 from boac.externals import calnet
+from boac.models.json_cache import stow
 from boac.models.student import Student
+
+
+@stow('calnet_user_for_uid_{uid}')
+def get_calnet_user_for_uid(app, uid):
+    persons = calnet.client(app).search_uids([uid])
+    p = persons[0] if len(persons) > 0 else None
+    return {
+        'uid': uid,
+        'firstName': p and p['first_name'],
+        'lastName': p and p['last_name'],
+    }
 
 
 def refresh_cohort_attributes(app, cohorts=None):

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -15,26 +15,25 @@ class AuthorizedUser(Base, UserMixin):
 
     id = db.Column(db.Integer, nullable=False, primary_key=True)
     uid = db.Column(db.String(255), nullable=False, unique=True)
-    is_advisor = db.Column(db.Boolean)
     is_admin = db.Column(db.Boolean)
+    is_advisor = db.Column(db.Boolean)
     is_director = db.Column(db.Boolean)
     cohort_filters = db.relationship('CohortFilter', secondary=cohort_filter_owners, back_populates='owners')
 
-    def __init__(self, uid, is_advisor=True, is_admin=False, is_director=False):
+    def __init__(self, uid, is_admin=False, is_advisor=True, is_director=False):
         self.uid = uid
-        self.is_advisor = is_advisor
         self.is_admin = is_admin
+        self.is_advisor = is_advisor
         self.is_director = is_director
 
     def __repr__(self):
-        return '<AuthorizedUser {}, is_advisor={}, is_admin={}, is_director={}, updated={}, created={}>'.format(
-            self.uid,
-            self.is_advisor,
-            self.is_admin,
-            self.is_director,
-            self.updated_at,
-            self.created_at,
-        )
+        return f"""<AuthorizedUser {self.uid},
+                    is_admin={self.is_admin},
+                    is_advisor={self.is_advisor},
+                    is_director={self.is_director},
+                    updated={self.updated_at},
+                    created={self.created_at}>
+                """
 
     def get_id(self):
         """Override UserMixin, since our DB conventionally reserves 'id' for generated keys."""

--- a/boac/static/app/cohort/all.html
+++ b/boac/static/app/cohort/all.html
@@ -8,15 +8,16 @@
       <div>Loading.... </div>
     </div>
     <div data-ng-if="!isLoading">
-      <div data-ng-if="isEmpty(allCohorts)">
+      <div data-ng-if="!owners.length">
         <div>There are no saved cohorts</div>
       </div>
-      <div data-ng-if="!isEmpty(allCohorts)">
+      <div data-ng-if="owners.length">
         <ul>
-          <li data-ng-repeat="(uid, cohorts) in allCohorts">
-            <span data-ng-bind="'Owned by UID ' + uid"></span>
+          <li data-ng-repeat="owner in owners">
+            <span data-ng-bind="owner.firstName"></span>
+            <span data-ng-bind="owner.lastName"></span>
             <ul>
-              <li data-ng-repeat="cohort in cohorts">
+              <li data-ng-repeat="cohort in owner.cohorts">
                 <a data-ng-bind="cohort.label" data-ng-href="/cohort?c={{cohort.id}}"></a>
                 (<span data-ng-bind="cohort.totalMemberCount"></span>)
               </li>

--- a/boac/static/app/cohort/allCohortsController.js
+++ b/boac/static/app/cohort/allCohortsController.js
@@ -5,11 +5,10 @@
   angular.module('boac').controller('AllCohortsController', function(cohortFactory, $scope) {
 
     $scope.isLoading = true;
-    $scope.isEmpty = _.isEmpty;
 
     var init = function() {
-      cohortFactory.getAll().then(function(allResponse) {
-        $scope.allCohorts = allResponse.data;
+      cohortFactory.getAll().then(function(response) {
+        $scope.owners = response.data;
         $scope.isLoading = false;
       });
     };

--- a/boac/static/app/shared/header.html
+++ b/boac/static/app/shared/header.html
@@ -10,7 +10,8 @@
       <find-student></find-student>
     </li>
     <li class="header-column-name" data-ng-if="me.authenticated_as.is_authenticated">
-      <span data-ng-bind="me.canvasProfile.name"></span>
+      <span data-ng-bind="me.firstName"></span>
+      <span data-ng-bind="me.lastName"></span>
     </li>
     <li class="flex-column-right" data-ng-controller="AuthController">
       <button id="header-sign-in"

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -26,6 +26,19 @@ class TestCohortDetail:
         assert 'totalMemberCount' in cohorts[0]
         assert len(cohorts[1]['teamGroups']) == 1
 
+    def test_cohorts_all(self, authenticated_session, client):
+        """returns all cohorts per owner"""
+        response = client.get('/api/cohorts/all')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert len(data) == 2
+        oliver = data[0]
+        assert oliver['uid'] == '2040'
+        assert 'firstName' in oliver and 'lastName' in oliver
+        cohorts = oliver['cohorts']
+        assert len(cohorts) == 3
+        assert [1, 3, 2] == [cohort['id'] for cohort in cohorts]
+
     def test_get_cohort(self, authenticated_session, client):
         """returns a well-formed response with custom cohort"""
         user = AuthorizedUser.find_by_uid(test_uid)

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -39,13 +39,16 @@ class TestUserProfile:
         response = client.get('/api/profile')
         assert response.status_code == 200
         assert response.json['uid'] == test_uid
-        assert response.json['canvasProfile'] is False
+        assert 'firstName' in response.json
+        assert 'lastName' in response.json
 
     def test_includes_canvas_profile_if_available(self, client, fake_auth):
         test_uid = '2040'
         fake_auth.login(test_uid)
         response = client.get('/api/profile')
-        assert response.json['canvasProfile']['sis_login_id'] == test_uid
+        assert response.json['uid'] == test_uid
+        assert 'firstName' in response.json
+        assert 'lastName' in response.json
 
 
 class TestUserPhoto:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-377
https://jira.ets.berkeley.edu/jira/browse/BOAC-369

Profile data of `authorized_users` is pulled from CalNet. Benefit to the customer: 'Everyone's Cohorts' page displays names, not UIDs. 