### PR TITLE
BOAC-385, put EB_ENVIRONMENT in config file (03_download_local_configuration)

### DIFF
--- a/.ebextensions/03_download_local_configuration.config
+++ b/.ebextensions/03_download_local_configuration.config
@@ -3,4 +3,6 @@
 #
 container_commands:
   01_get_configuration_file:
-    command: "aws s3 cp s3://boac-config/${EB_ENVIRONMENT}.py config/production-local.py"
+    command: |
+      aws s3 cp s3://boac-config/${EB_ENVIRONMENT}.py config/production-local.py
+      printf "\nEB_ENVIRONMENT = '${EB_ENVIRONMENT}'\n" >> config/production-local.py

--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -7,6 +7,7 @@ from flask import current_app as app
 def app_config():
     return tolerant_jsonify({
         'boacEnv': app.config['BOAC_ENV'],
+        'ebEnvironment': app.config['EB_ENVIRONMENT'] if 'EB_ENVIRONMENT' in app.config else None,
         'devAuthEnabled': app.config['DEVELOPER_AUTH_ENABLED'],
         'googleAnalyticsId': app.config['GOOGLE_ANALYTICS_ID'],
     })

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -6,7 +6,8 @@ class TestConfigController:
         response = client.get('/api/config')
         assert response.status_code == 200
         assert 'boacEnv' in response.json
-        # In tests, Google Analytics is integrated and disabled
+        # In tests, certain configs are omitted or disabled (e.g., Google Analytics)
+        assert response.json['ebEnvironment'] is None
         assert response.json['googleAnalyticsId'] is False
 
     def test_anonymous_api_version_request(self, client):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-385

`EB_ENVIRONMENT` is put to production-local.py at deploy time. The value of that config:
* surfaces in `/api/config`
* will be used by upcoming BOAC-385 script

See `ebEnvironment` in https://asc-pilot-dev.berkeley.edu/api/config  (deployed with my CodePipeline)