### PR TITLE
BOAC-251, maintenance page when HTTP status code 502, 503 or 504

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -39,6 +39,10 @@ files:
           group=wsgi
         WSGIProcessGroup wsgi-ssl
 
+        ErrorDocument 502 /static/app/maintenance.html
+        ErrorDocument 503 /static/app/maintenance.html
+        ErrorDocument 504 /static/app/maintenance.html
+
       </VirtualHost>
 
   # Load-balancer expects this SSL certificate on EC2 instances.

--- a/boac/static/app/main.css
+++ b/boac/static/app/main.css
@@ -121,6 +121,17 @@
   min-height: 370px;
 }
 
+.outage-banner {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  overflow: show;
+  z-index: 999;
+}
+
 .wrap-hard {
   flex-wrap: wrap;
   word-wrap: break-word;

--- a/boac/static/app/maintenance.html
+++ b/boac/static/app/maintenance.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Technical Difficulties | BOAC</title>
+
+    <link href="/static/lib/angular-bootstrap/ui-bootstrap-csp.css" rel="stylesheet">
+    <link href="/static/lib/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/static/app/main.css" rel="stylesheet">
+  </head>
+  <body style="background-color:black;">
+    <h1 class="sr-only">Please stand by</h1>
+    <img class="outage-banner"
+         alt="We are experiencing technical difficulties. Please stand by."
+         src="http://cuddlebuggery.com/wp-content/uploads/2012/05/TV-error-signal.png"/>
+  </body>
+</html>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ gulp.task('rev', function(done) {
   gulp.src('boac/static/lib/**/*').pipe(gulp.dest('dist/static/lib'));
   var css = filter('boac/static/app/**/*.css', {restore: true});
   // The index.html filename, unlike js/css files, is preserved
-  var index = filter(['**/*', '!**/index.html'], {restore: true});
+  var index = filter(['**/*', '!**/index.html', '!**/maintenance.html'], {restore: true});
   // We cannot minify our js due to http://budiirawan.com/uglify-angular-error-unpr-unknown-provider-aprovider/
   gulp.src(['boac/static/app/**', 'boac/templates/index.html'])
     .pipe(css)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-251

![image](https://user-images.githubusercontent.com/7606442/35022023-8f663c9c-fae8-11e7-9d6b-f95a2d345528.png)

* I'm using placeholder image: http://cuddlebuggery.com/wp-content/uploads/2012/05/TV-error-signal.png
* `maintenance.html` is in `boac/static/app` because it's convenient w.r.t  Apache config and existing `gulp dist` action. 
* Handles status codes:
** 502 Bad Gateway
** 503 Service Unavailable
** 504 Gateway Timeout
** Should we include 500s?
