### PR TITLE
BOAC-379, flake8-docstrings, flake8-strict, flake8-tidy-imports and necessary fixes

### DIFF
--- a/boac/__init__.py
+++ b/boac/__init__.py
@@ -6,11 +6,11 @@ db = SQLAlchemy()
 
 
 def std_commit(allow_test_environment=False):
-    """Commit failures in SQLAlchemy must be explicitly handled. This function follows the suggested default,
-    which is to roll back and close the active session, letting the pooled connection start a new transaction
-    cleanly.
-    WARNING: Session closure will invalidate any in-memory DB entities. Rows will have to be reloaded from the DB
-    to be read or updated.
+    """Commit failures in SQLAlchemy must be explicitly handled.
+
+    This function follows the suggested default, which is to roll back and close the active session, letting the pooled
+    connection start a new transaction cleanly. WARNING: Session closure will invalidate any in-memory DB entities. Rows
+    will have to be reloaded from the DB to be read or updated.
     """
     # Give a hoot, don't pollute.
     if app.config['TESTING'] and not allow_test_environment:

--- a/boac/api/admin_controller.py
+++ b/boac/api/admin_controller.py
@@ -46,8 +46,7 @@ def clear_cachejob():
 @app.route('/api/admin/cachejob/load')
 @admin_required
 def start_load_only():
-    """This endpoint lets us load still-uncached data without having to erase any data which was already cached.
-    """
+    """Lets us load still-uncached data without having to erase any data which was already cached."""
     job_state = cache_utils.refresh_request_handler(term(), load_only=True)
     return tolerant_jsonify(job_state)
 

--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -14,9 +14,7 @@ def current_term_id():
 
 
 def refresh_request_handler(term_id, load_only=False):
-    """Handle a start refresh admin request, either by returning an error status or by starting the job on a
-    background thread.
-    """
+    """Handle a start refresh admin request by returning an error status or starting the job on a background thread."""
     job_state = JobProgress().get()
     if job_state is None or (not job_state['start']) or job_state['end']:
         if not load_only:
@@ -48,8 +46,10 @@ def refresh_term(term_id=current_term_id()):
 
 
 def clear_term(term_id):
-    """Deletes term-specific cache entries. When refreshing the current term, also deletes non-term-specific cache
-    entries, since they hold 'current' external data."""
+    """Delete term-specific cache entries.
+
+    When refreshing current term, also deletes non-term-specific cache entries, since they hold 'current' external data.
+    """
     term_name = berkeley.term_name_for_sis_id(term_id)
     filter = JsonCache.key.like('term_{}%'.format(term_name))
     if term_name == app.config['CANVAS_CURRENT_ENROLLMENT_TERM']:
@@ -89,9 +89,7 @@ def load_canvas_externals(uid, term_id):
 
     canvas_user_profile = canvas.get_user_for_uid(uid)
     if canvas_user_profile is None:
-        failures.append('canvas.get_user_for_uid failed for UID {}'.format(
-            uid,
-        ))
+        failures.append(f'canvas.get_user_for_uid failed for UID {uid}')
     elif canvas_user_profile:
         success_count += 1
         sites = canvas.get_student_courses(uid)
@@ -105,31 +103,21 @@ def load_canvas_externals(uid, term_id):
                     continue
                 site_id = site['id']
                 if not canvas.get_course_sections(site_id, term_id):
-                    failures.append('canvas.get_course_sections failed for UID {}, site_id {}'.format(
-                        uid,
-                        site_id,
-                    ))
+                    failures.append(f'canvas.get_course_sections failed for UID {uid}, site_id {site_id}')
                     continue
                 success_count += 1
                 if not canvas.get_student_summaries(site_id, term_id):
-                    failures.append('canvas.get_student_summaries failed for site_id {}'.format(
-                        site_id,
-                    ))
+                    failures.append(f'canvas.get_student_summaries failed for site_id {site_id}')
                     continue
                 success_count += 1
                 # This is a very time-consuming API and might have to managed separately.
                 if not canvas.get_course_enrollments(site_id, term_id):
-                    failures.append('canvas.get_course_enrollments failed for site_id {}'.format(
-                        site_id,
-                    ))
+                    failures.append(f'canvas.get_course_enrollments failed for site_id {site_id}')
                     continue
                 success_count += 1
                 # Do not treat an empty list as a failure.
                 if canvas.get_assignments_analytics(site_id, uid, term_id) is None:
-                    failures.append('canvas.get_assignments_analytics failed for UID {}, site_id {}'.format(
-                        uid,
-                        site_id,
-                    ))
+                    failures.append(f'canvas.get_assignments_analytics failed for UID {uid}, site_id {site_id}')
                     continue
                 success_count += 1
     return success_count, failures
@@ -150,24 +138,20 @@ def load_sis_externals(term_id, csid):
                 if sis_degree_progress_api.get_degree_progress(csid):
                     success_count += 1
                 else:
-                    failures.append('SIS get_degree_progresss failed for CSID {}'.format(csid))
+                    failures.append(f'SIS get_degree_progresss failed for CSID {csid}')
     else:
-        failures.append('SIS get_student failed for CSID {}'.format(csid))
+        failures.append(f'SIS get_student failed for CSID {csid}')
 
     enrollments = sis_enrollments_api.get_enrollments(csid, term_id)
     if enrollments:
         success_count += 1
     elif enrollments is None:
-        failures.append('SIS get_enrollments failed for CSID {}, term_id {}'.format(
-            csid,
-            term_id,
-        ))
+        failures.append(f'SIS get_enrollments failed for CSID {csid}, term_id {term_id}')
     return success_count, failures
 
 
 def load_merged_sis_profiles():
-    """TODO For now, pending a general refresh strategy for merged models, this sits to the side of other
-    cache loading methods."""
+    """TODO For now, pending one merged model refresh strategy, this sits to the side of other cache loading methods."""
     from boac.models.student import Student
 
     success_count = 0
@@ -178,5 +162,5 @@ def load_merged_sis_profiles():
         if sis_profile:
             success_count += 1
         else:
-            failures.append('merge_sis_profile failed for SID {}'.format(sid))
+            failures.append(f'merge_sis_profile failed for SID {sid}')
     return success_count, failures

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -78,9 +78,16 @@ def create_cohort():
     unit_ranges_pacing = util.get(params, 'unitRangesPacing')
     if not label:
         raise BadRequestError('Cohort creation requires \'label\'')
-    cohort = CohortFilter.create(uid=current_user.get_id(), label=label, gpa_ranges=gpa_ranges, group_codes=group_codes,
-                                 levels=levels, majors=majors, unit_ranges_eligibility=unit_ranges_eligibility,
-                                 unit_ranges_pacing=unit_ranges_pacing)
+    cohort = CohortFilter.create(
+        uid=current_user.get_id(),
+        label=label,
+        gpa_ranges=gpa_ranges,
+        group_codes=group_codes,
+        levels=levels,
+        majors=majors,
+        unit_ranges_eligibility=unit_ranges_eligibility,
+        unit_ranges_pacing=unit_ranges_pacing,
+    )
     return tolerant_jsonify(cohort)
 
 

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -45,9 +45,17 @@ def get_students():
     order_by = util.get(params, 'orderBy', None)
     offset = util.get(params, 'offset', 0)
     limit = util.get(params, 'limit', 50)
-    results = Student.get_students(gpa_ranges=gpa_ranges, group_codes=group_codes, levels=levels, majors=majors,
-                                   unit_ranges_eligibility=unit_ranges_eligibility,
-                                   unit_ranges_pacing=unit_ranges_pacing, order_by=order_by, offset=offset, limit=limit)
+    results = Student.get_students(
+        gpa_ranges=gpa_ranges,
+        group_codes=group_codes,
+        levels=levels,
+        majors=majors,
+        unit_ranges_eligibility=unit_ranges_eligibility,
+        unit_ranges_pacing=unit_ranges_pacing,
+        order_by=order_by,
+        offset=offset,
+        limit=limit,
+    )
     member_details.merge_all(results['students'])
     return tolerant_jsonify({
         'members': results['students'],

--- a/boac/configs.py
+++ b/boac/configs.py
@@ -3,8 +3,9 @@ import os
 
 
 def load_configs(app):
-    """
-    On app creation, load and and override configs in the following order:
+    """On app creation, load and and override configs.
+
+    Order:
      - config/default.py
      - config/{BOAC_ENV}.py
      - {BOAC_LOCAL_CONFIGS}/{BOAC_ENV}-local.py (excluded from version control; sensitive values go here)

--- a/boac/externals/cal1card_photo_api.py
+++ b/boac/externals/cal1card_photo_api.py
@@ -1,4 +1,4 @@
-"""Official access to Cal1Card photos"""
+"""Official access to Cal1Card photos."""
 
 from boac.lib import http
 from boac.lib.mockingbird import fixture

--- a/boac/externals/canvas.py
+++ b/boac/externals/canvas.py
@@ -17,9 +17,7 @@ def _get_course_sections(course_id, mock=None):
 
 @stow('canvas_user_for_uid_{uid}')
 def get_user_for_uid(uid):
-    """If the user is not found, returns False (which can be cached).
-    For any other error response, returns None (which will not be cached).
-    """
+    """If the user is not found, returns False (which can be cached). Otherwise, returns None (not cached)."""
     response = _get_user_for_uid(uid)
     if response and hasattr(response, 'json'):
         return response.json()
@@ -46,10 +44,7 @@ def get_student_courses(uid):
 
     def include_course(course):
         if course.get('enrollments'):
-            if next((e for e in course['enrollments'] if
-                     e['type'] == 'student' and
-                     e['enrollment_state'] in ['active', 'completed', 'inactive']
-                     ), None):
+            if next((e for e in course['enrollments'] if e['type'] == 'student' and e['enrollment_state'] in ['active', 'completed', 'inactive']), None):
                 return True
         return False
 
@@ -98,11 +93,15 @@ def get_course_enrollments(course_id, term_id):
 @fixture('canvas_course_enrollments_{course_id}')
 def _get_course_enrollments(course_id, mock=None):
     path = '/api/v1/courses/{course_id}/enrollments'.format(course_id=course_id)
-    return paged_request(path=path, mock=mock, query={
-        'type[]': 'StudentEnrollment',
-        # By default, Canvas will not return any students at all for completed course sites.
-        'state[]': ['active', 'completed', 'inactive'],
-    })
+    return paged_request(
+        path=path,
+        mock=mock,
+        query={
+            'type[]': 'StudentEnrollment',
+            # By default, Canvas will not return any students at all for completed course sites.
+            'state[]': ['active', 'completed', 'inactive'],
+        },
+    )
 
 
 def build_url(path, query=None):

--- a/boac/externals/import_asc_athletes.py
+++ b/boac/externals/import_asc_athletes.py
@@ -43,11 +43,7 @@ SPORT_TRANSLATIONS = {
 def load_csv(app, csv_file='tmp/FilteredAscStudents.csv'):
     with open(csv_file) as f:
         athletics, students = load_student_athletes(app, csv.DictReader(f))
-        app.logger.info('{} rows added to \'athletics\' table; {} rows added to \'students\' table; CSV file: {}'.format(
-            len(athletics),
-            len(students),
-            csv_file,
-        ))
+        app.logger.info(f'{len(athletics)} rows added to \'athletics\' table; {len(students)} rows added to \'students\' table; CSV file: {csv_file}')
 
 
 def load_student_athletes(app, rows):

--- a/boac/externals/sis_athlete_api.py
+++ b/boac/externals/sis_athlete_api.py
@@ -1,4 +1,4 @@
-"""Official access to team memberships"""
+"""Official access to team memberships."""
 
 from boac.lib import http
 from boac.models.json_cache import stow

--- a/boac/externals/sis_degree_progress_api.py
+++ b/boac/externals/sis_degree_progress_api.py
@@ -1,4 +1,4 @@
-"""Official access to undergraduate degree progress"""
+"""Official access to undergraduate degree progress."""
 
 from boac.lib import http
 from boac.lib.mockingbird import fixture

--- a/boac/externals/sis_enrollments_api.py
+++ b/boac/externals/sis_enrollments_api.py
@@ -1,4 +1,4 @@
-"""Official access to student enrollment data"""
+"""Official access to student enrollment data."""
 
 from boac.lib import http
 from boac.lib.mockingbird import fixture

--- a/boac/externals/sis_student_api.py
+++ b/boac/externals/sis_student_api.py
@@ -1,4 +1,4 @@
-"""Official access to student data"""
+"""Official access to student data."""
 
 from boac.lib import http
 from boac.lib.mockingbird import fixture

--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -42,7 +42,7 @@ def mean_course_analytics_for_user(user_courses, uid, canvas_user_id, term_id):
 
 
 def analytics_from_summary_feed(summary_feed, canvas_user_id, canvas_course_id):
-    """Given a student summary feed for a Canvas course, return analytics for a given user"""
+    """Given a student summary feed for a Canvas course, return analytics for a given user."""
     # TODO Remove misleading tardiness_breakdown stats.
     df = pandas.DataFrame(summary_feed, columns=['id', 'page_views', 'participations', 'tardiness_breakdown'])
     df['on_time'] = [row['on_time'] for row in df['tardiness_breakdown']]
@@ -91,10 +91,13 @@ def analytics_from_canvas_course_assignments(feed):
         data['assignmentTotals'][total_type] += 1
 
         # If there is no submission, the Canvas API may return a nil-valued 'submission' property or may leave it out.
-        submission = assignment.get('submission', {
-            'score': None,
-            'submitted_at': None,
-        })
+        submission = assignment.get(
+            'submission',
+            {
+                'score': None,
+                'submitted_at': None,
+            },
+        )
 
         assignment_data = {
             'name': assignment['title'],
@@ -183,12 +186,13 @@ def ordinal(nbr):
 
 
 def quantiles(series, count):
-    """Return a given number of evenly spaced quantiles for a given series"""
+    """Return a given number of evenly spaced quantiles for a given series."""
     return [round(series.quantile(n / count)) for n in range(0, count + 1)]
 
 
 def rounded_up_percentile(dataframe, student_row):
     """Given a dataframe and an individual student row, return a more easily understood meaning of percentile.
+
     Z-score percentile is useful in a scatterplot to spot outliers in the overall population across contexts.
     (If 90% of the course's students received a score of '5', then one student with a '5' is not called out.)
     Rounded-up matches what non-statisticians would expect when viewing one particular student in one
@@ -201,7 +205,7 @@ def rounded_up_percentile(dataframe, student_row):
 
 
 def zptile(z_score):
-    """Derive percentile from zscore"""
+    """Derive percentile from zscore."""
     if z_score is None:
         return None
     else:
@@ -209,7 +213,7 @@ def zptile(z_score):
 
 
 def zscore(dataframe, value):
-    """Given a dataframe and an individual value, return a zscore"""
+    """Given a dataframe and an individual value, return a zscore."""
     if dataframe.std(ddof=0) == 0:
         return None
     else:

--- a/boac/lib/http.py
+++ b/boac/lib/http.py
@@ -36,8 +36,8 @@ def get_next_page(response):
 
 
 def request(url, headers={}, auth=None):
-    """
-    Exception and error catching wrapper for outgoing HTTP requests.
+    """Exception and error catching wrapper for outgoing HTTP requests.
+
     :param url:
     :param headers:
     :return: The HTTP response from the external server, if the request was successful.

--- a/boac/lib/mockingbird.py
+++ b/boac/lib/mockingbird.py
@@ -20,8 +20,9 @@ A test function can temporarily substitute custom mock behavior with the registe
 
 
 class MockResponse:
-    """A callable object that can be passed into httpretty's register_uri method with the 'body' keyword. (Despite
-    that keyword's name, it takes a tuple including status and headers as well as response body.)
+    """A callable object that can be passed into httpretty's register_uri method with the 'body' keyword.
+
+    Despite that keyword's name, it takes a tuple including status and headers as well as response body.
 
     Functions that use the @mocking decorator should return a MockResponse object.
 
@@ -35,7 +36,7 @@ class MockResponse:
         self.body = body
 
     def __call__(self, *args):
-        return (self.status, self.headers, self.body)
+        return self.status, self.headers, self.body
 
 
 """Registry associating mockable request functions with zero or more mock response functions. Responses are arranged
@@ -52,8 +53,10 @@ def _unregister_mock(request_function):
 
 
 def mockable(func):
-    """Decorator marking a function as mockable. Since httpretty registers mock responses against URLs, the function
-    to be decorated must generate (or have access to) the complete URL to be called.
+    """Mark function as mockable.
+
+    Since httpretty registers mock responses against URLs, the function to be decorated must generate (or have access
+    to) the complete URL to be called.
 
     Functions using this decorator should accept an optional 'mock' argument. The decorator will replace this argument
     with a context manager that activates the mock response currently associated to the mockable function in the
@@ -84,9 +87,11 @@ def mockable(func):
 
 
 def mocking(request_func):
-    """Decorator marking a function that returns a mock response. The function to be mocked should be supplied to the
-    decorator as an argument. The decorated function will be called with the same arguments as the function to be
-    mocked (apart from the optional 'mock' argument) and may generate a dynamic response.
+    """Mark function as returning mock response.
+
+    The function to be mocked should be supplied to the decorator as an argument. The decorated function will be called
+    with the same arguments as the function to be mocked (apart from the optional 'mock' argument) and may generate a
+    dynamic response.
 
     Usage:
 
@@ -103,8 +108,9 @@ def mocking(request_func):
 
 
 def fixture(pattern):
-    """As an alternative to @mockable, @mocking, and response_from_fixture, the @fixture decorator with a template
-    pattern can be used as a shorthand. Wrapping a function like so:
+    """Alternative to @mockable, @mocking, and response_from_fixture.
+
+    The @fixture decorator with a template pattern can be used as a shorthand. Wrapping a function like so:
 
     @fixture('resource_{resource_id}_feed')
     def call_external_api(hostname, resource_id, mock=None):
@@ -138,16 +144,17 @@ def fixture(pattern):
 
 
 def parse_suffix(pattern):
-    """Extract base pattern and file suffix from original string"""
+    """Extract base pattern and file suffix from original string."""
     match = re.match(r'^(.+)\.([a-z]+)$', pattern)
     if match:
-        return (match.group(1), match.group(2))
+        return match.group(1), match.group(2)
     else:
-        return (pattern, 'json')
+        return pattern, 'json'
 
 
 def response_from_fixture(pattern, suffix):
     """Generate a mock response from a fixture filename.
+
     If a fixture matching {pattern}.json is found, return 200 with the fixture body.
     If a fixture matching {pattern}_page_1.json is found, delegate to response_from_paged_fixture.
     If a matching fixture is not found, return a generic 404.
@@ -177,8 +184,9 @@ def response_from_fixture(pattern, suffix):
 
 
 def response_from_paged_fixture(pattern, suffix):
-    """Convenience function to generate a mock response for an API with multiple pages. Fixture files should be
-    saved in the format:
+    """Generate mock response for an API with multiple pages.
+
+    Fixture files should be saved in the format:
       - some_resource_page_1.json
       - some_resource_page_2.json
     etc.
@@ -216,7 +224,7 @@ def response_from_paged_fixture(pattern, suffix):
                 '',
             ])
             headers['Link'] = '<{}>; rel="next"'.format(next_url)
-        return (200, headers, fixture)
+        return 200, headers, fixture
     # The fixtures path is based on app config and for obscure scoping reasons needs to be passed in as a partial;
     # otherwise Flask will see it as an attempt to evaluate app config outside an application context.
     return partial(handle_request, fixtures_path=_get_fixtures_path())
@@ -225,6 +233,7 @@ def response_from_paged_fixture(pattern, suffix):
 @contextmanager
 def register_mock(request_function, response):
     """Context manager, intended to be used from tests, that temporarily registers a mock response for a given request.
+
     A MockResponse object may be supplied, or, if dynamic behavior is required, a function that returns a MockResponse.
     """
     if isinstance(response, MockResponse):
@@ -258,7 +267,7 @@ def _environment_supports_mocks():
     if os.environ.get('FIXTURE_OUTPUT_PATH'):
         return False
     env = os.environ.get('BOAC_ENV')
-    return (env == 'test' or env == 'demo')
+    return env == 'test' or env == 'demo'
 
 
 def _evaluate_fixture_pattern(func, pattern, *args, **kw):

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -1,4 +1,4 @@
-"""Generic utilities"""
+"""Generic utilities."""
 
 
 def get(_dict, key, default_value=None):

--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -26,10 +26,7 @@ def refresh_cohort_attributes(app, cohorts=None):
     # Search LDAP.
     all_attrs = calnet.client(app).search_csids(csids)
     if len(csids) != len(all_attrs):
-        app.logger.warning('Looked for {} CSIDS but only found {}'.format(
-            len(csids),
-            len(all_attrs),
-        ))
+        app.logger.warning(f'Looked for {len(csids)} CSIDS but only found {len(all_attrs)}')
 
     # Update the DB.
     for attrs in all_attrs:

--- a/boac/merged/member_details.py
+++ b/boac/merged/member_details.py
@@ -1,4 +1,4 @@
-"""Helper utils for cohort controller"""
+"""Helper utils for cohort controller."""
 
 from boac.api.util import canvas_courses_api_feed
 from boac.externals import canvas
@@ -42,8 +42,7 @@ def merged_data(uid, csid):
         student_courses = canvas.get_student_courses(uid) or []
         current_term = app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM')
         term_id = sis_term_id_for_name(current_term)
-        student_courses_in_current_term = [course for course in student_courses if
-                                           course.get('term', {}).get('name') == current_term]
+        student_courses_in_current_term = [course for course in student_courses if course.get('term', {}).get('name') == current_term]
         canvas_courses = canvas_courses_api_feed(student_courses_in_current_term)
         # Decorate the Canvas courses list with per-course statistics, and return summary statistics.
         data['analytics'] = mean_course_analytics_for_user(canvas_courses, uid, canvas_profile['id'], term_id)

--- a/boac/models/athletics.py
+++ b/boac/models/athletics.py
@@ -62,10 +62,12 @@ class Athletics(Base):
 
     @classmethod
     def get_team(cls, team_code, order_by):
-        results = db.session.query(cls.team_code,
-                                   cls.team_name,
-                                   cls.group_code,
-                                   cls.group_name).filter(cls.team_code == team_code).all()
+        results = db.session.query(
+            cls.team_code,
+            cls.team_name,
+            cls.group_code,
+            cls.group_name,
+        ).filter(cls.team_code == team_code).all()
         team = None
         if len(results):
             team = {

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -1,8 +1,4 @@
-"""
-This package integrates with Flask-Login to determine who can use the app,
-and which privileges they have. It will probably end up as a DB table, but is
-simply mocked-out a la "demo mode" for now.
-"""
+"""This package integrates with Flask-Login. Determine who can use the app and which privileges they have."""
 
 from boac import db
 from boac.models.base import Base

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -1,9 +1,3 @@
-"""
-This package integrates with Flask-Login to determine who can use the app,
-and which privileges they have. It will probably end up as a DB table, but is
-simply mocked-out a la "demo mode" for now.
-"""
-
 import json
 import re
 from boac import db, std_commit
@@ -39,11 +33,25 @@ class CohortFilter(Base, UserMixin):
         )
 
     @classmethod
-    def create(cls, uid, label, gpa_ranges=None, group_codes=None, levels=None, majors=None,
-               unit_ranges_eligibility=None, unit_ranges_pacing=None):
-        criteria = cls.compose_filter_criteria(gpa_ranges=gpa_ranges, group_codes=group_codes, levels=levels,
-                                               majors=majors, unit_ranges_eligibility=unit_ranges_eligibility,
-                                               unit_ranges_pacing=unit_ranges_pacing)
+    def create(
+            cls,
+            uid,
+            label,
+            gpa_ranges=None,
+            group_codes=None,
+            levels=None,
+            majors=None,
+            unit_ranges_eligibility=None,
+            unit_ranges_pacing=None,
+    ):
+        criteria = cls.compose_filter_criteria(
+            gpa_ranges=gpa_ranges,
+            group_codes=group_codes,
+            levels=levels,
+            majors=majors,
+            unit_ranges_eligibility=unit_ranges_eligibility,
+            unit_ranges_pacing=unit_ranges_pacing,
+        )
         cf = CohortFilter(label=label, filter_criteria=json.dumps(criteria))
         user = AuthorizedUser.find_by_uid(uid)
         user.cohort_filters.append(cf)
@@ -91,8 +99,15 @@ class CohortFilter(Base, UserMixin):
         std_commit()
 
     @classmethod
-    def compose_filter_criteria(cls, gpa_ranges=None, group_codes=None, levels=None, majors=None,
-                                unit_ranges_eligibility=None, unit_ranges_pacing=None):
+    def compose_filter_criteria(
+            cls,
+            gpa_ranges=None,
+            group_codes=None,
+            levels=None,
+            majors=None,
+            unit_ranges_eligibility=None,
+            unit_ranges_pacing=None,
+    ):
         if not gpa_ranges and not group_codes and not levels and not majors and not unit_ranges_eligibility and not unit_ranges_pacing:
             raise InternalServerError('CohortFilter creation requires one or more non-empty criteria.')
         # Validate
@@ -138,10 +153,18 @@ def construct_cohort(cf, order_by=None, offset=0, limit=50, include_students=Tru
     majors = util.get(c, 'majors', [])
     unit_ranges_eligibility = util.get(c, 'unitRangesEligibility', [])
     unit_ranges_pacing = util.get(c, 'unitRangesPacing', [])
-    results = Student.get_students(gpa_ranges=gpa_ranges, group_codes=group_codes, levels=levels, majors=majors,
-                                   unit_ranges_eligibility=unit_ranges_eligibility,
-                                   unit_ranges_pacing=unit_ranges_pacing, order_by=order_by, offset=offset, limit=limit,
-                                   only_total_student_count=not include_students)
+    results = Student.get_students(
+        gpa_ranges=gpa_ranges,
+        group_codes=group_codes,
+        levels=levels,
+        majors=majors,
+        unit_ranges_eligibility=unit_ranges_eligibility,
+        unit_ranges_pacing=unit_ranges_pacing,
+        order_by=order_by,
+        offset=offset,
+        limit=limit,
+        only_total_student_count=not include_students,
+    )
     team_groups = Athletics.get_team_groups(group_codes) if group_codes else []
     cohort.update({
         'filterCriteria': {

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -75,9 +75,9 @@ def load(cohort_test_data=False):
 
 
 def load_schemas():
-    """
-    During early development, create the test DB from Python code.
-    We will convert to SQL scripts before enabling production deployments.
+    """Create db from Python code.
+
+    TODO: Convert to SQL scripts?
     """
     db.create_all()
 
@@ -94,8 +94,12 @@ def load_development_data():
 
 
 def create_team_group(t):
-    athletics = Athletics(group_code=t['group_code'], group_name=t['group_name'], team_code=t['team_code'],
-                          team_name=t['team_name'])
+    athletics = Athletics(
+        group_code=t['group_code'],
+        group_name=t['group_name'],
+        team_code=t['team_code'],
+        team_name=t['team_name'],
+    )
     db.session.add(athletics)
     return athletics
 
@@ -133,7 +137,8 @@ def load_student_athletes():
         level=None,
         units=0,
         majors=['Economics BA'],
-        in_intensive_cohort=True)
+        in_intensive_cohort=True,
+    )
     create_student(
         uid='1022796',
         sid='8901234567',
@@ -144,7 +149,8 @@ def load_student_athletes():
         level='Freshman',
         units=12,
         majors=['Chemistry BS'],
-        in_intensive_cohort=True)
+        in_intensive_cohort=True,
+    )
     create_student(
         uid='2040',
         sid='2345678901',
@@ -154,7 +160,8 @@ def load_student_athletes():
         gpa='3.495',
         level='Junior',
         units=34,
-        majors=['History BA'])
+        majors=['History BA'],
+    )
     create_student(
         uid='242881',
         sid='3456789012',
@@ -165,7 +172,8 @@ def load_student_athletes():
         level='Junior',
         units=70,
         majors=['English BA', 'Political Economy BA'],
-        in_intensive_cohort=True)
+        in_intensive_cohort=True,
+    )
     create_student(
         uid='1133399',
         sid='5678901234',
@@ -175,7 +183,8 @@ def load_student_athletes():
         gpa='3.501',
         level='Senior',
         units=102,
-        majors=['Letters & Sci Undeclared UG'])
+        majors=['Letters & Sci Undeclared UG'],
+    )
     create_student(
         uid='1049291',
         sid='7890123456',
@@ -186,7 +195,8 @@ def load_student_athletes():
         level='Senior',
         units=110,
         majors=['History BA'],
-        in_intensive_cohort=True)
+        in_intensive_cohort=True,
+    )
     std_commit(allow_test_environment=True)
 
 

--- a/boac/models/job_progress.py
+++ b/boac/models/job_progress.py
@@ -44,15 +44,11 @@ class JobProgress:
     def update(self, step_description):
         row = JsonCache.query.filter_by(key=self.key).first()
         if row is None:
-            app.logger.error('No active progress record to append step "{}" to {}'.format(step_description, self.key))
+            app.logger.error(f'No active progress record to append step "{step_description}" to {self.key}')
             return False
         progress = row.json
         if (not progress.get('start')) or progress.get('end') or (progress.get('steps') is None):
-            app.logger.error('Progress record {} not ready to append step {} to {}'.format(
-                progress,
-                step_description,
-                self.key,
-            ))
+            app.logger.error(f'Progress record {progress} not ready to append step {step_description} to {self.key}')
             return False
         step = '{} : {}'.format(
             datetime.now().strftime('%Y-%m-%d %H:%M:%S'),

--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -41,11 +41,10 @@ def clear_other(key_like):
 
 
 def stow(key_pattern, for_term=False):
-    """Uses the Decorator module to preserve the wrapped function's signature,
-    allowing easy wrapping by other decorators.
+    """Use Decorator module to preserve the wrapped function's signature, allowing easy wrapping by other decorators.
+
     If the for_term option is enabled, the wrapped function is expected to take a term_id argument.
-    TODO Mockingbird does not currently preserve signatures, and so JsonCache
-    cannot directly wrap a @fixture.
+    TODO Mockingbird does not currently preserve signatures, and so JsonCache cannot directly wrap a @fixture.
     """
     @decorator
     def _stow(func, *args, **kw):
@@ -77,7 +76,7 @@ def stow(key_pattern, for_term=False):
 
 
 def update_jsonb_row(stowed):
-    """Changes to a JSONB column will not be committed without some extra hoop-jumping."""
+    """Jump through some hoops to commit changes to a JSONB column."""
     flag_modified(stowed, 'json')
     db.session.merge(stowed)
     std_commit()

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -37,9 +37,20 @@ class Student(Base):
         )
 
     @classmethod
-    def get_students(cls, gpa_ranges=None, group_codes=None, in_intensive_cohort=None, levels=None, majors=None,
-                     unit_ranges_eligibility=None, unit_ranges_pacing=None, order_by=None, offset=0, limit=50,
-                     only_total_student_count=False):
+    def get_students(
+            cls,
+            gpa_ranges=None,
+            group_codes=None,
+            in_intensive_cohort=None,
+            levels=None,
+            majors=None,
+            unit_ranges_eligibility=None,
+            unit_ranges_pacing=None,
+            order_by=None,
+            offset=0,
+            limit=50,
+            only_total_student_count=False,
+    ):
         # TODO: unit ranges
         query_tables, query_filter, all_bindings = cls.get_students_query(group_codes, gpa_ranges, levels, majors, in_intensive_cohort)
         # First, get total_count of matching students

--- a/consoler.py
+++ b/consoler.py
@@ -1,4 +1,4 @@
-"""Run Flask-wrapped code from a Python Console
+"""Run Flask-wrapped code from a Python console.
 
 * From the command line:
     ``boac> python -i consoler.py``
@@ -27,7 +27,6 @@
 """
 
 from boac.factory import create_app
-from pprintpp import pprint as pp
 
 app = create_app()
 ac = app.app_context()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,6 @@ def app(request):
 @pytest.fixture(scope='session')
 def db(app, request):
     """Fixture database object, shared by all tests."""
-
     from boac.models import development_db
     # Drop all tables before re-loading the schemas.
     # If we dropped at teardown instead, an interrupted test run would block the next test run.
@@ -59,9 +58,9 @@ def db(app, request):
 
 @pytest.fixture(scope='function', autouse=True)
 def db_session(db, request):
-    """
-    Fixture database session used for the scope of a single test. All executions are wrapped
-    in a session and then rolled back to keep individual tests isolated.
+    """Fixture database session used for the scope of a single test.
+
+    All executions are wrapped in a session and then rolled back to keep individual tests isolated.
     """
     # Mixing SQL-using test fixtures with SQL-using decorators seems to cause timing issues with pytest's
     # fixture finalizers. Instead of using a finalizer to roll back the session and close connections,
@@ -86,9 +85,7 @@ def db_session(db, request):
 
 @pytest.fixture(scope='function')
 def fake_auth(app, db, client):
-    """
-    Shortcut to start an authenticated session.
-    """
+    """Shortcut to start an authenticated session."""
     return FakeAuth(app, client)
 
 

--- a/tests/test_api/test_admin_controller.py
+++ b/tests/test_api/test_admin_controller.py
@@ -1,19 +1,19 @@
 class TestCachejobAccess:
 
     def test_not_authenticated(self, client):
-        """requires authentication"""
+        """Require authentication."""
         response = client.get('/api/admin/cachejob')
         assert response.status_code == 401
 
     def test_not_an_admin(self, client, fake_auth):
-        """returns 403 for normal users"""
+        """Return 403 for normal users."""
         test_uid = '6446'
         fake_auth.login(test_uid)
         response = client.get('/api/admin/cachejob')
         assert response.status_code == 401
 
     def test_as_an_admin(self, client, fake_auth):
-        """returns success"""
+        """Return success."""
         test_uid = '2040'
         fake_auth.login(test_uid)
         response = client.get('/api/admin/cachejob')

--- a/tests/test_api/test_api_errors.py
+++ b/tests/test_api/test_api_errors.py
@@ -1,13 +1,14 @@
 class TestApiErrors:
-    """API error handling"""
+    """API error handling."""
+
     def test_api_route_not_found(self, client):
-        """returns a 404 for unknown API routes"""
+        """Returns a 404 for unknown API routes."""
         response = client.get('/api/rumpus/')
         assert response.status_code == 404
         assert response.json['message'] == 'The requested resource could not be found.'
 
     def test_non_api_route_not_found(self, client):
-        """serves front-end template for unknown non-API routes"""
+        """Serves front-end template for unknown non-API routes."""
         response = client.get('/rumpus/')
         assert response.status_code == 200
         assert '<title>BOAC</title>' in str(response.data)

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -10,20 +10,20 @@ def authenticated_session(fake_auth):
 
 
 class TestAthletics:
-    """Athletics API"""
+    """Athletics API."""
 
     def test_team_not_authenticated(self, client):
-        """returns 401 if not authenticated"""
+        """Returns 401 if not authenticated."""
         response = client.get('/api/team/FHW')
         assert response.status_code == 401
 
     def test_teams_not_authenticated(self, client):
-        """returns 401 if not authenticated"""
+        """Returns 401 if not authenticated."""
         response = client.get('/api/teams/all')
         assert response.status_code == 401
 
     def test_get_all_team_groups(self, authenticated_session, client):
-        """returns all team-groups if authenticated"""
+        """Returns all team-groups if authenticated."""
         response = client.get('/api/team_groups/all')
         assert response.status_code == 200
         team_groups = response.json
@@ -42,7 +42,7 @@ class TestAthletics:
         assert [2, 3, 1, 1, 1, 1] == total_member_counts
 
     def test_get_all_teams(self, authenticated_session, client):
-        """returns all teams if authenticated"""
+        """Returns all teams if authenticated."""
         response = client.get('/api/teams/all')
         assert response.status_code == 200
         teams = response.json
@@ -59,14 +59,14 @@ class TestAthletics:
         assert football['totalMemberCount'] == 3
 
     def test_team_not_found(self, authenticated_session, client):
-        """returns code as name when no code-to-name translation exists"""
+        """Returns code as name when no code-to-name translation exists."""
         response = client.get('/api/team/XYZ')
         assert response.status_code == 404
         assert 'code' not in response.json
         assert 'No team found' in json.loads(response.data)['message']
 
     def test_team_with_athletes_in_multiple_groups(self, authenticated_session, client):
-        """returns a well-formed response on a valid code if authenticated"""
+        """Returns a well-formed response on a valid code if authenticated."""
         response = client.get('/api/team/FBM?orderBy=last_name')
         assert response.status_code == 200
         team = response.json
@@ -87,7 +87,7 @@ class TestAthletics:
         assert athlete['inIntensiveCohort'] is False
 
     def test_includes_student_sis_data(self, authenticated_session, client):
-        """includes SIS data for team members"""
+        """Includes SIS data for team members."""
         response = client.get('/api/team/FHW')
         athlete = response.json['members'][0]
         assert athlete['cumulativeGPA'] == 3.8
@@ -96,7 +96,7 @@ class TestAthletics:
         assert athlete['majors'] == ['Astrophysics BS', 'English BA']
 
     def test_includes_student_current_enrollments(self, authenticated_session, client):
-        """includes current-term active enrollments and analytics for team members"""
+        """Includes current-term active enrollments and analytics for team members."""
         response = client.get('/api/team/FHW')
         athlete = response.json['members'][0]
         assert athlete['currentTerm']['termName'] == 'Fall 2017'

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -12,7 +12,7 @@ def authenticated_session(fake_auth):
 
 
 class TestCohortDetail:
-    """Cohort API"""
+    """Cohort API."""
 
     def test_my_cohorts(self, authenticated_session, client):
         response = client.get('/api/cohorts/my')
@@ -27,7 +27,7 @@ class TestCohortDetail:
         assert len(cohorts[1]['teamGroups']) == 1
 
     def test_cohorts_all(self, authenticated_session, client):
-        """returns all cohorts per owner"""
+        """Returns all cohorts per owner."""
         response = client.get('/api/cohorts/all')
         assert response.status_code == 200
         data = json.loads(response.data)
@@ -40,7 +40,7 @@ class TestCohortDetail:
         assert [1, 3, 2] == [cohort['id'] for cohort in cohorts]
 
     def test_get_cohort(self, authenticated_session, client):
-        """returns a well-formed response with custom cohort"""
+        """Returns a well-formed response with custom cohort."""
         user = AuthorizedUser.find_by_uid(test_uid)
         cohort_id = user.cohort_filters[0].id
         response = client.get('/api/cohort/{}'.format(cohort_id))
@@ -57,7 +57,7 @@ class TestCohortDetail:
         assert cohort['totalMemberCount'] == len(cohort['members'])
 
     def test_includes_cohort_member_sis_data(self, authenticated_session, client):
-        """includes SIS data for custom cohort members"""
+        """Includes SIS data for custom cohort members."""
         user = AuthorizedUser.find_by_uid(test_uid)
         cohort_id = user.cohort_filters[0].id
         response = client.get('/api/cohort/{}'.format(cohort_id))
@@ -69,7 +69,7 @@ class TestCohortDetail:
         assert athlete['majors'] == ['Astrophysics BS', 'English BA']
 
     def test_includes_cohort_member_current_enrollments(self, authenticated_session, client):
-        """includes current-term active enrollments and analytics for custom cohort members"""
+        """Includes current-term active enrollments and analytics for custom cohort members."""
         user = AuthorizedUser.find_by_uid(test_uid)
         cohort_id = user.cohort_filters[0].id
         response = client.get('/api/cohort/{}?orderBy=firstName'.format(cohort_id))
@@ -86,7 +86,7 @@ class TestCohortDetail:
             assert analytics[metric]['displayPercentile'].endswith(('rd', 'st', 'th'))
 
     def test_includes_cohort_member_athletics(self, authenticated_session, client):
-        """includes team memberships for custom cohort members"""
+        """Includes team memberships for custom cohort members."""
         user = AuthorizedUser.find_by_uid(test_uid)
         cohort_id = user.cohort_filters[0].id
         response = client.get('/api/cohort/{}'.format(cohort_id))
@@ -102,13 +102,13 @@ class TestCohortDetail:
         assert field_hockey['teamName'] == 'Women\'s Field Hockey'
 
     def test_get_cohort_404(self, authenticated_session, client):
-        """returns a well-formed response when no cohort found"""
+        """Returns a well-formed response when no cohort found."""
         response = client.get('/api/cohort/99999999')
         assert response.status_code == 404
         assert 'No cohort found' in str(response.data)
 
     def test_get_intensive_cohort(self, authenticated_session, client):
-        """returns the canned 'intensive' cohort, available to all authenticated users"""
+        """Returns the canned 'intensive' cohort, available to all authenticated users."""
         response = client.get('/api/intensive_cohort')
         assert response.status_code == 200
         cohort = json.loads(response.data)
@@ -119,7 +119,7 @@ class TestCohortDetail:
         assert 'teamGroups' not in cohort
 
     def test_order_by_with_intensive_cohort(self, authenticated_session, client):
-        """returns the canned 'intensive' cohort, available to all authenticated users"""
+        """Returns the canned 'intensive' cohort, available to all authenticated users."""
         all_expected_order = {
             'first_name': ['61889', '1022796', '1049291', '242881'],
             'gpa': ['1022796', '242881', '1049291', '61889'],
@@ -138,7 +138,7 @@ class TestCohortDetail:
             assert uid_list == expected_uid_list, f'Unmet expectation where order_by={order_by}'
 
     def test_offset_and_limit(self, authenticated_session, client):
-        """returns a well-formed response with custom cohort"""
+        """Returns a well-formed response with custom cohort."""
         user = AuthorizedUser.find_by_uid(test_uid)
         api_path = '/api/cohort/{}'.format(user.cohort_filters[0].id)
         # First, offset is zero
@@ -154,7 +154,7 @@ class TestCohortDetail:
         assert data_0['members'][0]['uid'] != data_1['members'][0]['uid']
 
     def test_create_cohort(self, authenticated_session, client):
-        """creates custom cohort, owned by current user"""
+        """Creates custom cohort, owned by current user."""
         label = 'Tennis'
         group_codes = ['MTE-AA', 'WTE-AA']
         data = {
@@ -207,16 +207,18 @@ class TestCohortDetail:
     def test_create_cohort_with_invalid_data_structure(self, authenticated_session, client):
         data = {
             'label': 'Majors must be a list of strings',
-            'majors': [{
-                'label': 'American Studies',
-                'selected': True,
-            }],
+            'majors': [
+                {
+                    'label': 'American Studies',
+                    'selected': True,
+                },
+            ],
         }
         response = client.post('/api/cohort/create', data=json.dumps(data), content_type='application/json')
         assert 500 == response.status_code
 
     def test_create_cohort_with_complex_filters(self, authenticated_session, client):
-        """creates custom cohort, with many non-empty filter_criteria"""
+        """Creates custom cohort, with many non-empty filter_criteria."""
         label = 'Complex'
         gpa_ranges = [
             'numrange(0, 2, \'[)\')',
@@ -243,7 +245,7 @@ class TestCohortDetail:
             assert data[key] == cohort['filterCriteria'][key]
 
     def test_cohort_ordering(self, authenticated_session, client):
-        """orders custom cohorts alphabetically"""
+        """Orders custom cohorts alphabetically."""
         z_team_data = {
             'label': 'Zteam',
             'groupCodes': ['MTE-AA', 'WWP-AA'],
@@ -259,12 +261,12 @@ class TestCohortDetail:
         assert [cohort['label'] for cohort in response.json] == ['All sports', 'Ateam', 'Football, Defense Backs', 'Zteam']
 
     def test_delete_cohort_not_authenticated(self, client):
-        """custom cohort deletion requires authentication"""
+        """Custom cohort deletion requires authentication."""
         response = client.delete('/api/cohort/delete/{}'.format('123'))
         assert response.status_code == 401
 
     def test_delete_cohort_wrong_user(self, client, fake_auth):
-        """custom cohort deletion is only available to owners"""
+        """Custom cohort deletion is only available to owners."""
         cohort = CohortFilter.create(uid=test_uid, label='Badminton teams', group_codes=['WWP-AA', 'MWP-AA'])
         assert cohort and 'id' in cohort
 
@@ -275,7 +277,7 @@ class TestCohortDetail:
         assert '2040 does not own' in str(response.data)
 
     def test_delete_cohort(self, authenticated_session, client):
-        """deletes existing custom cohort while enforcing rules of ownership"""
+        """Deletes existing custom cohort while enforcing rules of ownership."""
         label = 'Water polo teams'
         cohort = CohortFilter.create(uid=test_uid, label=label, group_codes=['WWP-AA', 'MWP-AA'])
 

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -1,8 +1,8 @@
 class TestConfigController:
-    """Config API"""
+    """Config API."""
 
     def test_anonymous_api_config_request(self, client):
-        """returns a well-formed response"""
+        """Returns a well-formed response."""
         response = client.get('/api/config')
         assert response.status_code == 200
         assert 'boacEnv' in response.json
@@ -10,7 +10,7 @@ class TestConfigController:
         assert response.json['googleAnalyticsId'] is False
 
     def test_anonymous_api_version_request(self, client):
-        """returns a well-formed response"""
+        """Returns a well-formed response."""
         response = client.get('/api/version')
         assert response.status_code == 200
         assert 'version' in response.json

--- a/tests/test_api/test_status_controller.py
+++ b/tests/test_api/test_status_controller.py
@@ -1,8 +1,8 @@
 class TestStatusController:
-    """Status API"""
+    """Status API."""
 
     def test_anonymous_status(self, client):
-        """returns a well-formed response"""
+        """Returns a well-formed response."""
         response = client.get('/api/status')
         assert response.status_code == 200
         assert 'authenticated_as' in response.json
@@ -17,7 +17,7 @@ class TestStatusController:
         assert response.json['authenticated_as']['uid'] == test_uid
 
     def test_ping(self, client):
-        """answers the phone when pinged"""
+        """Answers the phone when pinged."""
         response = client.get('/api/ping')
         assert response.status_code == 200
         assert response.json['app'] is True

--- a/tests/test_auth/test_cas_auth.py
+++ b/tests/test_auth/test_cas_auth.py
@@ -2,15 +2,15 @@ import re
 
 
 class TestCasAuth:
-    """CAS login URL generation and redirects"""
+    """CAS login URL generation and redirects."""
 
     def test_cas_login_url(self, client):
-        """fails if the chosen UID does not match an authorized user"""
+        """Fails if the chosen UID does not match an authorized user."""
         response = client.get('/cas/login_url')
         assert response.status_code == 200
         assert re.compile('.*berkeley.edu/cas/login').match(str(response.data)) is not None
 
     def test_cas_callback_with_invalid_ticket(self, client):
-        """fails if CAS can not verify the ticket"""
+        """Fails if CAS can not verify the ticket."""
         response = client.get('/cas/callback?ticket=is_invalid')
         assert response.status_code == 403

--- a/tests/test_auth/test_dev_auth.py
+++ b/tests/test_auth/test_dev_auth.py
@@ -2,12 +2,12 @@ import json
 
 
 class TestDevAuth:
-    """DevAuth handling"""
+    """DevAuth handling."""
 
     authorized_uid = '2040'
 
     def test_disabled(self, app, client):
-        """blocks access unless enabled"""
+        """Blocks access unless enabled."""
         app.config['DEVELOPER_AUTH_ENABLED'] = False
         response = client.post('/devauth/login')
         assert response.status_code == 404
@@ -16,21 +16,21 @@ class TestDevAuth:
         assert response.status_code == 404
 
     def test_password_fail(self, app, client):
-        """fails if no match on developer password"""
+        """Fails if no match on developer password."""
         app.config['DEVELOPER_AUTH_ENABLED'] = True
         params = {'uid': self.authorized_uid, 'password': 'Born 2 Lose'}
         response = client.post('/devauth/login', data=json.dumps(params), content_type='application/json')
         assert response.status_code == 403
 
     def test_authorized_user_fail(self, app, client):
-        """fails if the chosen UID does not match an authorized user"""
+        """Fails if the chosen UID does not match an authorized user."""
         app.config['DEVELOPER_AUTH_ENABLED'] = True
         params = {'uid': 'A Bad Sort', 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
         response = client.post('/devauth/login', data=json.dumps(params), content_type='application/json')
         assert response.status_code == 403
 
     def test_known_user_with_correct_password_logs_in(self, app, client):
-        """there is a happy path"""
+        """There is a happy path."""
         app.config['DEVELOPER_AUTH_ENABLED'] = True
         params = {'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
         response = client.post('/devauth/login', data=json.dumps(params), content_type='application/json')

--- a/tests/test_externals/test_cal1card_photo_api.py
+++ b/tests/test_externals/test_cal1card_photo_api.py
@@ -3,22 +3,22 @@ from boac.lib.mockingbird import MockResponse, register_mock
 
 
 class TestCal1CardPhotoApi:
-    """Cal1Card Photo API query"""
+    """Cal1Card Photo API query."""
 
     def test_get_photo(self, app):
-        """returns fixture data"""
+        """Returns fixture data."""
         oski_response = cal1card_photo_api.get_cal1card_photo(61889)
         assert isinstance(oski_response, bytes)
         assert len(oski_response) == 3559
 
     def test_user_not_found(self, app, caplog):
-        """logs error and returns False when user not found"""
+        """Logs error and returns False when user not found."""
         response = cal1card_photo_api.get_cal1card_photo(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert response is False
 
     def test_server_error(self, app, caplog):
-        """logs unexpected server errors and returns informative message"""
+        """Logs unexpected server errors and returns informative message."""
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(cal1card_photo_api._get_cal1card_photo, api_error):
             response = cal1card_photo_api._get_cal1card_photo(61889)

--- a/tests/test_externals/test_canvas.py
+++ b/tests/test_externals/test_canvas.py
@@ -1,12 +1,12 @@
-import boac.externals.canvas as canvas
+from boac.externals import canvas
 from boac.lib.mockingbird import MockResponse, register_mock
 
 
 class TestCanvasGetCourseSections:
-    """Canvas API query (get course sections)"""
+    """Canvas API query (get course sections)."""
 
     def test_get_course_sections(self, app):
-        """returns fixture data"""
+        """Returns fixture data."""
         burmese_sections = canvas._get_course_sections(7654320)
         assert burmese_sections
         assert len(burmese_sections) == 3
@@ -25,13 +25,13 @@ class TestCanvasGetCourseSections:
         assert nuclear_sections[1]['sis_section_id'] == 'SEC:2017-D-90300'
 
     def test_course_not_found(self, app, caplog):
-        """logs 404 for unknown course"""
+        """Logs 404 for unknown course."""
         response = canvas._get_course_sections(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
 
     def test_server_error(self, app, caplog):
-        """logs unexpected server errors"""
+        """Logs unexpected server errors."""
         canvas_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(canvas._get_course_sections, canvas_error):
             response = canvas._get_course_sections(7654320)
@@ -40,10 +40,10 @@ class TestCanvasGetCourseSections:
 
 
 class TestCanvasGetUserForUid:
-    """Canvas API query (user for LDAP UID)"""
+    """Canvas API query (user for LDAP UID)."""
 
     def test_user_for_uid(self, app):
-        """returns fixture data"""
+        """Returns fixture data."""
         oliver_response = canvas.get_user_for_uid(2040)
         assert oliver_response
         assert oliver_response['sortable_name'] == 'Heyer, Oliver'
@@ -55,13 +55,13 @@ class TestCanvasGetUserForUid:
         assert paul_response['avatar_url'] == 'https://en.wikipedia.org/wiki/Daffy_Duck#/media/File:Daffy_Duck.svg'
 
     def test_user_not_found(self, app, caplog):
-        """logs 404 for unknown user and returns False rather than None"""
+        """Logs 404 for unknown user and returns False rather than None."""
         response = canvas.get_user_for_uid(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert response is False
 
     def test_raw_user_not_found(self, app, caplog):
-        """logs 404 for unknown user and returns informative message"""
+        """Logs 404 for unknown user and returns informative message."""
         response = canvas._get_user_for_uid(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
@@ -69,7 +69,7 @@ class TestCanvasGetUserForUid:
         assert response.raw_response.json()['message']
 
     def test_raw_server_error(self, app, caplog):
-        """logs unexpected server errors and returns informative message"""
+        """Logs unexpected server errors and returns informative message."""
         canvas_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(canvas._get_user_for_uid, canvas_error):
             response = canvas._get_user_for_uid(2040)
@@ -80,10 +80,10 @@ class TestCanvasGetUserForUid:
 
 
 class TestCanvasGetUserCourses:
-    """Canvas API query (get courses for user)"""
+    """Canvas API query (get courses for user)."""
 
     def test_get_courses(self, app):
-        """returns a well-formed response from multiple terms"""
+        """Returns a well-formed response from multiple terms."""
         courses = canvas.get_student_courses(61889)
         assert courses
         assert len(courses) == 5
@@ -109,20 +109,20 @@ class TestCanvasGetUserCourses:
         assert courses[4]['term']['name'] == 'Spring 2017'
 
     def test_student_enrollments(self, app):
-        """returns only enrollments of type 'student'"""
+        """Returns only enrollments of type 'student'."""
         courses = canvas.get_student_courses(61889)
         for course in courses:
             assert course['enrollments'][0]['type'] == 'student'
             assert course['enrollments'][0]['enrollment_state'] == 'active'
 
     def test_user_not_found(self, app, caplog):
-        """logs 404 for unknown user"""
+        """Logs 404 for unknown user."""
         courses = canvas.get_student_courses(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not courses
 
     def test_server_error(self, app, caplog):
-        """logs unexpected server errors"""
+        """Logs unexpected server errors."""
         canvas_error = MockResponse(503, {}, '{"message": "Server at capacity, go away."}')
         with register_mock(canvas._get_all_user_courses, canvas_error):
             courses = canvas._get_all_user_courses(61889)
@@ -131,10 +131,10 @@ class TestCanvasGetUserCourses:
 
 
 class TestCanvasGetStudentSummariesForCourse:
-    """Canvas API query (student summaries for course)"""
+    """Canvas API query (student summaries for course)."""
 
     def test_student_summaries(self, app):
-        """returns a large result set from paged Canvas API"""
+        """Returns a large result set from paged Canvas API."""
         student_summaries = canvas._get_student_summaries(7654321)
         assert student_summaries
         assert len(student_summaries) == 730
@@ -144,13 +144,13 @@ class TestCanvasGetStudentSummariesForCourse:
         assert student_summaries[729]['page_views'] == 400
 
     def test_course_not_found(self, app, caplog):
-        """logs 404 for unknown course"""
+        """Logs 404 for unknown course."""
         student_summaries = canvas._get_student_summaries(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not student_summaries
 
     def test_server_error(self, app, caplog):
-        """logs unexpected server errors"""
+        """Logs unexpected server errors."""
         canvas_error = MockResponse(503, {}, '{"message": "Server at capacity, go away."}')
         with register_mock(canvas._get_student_summaries, canvas_error):
             student_summaries = canvas._get_student_summaries(7654321)
@@ -159,10 +159,10 @@ class TestCanvasGetStudentSummariesForCourse:
 
 
 class TestCanvasGrades:
-    """Canvas API queries for grade data"""
+    """Canvas API queries for grade data."""
 
     def test_course_enrollments(self, app):
-        """returns course enrollments"""
+        """Returns course enrollments."""
         feed = canvas._get_course_enrollments(7654321)
         assert feed
         assert len(feed) == 43
@@ -172,7 +172,7 @@ class TestCanvasGrades:
         assert feed[42]['grades']['current_score'] == 91.0
 
     def test_assignments_analytics(self, app):
-        """returns course assignments analytics"""
+        """Returns course assignments analytics."""
         feed = canvas._get_assignments_analytics(7654321, 61889)
         assert feed
         assert len(feed) == 7

--- a/tests/test_externals/test_import_asc_athletes.py
+++ b/tests/test_externals/test_import_asc_athletes.py
@@ -3,24 +3,40 @@ from boac.models.athletics import Athletics
 
 
 class TestImportAscAthletes:
-    """Import ASC data"""
+    """Import ASC data."""
 
     def test_empty_import(self, app):
-        """gracefully handles empty dataset"""
+        """Gracefully handles empty dataset."""
         athletics, students = import_asc_athletes.load_student_athletes(app, [])
         assert not athletics
         assert not students
 
     def test_students_on_multiple_teams(self, app):
-        """maps one student to more than one team"""
+        """Maps one student to more than one team."""
         jane_sid = '1234567890'
         polo_code = 'WWP-AA'
         volleyball_code = 'WVB-AA'
         asc_data = [
-            asc_data_row(jane_sid, 'Jane B. Sporty', polo_code, 'Women\'s Water Polo', 'MBB',
-                         'Women\'s Water Polo', '2017-18', 'Yes'),
-            asc_data_row(jane_sid, 'Jane B. Sporty', volleyball_code, 'Women\'s Volleyball', 'WVB',
-                         'Women\'s Volleyball', '2017-18', 'Yes'),
+            asc_data_row(
+                jane_sid,
+                'Jane B. Sporty',
+                polo_code,
+                'Women\'s Water Polo',
+                'MBB',
+                'Women\'s Water Polo',
+                '2017-18',
+                'Yes',
+            ),
+            asc_data_row(
+                jane_sid,
+                'Jane B. Sporty',
+                volleyball_code,
+                'Women\'s Volleyball',
+                'WVB',
+                'Women\'s Volleyball',
+                '2017-18',
+                'Yes',
+            ),
         ]
         # Run import script
         athletics, students = import_asc_athletes.load_student_athletes(app, asc_data)

--- a/tests/test_externals/test_sis_degree_progress_api.py
+++ b/tests/test_externals/test_sis_degree_progress_api.py
@@ -4,10 +4,10 @@ from boac.lib.mockingbird import MockResponse, register_mock
 
 
 class TestSisDegreeProgressApi:
-    """SIS Degree Progress API query"""
+    """SIS Degree Progress API query."""
 
     def test_parsed(self, app):
-        """returns the front-end-friendly data"""
+        """Returns the front-end-friendly data."""
         parsed = sis_degree_progress_api.parsed_degree_progress(11667051)
         assert parsed['reportDate'] == '2017-03-03'
         reqs = parsed['requirements']
@@ -17,14 +17,14 @@ class TestSisDegreeProgressApi:
         assert reqs['americanInstitutions']['status'] == 'Not Satisfied'
 
     def test_get_degree_progress(self, app):
-        """returns unwrapped data"""
+        """Returns unwrapped data."""
         xml_dict = sis_degree_progress_api.get_degree_progress(11667051)
         degree_progress = xml_dict['UC_AA_PROGRESS']['PROGRESSES']['PROGRESS']
         assert degree_progress['RPT_DATE'] == '2017-03-03'
         assert degree_progress['REQUIREMENTS']['REQUIREMENT'][1]['NAME'] == 'American History (R-0002)'
 
     def test_inner_get_degree_progress(self, app):
-        """returns fixture data"""
+        """Returns fixture data."""
         oski_response = sis_degree_progress_api._get_degree_progress(11667051)
         assert oski_response
         assert oski_response.status_code == 200
@@ -32,14 +32,14 @@ class TestSisDegreeProgressApi:
         assert re.search(r'<UC_AA_PROGRESS>', xml)
 
     def test_user_not_found(self, app, caplog):
-        """returns False when CS delivers an error in the XML"""
+        """Returns False when CS delivers an error in the XML."""
         response = sis_degree_progress_api._get_degree_progress(9999999)
         assert response
         parsed = sis_degree_progress_api.get_degree_progress(9999999)
         assert not parsed
 
     def test_server_error(self, app, caplog):
-        """logs unexpected server errors and returns informative message"""
+        """Logs unexpected server errors and returns informative message."""
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(sis_degree_progress_api._get_degree_progress, api_error):
             response = sis_degree_progress_api._get_degree_progress(11667051)

--- a/tests/test_externals/test_sis_enrollments_api.py
+++ b/tests/test_externals/test_sis_enrollments_api.py
@@ -3,10 +3,10 @@ from boac.lib.mockingbird import MockResponse, register_mock
 
 
 class TestSisEnrollmentsApi:
-    """SIS enrollments API query"""
+    """SIS enrollments API query."""
 
     def test_get_enrollments(self, app):
-        """returns unwrapped data"""
+        """Returns unwrapped data."""
         oski_response = enrollments_api.get_enrollments(11667051, 2178)
         student = oski_response['student']
 
@@ -34,7 +34,7 @@ class TestSisEnrollmentsApi:
         assert enrollments[5]['grades'][0]['mark'] == 'P'
 
     def test_inner_get_enrollments(self, app):
-        """returns fixture data"""
+        """Returns fixture data."""
         oski_response = enrollments_api._get_enrollments(11667051, 2178)
         assert oski_response
         assert oski_response.status_code == 200
@@ -89,7 +89,7 @@ class TestSisEnrollmentsApi:
         assert enrollments[5]['grades'][0]['mark'] == 'P'
 
     def test_user_not_found(self, app, caplog):
-        """logs 404 for unknown user and returns informative message"""
+        """Logs 404 for unknown user and returns informative message."""
         response = enrollments_api._get_enrollments(9999999, 2178)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
@@ -97,7 +97,7 @@ class TestSisEnrollmentsApi:
         assert response.raw_response.json()['message']
 
     def test_server_error(self, app, caplog):
-        """logs unexpected server errors and returns informative message"""
+        """Logs unexpected server errors and returns informative message."""
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(enrollments_api._get_enrollments, api_error):
             response = enrollments_api._get_enrollments(11667051, 2178)

--- a/tests/test_externals/test_sis_student_api.py
+++ b/tests/test_externals/test_sis_student_api.py
@@ -4,10 +4,10 @@ import pytest
 
 
 class TestSisStudentApi:
-    """SIS student API query"""
+    """SIS student API query."""
 
     def test_get_student(self, app):
-        """returns unwrapped data"""
+        """Returns unwrapped data."""
         student = student_api.get_student(11667051)
         assert len(student['academicStatuses']) == 2
         assert student['academicStatuses'][0]['currentRegistration']['academicCareer']['code'] == 'UCBX'
@@ -19,7 +19,7 @@ class TestSisStudentApi:
         assert student['emails'][0]['emailAddress'] == 'oski@berkeley.edu'
 
     def test_inner_get_student(self, app):
-        """returns fixture data"""
+        """Returns fixture data."""
         oski_response = student_api._get_student(11667051)
         assert oski_response
         assert oski_response.status_code == 200
@@ -27,7 +27,7 @@ class TestSisStudentApi:
         assert len(students) == 1
 
     def test_user_not_found(self, app, caplog):
-        """logs 404 for unknown user and returns informative message"""
+        """Logs 404 for unknown user and returns informative message."""
         response = student_api._get_student(9999999)
         assert 'HTTP/1.1" 404' in caplog.text
         assert not response
@@ -35,7 +35,7 @@ class TestSisStudentApi:
         assert response.raw_response.json()['message']
 
     def test_server_error(self, app, caplog):
-        """logs unexpected server errors and returns informative message"""
+        """Logs unexpected server errors and returns informative message."""
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(student_api._get_student, api_error):
             response = student_api._get_student(11667051)

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -3,10 +3,10 @@ from boac.lib import analytics
 
 
 class TestAnalytics:
-    """Analytics"""
+    """Analytics."""
 
     def test_ordinal(self):
-        """Format a whole number as a position"""
+        """Format a whole number as a position."""
         assert analytics.ordinal(1) == '1st'
         assert analytics.ordinal(2) == '2nd'
         assert analytics.ordinal(3) == '3rd'
@@ -17,7 +17,7 @@ class TestAnalytics:
         assert analytics.ordinal(23) == '23rd'
 
     def test_canvas_course_scores(self, app):
-        """Summarizes current course score in fixture"""
+        """Summarizes current course score in fixture."""
         canvas_user_id = 9000100
         canvas_course_id = 7654321
         feed = canvas.get_course_enrollments(canvas_course_id, '2178')
@@ -30,7 +30,7 @@ class TestAnalytics:
         assert course_current_score['student']['roundedUpPercentile'] == 11
 
     def test_no_canvas_course_scores(self, app):
-        """Handles complete absence of scored assignments"""
+        """Handles complete absence of scored assignments."""
         canvas_user_id = 9000100
         canvas_course_id = 7654321
         feed = canvas.get_course_enrollments(canvas_course_id, '2178')
@@ -49,7 +49,7 @@ class TestAnalytics:
         assert course_current_score['student']['roundedUpPercentile'] is None
 
     def test_canvas_course_assignments(self, app):
-        """Summarizes the student assignment statuses from fixture"""
+        """Summarizes the student assignment statuses from fixture."""
         uid = '61889'
         canvas_course_id = 7654321
         feed = canvas.get_assignments_analytics(canvas_course_id, uid, '2178')
@@ -79,12 +79,13 @@ class TestAnalytics:
 
 
 class TestAnalyticsFromSummaryFeed:
-    """Canvas course summary analytics"""
+    """Canvas course summary analytics."""
+
     canvas_course_id = 7654321
     canvas_user_id = '9000001'
 
     def test_small_difference(self, app):
-        """notices that small difference"""
+        """Notices that small difference."""
         summary_feed = [
             {
                 'id': '9000000',
@@ -128,7 +129,7 @@ class TestAnalyticsFromSummaryFeed:
         assert best['assignmentsOnTime']['student']['raw'] == 3
 
     def test_insufficient_data(self, app):
-        """notes insufficient data status"""
+        """Notes insufficient data status."""
         summary_feed = [
             {
                 'id': '9000000',
@@ -159,7 +160,7 @@ class TestAnalyticsFromSummaryFeed:
             assert digested[column]['student']['percentile'] is None
 
     def test_zero_counts(self, app):
-        """does not calculate statistics on a void"""
+        """Does not calculate statistics on a void."""
         summary_feed = [
             {
                 'id': '9000000',
@@ -190,7 +191,7 @@ class TestAnalyticsFromSummaryFeed:
             assert digested[column]['student']['percentile'] is None
 
     def test_zeroth_percentile(self, app):
-        """returns statistics even if this student did sweet nothing"""
+        """Returns statistics even if this student did sweet nothing."""
         summary_feed = [
             {
                 'id': '9000000',

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -1,20 +1,20 @@
-import boac.lib.berkeley as berkeley
+from boac.lib import berkeley
 
 
 class TestBerkeleySisTermIdForName:
-    """Term name to SIS id translation"""
+    """Term name to SIS id translation."""
 
     def test_sis_term_id_for_name(self):
-        """handles well-formed term names"""
+        """Handles well-formed term names."""
         assert berkeley.sis_term_id_for_name('Spring 2015') == '2152'
         assert berkeley.sis_term_id_for_name('Summer 2016') == '2165'
         assert berkeley.sis_term_id_for_name('Fall 2017') == '2178'
 
     def test_unparseable_term_name(self):
-        """returns None for unparseable term names"""
+        """Returns None for unparseable term names."""
         assert berkeley.sis_term_id_for_name('Winter 2061') is None
         assert berkeley.sis_term_id_for_name('Default Term') is None
 
     def test_missing_term_name(self):
-        """returns None for missing term names"""
+        """Returns None for missing term names."""
         assert berkeley.sis_term_id_for_name(None) is None

--- a/tests/test_lib/test_util.py
+++ b/tests/test_lib/test_util.py
@@ -1,9 +1,9 @@
-import boac.lib.util as util
+from boac.lib import util
 
 
 class TestUtil:
-    """Generic utilities"""
+    """Generic utilities."""
 
     def test_vacuum_whitespace(self):
-        """cleans up leading, trailing, and repeated whitespace"""
+        """Cleans up leading, trailing, and repeated whitespace."""
         assert util.vacuum_whitespace('  Firstname    Lastname   ') == 'Firstname Lastname'

--- a/tests/test_merged/test_calnet.py
+++ b/tests/test_merged/test_calnet.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.mark.usefixtures('db_session')
 class TestCalnet:
-    """TestCalnet"""
+    """Test Calnet."""
 
     def test_refresh_cohort_attributes(self, app):
         athlete = Student.query.filter_by(uid='61889').first()

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -10,10 +10,10 @@ import pytest
 
 @pytest.mark.usefixtures('db_session')
 class TestSisProfile:
-    """TestSisProfile"""
+    """Test SIS profile."""
 
     def test_populates_normalized_cache(self, app):
-        """populates the normalized cache"""
+        """Populates the normalized cache."""
         merge_sis_profile('11667051')
 
         student_rows = NormalizedCacheStudent.query.all()
@@ -28,8 +28,7 @@ class TestSisProfile:
         assert 'Astrophysics BS' in majors
 
     def test_updates_normalized_cache(self, app):
-        """updates the normalized cache"""
-
+        """Updates the normalized cache."""
         # Load default fixture data, clear the JSON cache.
         merge_sis_profile('11667051')
         json_cache.clear('merged_sis_profile_11667051')
@@ -56,6 +55,6 @@ class TestSisProfile:
                 assert 'Hungarian BA' in majors
 
     def test_skips_concurrent_academic_status(self, app):
-        """skips concurrent academic status"""
+        """Skips concurrent academic status."""
         profile = merge_sis_profile('11667051')
         assert profile['academicCareer'] == 'UGRD'

--- a/tests/test_models/test_authorized_user.py
+++ b/tests/test_models/test_authorized_user.py
@@ -4,15 +4,15 @@ import pytest
 
 @pytest.mark.usefixtures('db_session')
 class TestAuthorizedUser:
-    """Authorized User"""
+    """Authorized user."""
 
     def test_load_unknown_user(self):
-        """returns None to Flask-Login for unrecognized UID"""
+        """Returns None to Flask-Login for unrecognized UID."""
         unknown_uid = 'Ms. X'
         assert AuthorizedUser.find_by_uid(unknown_uid) is None
 
     def test_load_admin_user(self):
-        """returns authorization record to Flask-Login for recognized UID"""
+        """Returns authorization record to Flask-Login for recognized UID."""
         admin_uid = '1133399'
         loaded_user = AuthorizedUser.find_by_uid(admin_uid)
         assert loaded_user.is_active

--- a/tests/test_models/test_cohort_filter.py
+++ b/tests/test_models/test_cohort_filter.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.mark.usefixtures('db_session')
 class TestCohortFilter:
-    """Cohort Filter"""
+    """Cohort filter."""
 
     def test_no_cohort(self):
         assert not CohortFilter.find_by_id(99999999)
@@ -32,14 +32,16 @@ class TestCohortFilter:
             'numrange(30, NULL, \'[)\')',
         ]
         unit_ranges_pacing = ['numrange(30, 59, \'[]\')']
-        cohort = CohortFilter.create(uid='1022796',
-                                     label='All criteria, all the time',
-                                     gpa_ranges=gpa_ranges,
-                                     group_codes=group_codes,
-                                     levels=levels,
-                                     majors=majors,
-                                     unit_ranges_eligibility=unit_ranges_eligibility,
-                                     unit_ranges_pacing=unit_ranges_pacing)
+        cohort = CohortFilter.create(
+            uid='1022796',
+            label='All criteria, all the time',
+            gpa_ranges=gpa_ranges,
+            group_codes=group_codes,
+            levels=levels,
+            majors=majors,
+            unit_ranges_eligibility=unit_ranges_eligibility,
+            unit_ranges_pacing=unit_ranges_pacing,
+        )
         cohort = CohortFilter.find_by_id(cohort['id'])
         expected = {
             'gpaRanges': gpa_ranges,
@@ -59,7 +61,7 @@ class TestCohortFilter:
             CohortFilter.create(uid='2040', label='Cohort with undefined filter criteria')
 
     def test_create_and_delete_cohort(self):
-        """cohort_filter record to Flask-Login for recognized UID"""
+        """Cohort_filter record to Flask-Login for recognized UID."""
         owner = AuthorizedUser.find_by_uid('2040').uid
         shared_with = AuthorizedUser.find_by_uid('1133399').uid
         # Check validity of UIDs

--- a/tests/test_models/test_job_progress.py
+++ b/tests/test_models/test_job_progress.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.mark.usefixtures('db_session')
 class TestJobProgress:
-    """Background Job Process Tracker"""
+    """Background job process tracker."""
 
     def test_start_and_end(self):
         assert JobProgress().get() is None

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,18 @@ commands =
 [testenv:lint-py]
 # Bottom of file has Flake8 settings
 commands =
-    flake8 {posargs:boac config scripts tests run.py}
+    flake8 {posargs:boac config consoler.py scripts tests run.py}
 deps =
     flake8
     flake8-colors
     flake8-commas
+    flake8-docstrings
     flake8-import-order>=0.15
+    flake8-print
     flake8-pytest
     flake8-quotes
+    flake8-strict
+    flake8-tidy-imports
 
 [testenv:lint-css]
 commands =
@@ -46,7 +50,7 @@ exclude =
     *.pyc
     .cache
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
-ignore = E731,I201
+ignore = D100,D101,D102,D103,D104,D105,D107,E731,I201
 import-order-style = google
 max-complexity = 10
 max-line-length = 155


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-379

Many files touched and yet few significant changes. The one debatable – and IMO, desirable – rule is `D400: First line should end with a period`. The D400 downside is **specifically in test classes**, the `tox -e test` output looks a bit odd:
```
Cohort API. Returns all cohorts per owner.
Cohort API. Returns a well-formed response with custom cohort.
...
```
In test classes, you can omit class-level docs and you will get useful output:
```
TestCohortDetail Returns all cohorts per owner.
TestCohortDetail Returns a well-formed response with custom cohort
...
```
