### PR TITLE
BOAC-403, put URL to history before matrix view > student profile

### DIFF
--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -284,7 +284,9 @@
       });
       // Pass along a subset of students that have useful data.
       cohortService.drawScatterplot(partitions[0], yAxisMeasure, function(uid) {
-        var encodedAbsUrl = encodeURIComponent($base64.encode($location.absUrl()));
+        var absUrl = $location.absUrl();
+        $location.state(absUrl);
+        var encodedAbsUrl = encodeURIComponent($base64.encode(absUrl));
         $state.go('user', {uid: uid, r: encodedAbsUrl});
       });
       // List of students-without-data is rendered below the scatterplot.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-403

Unlike search and sortBy, the URL change when you click to 'matrix' view is not recorded in browser history. We must use an explicit `$location.state(url)`. 