### PR TITLE
BOAC-441 Per-advisor alert visibility logic

### DIFF
--- a/boac/api/advisor_watchlist_controller.py
+++ b/boac/api/advisor_watchlist_controller.py
@@ -1,4 +1,5 @@
 from boac.lib.http import tolerant_jsonify
+from boac.models.alert import Alert
 from boac.models.student import Student
 from flask import current_app as app
 from flask_login import current_user, login_required
@@ -8,6 +9,12 @@ from flask_login import current_user, login_required
 @login_required
 def my_watchlist():
     watchlist = [student.to_api_json() for student in current_user.watchlist]
+    watchlist_by_sid = {student['sid']: student for student in watchlist}
+    alert_counts = Alert.current_alert_counts_for_sids(current_user.id, list(watchlist_by_sid.keys()))
+    for result in alert_counts:
+        watchlist_by_sid[result['sid']].update({
+            'alertCount': result['alertCount'],
+        })
     return tolerant_jsonify(sorted(watchlist, key=lambda s: (s['firstName'], s['lastName'])))
 
 

--- a/boac/api/alerts_controller.py
+++ b/boac/api/alerts_controller.py
@@ -4,13 +4,6 @@ from flask import current_app as app
 from flask_login import current_user, login_required
 
 
-@app.route('/api/alerts/current')
-@login_required
-def get_current_alerts():
-    alerts = Alert.current_alerts(viewer_id=current_user.id)
-    return tolerant_jsonify(alerts)
-
-
 @app.route('/api/alerts/current/<sid>')
 @login_required
 def get_current_alerts_for_sid(sid):
@@ -21,5 +14,5 @@ def get_current_alerts_for_sid(sid):
 @app.route('/api/alerts/<alert_id>/dismiss')
 @login_required
 def dismiss_alert(alert_id):
-    current_user.dismiss_alert(alert_id)
+    Alert.dismiss(alert_id, current_user.id)
     return tolerant_jsonify({'message': f'Alert {alert_id} dismissed by UID {current_user.uid}'}), 200

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -32,7 +32,7 @@ def all_cohorts():
 @app.route('/api/cohorts/my')
 @login_required
 def my_cohorts():
-    return tolerant_jsonify(CohortFilter.all_owned_by(current_user.get_id()))
+    return tolerant_jsonify(CohortFilter.all_owned_by(current_user.get_id(), include_alerts=True))
 
 
 @app.route('/api/intensive_cohort')

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -1,6 +1,15 @@
 """Generic utilities."""
 
 
+def camelize(string):
+    def lower_then_capitalize():
+        yield str.lower
+        while True:
+            yield str.capitalize
+    string_transform = lower_then_capitalize()
+    return ''.join(next(string_transform)(segment) for segment in string.split('_'))
+
+
 def get(_dict, key, default_value=None):
     value = _dict and key in _dict and _dict[key]
     return value or default_value

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -1,10 +1,7 @@
 """This package integrates with Flask-Login. Determine who can use the app and which privileges they have."""
-from datetime import datetime
-
 from boac import db, std_commit
-from boac.api.errors import BadRequestError
 from boac.models.base import Base
-from boac.models.db_relationships import advisor_watchlists, AlertView, cohort_filter_owners
+from boac.models.db_relationships import advisor_watchlists, cohort_filter_owners
 from flask_login import UserMixin
 
 
@@ -60,14 +57,6 @@ class AuthorizedUser(Base, UserMixin):
         watchlist = [s for s in self.watchlist if not s.sid == sid]
         self.watchlist = watchlist
         std_commit()
-
-    def dismiss_alert(self, alert_id):
-        alert_view = AlertView.query.filter_by(viewer_id=self.id, alert_id=alert_id, dismissed_at=None).first()
-        if alert_view:
-            alert_view.dismissed_at = datetime.now()
-            std_commit()
-        else:
-            raise BadRequestError(f'No current alert view found for alert {alert_id} and UID {self.uid}')
 
     @classmethod
     def find_by_uid(cls, uid):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import boac.factory
+from boac.models.alert import Alert
 import pytest
 
 
@@ -87,6 +88,29 @@ def db_session(db, request):
 def fake_auth(app, db, client):
     """Shortcut to start an authenticated session."""
     return FakeAuth(app, client)
+
+
+@pytest.fixture()
+def create_alerts(db_session):
+    """Create three canned alerts."""
+    Alert.create(
+        sid='11667051',
+        alert_type='late_assignment',
+        key='800900300',
+        message='Week 5 homework in RUSSIAN 13 is late.',
+    )
+    Alert.create(
+        sid='11667051',
+        alert_type='missing_assignment',
+        key='500600700',
+        message='Week 6 homework in PORTUGUESE 12 is missing.',
+    )
+    Alert.create(
+        sid='2345678901',
+        alert_type='late_assignment',
+        key='100200300',
+        message='Week 5 homework in BOSCRSR 27B is late.',
+    )
 
 
 def pytest_itemcollected(item):

--- a/tests/test_api/test_advisor_watchlist_controller.py
+++ b/tests/test_api/test_advisor_watchlist_controller.py
@@ -24,6 +24,18 @@ class TestAdvisorWatchlist:
         names = [student['firstName'] + ' ' + student['lastName'] for student in response.json]
         assert ['Brigitte Lin', 'Paul Farestveit', 'Paul Kerschen', 'Sandeep Jayaprakash'] == names
 
+    def test_watchlist_includes_alert_counts(self, create_alerts, authenticated_session, client):
+        watchlist = client.get('/api/watchlist/my').json
+        assert watchlist[0]['alertCount'] == 2
+        assert 'alertCount' not in watchlist[1]
+        assert 'alertCount' not in watchlist[2]
+        assert 'alertCount' not in watchlist[3]
+
+        alert_to_dismiss = client.get('/api/alerts/current/11667051').json[0]['id']
+        client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
+        watchlist = client.get('/api/watchlist/my').json
+        assert watchlist[0]['alertCount'] == 1
+
     def test_watchlist_add_and_remove(self, authenticated_session, client):
         """Add student to current_user's watchlist and then remove him."""
         sid = '2345678901'

--- a/tests/test_api/test_alerts_controller.py
+++ b/tests/test_api/test_alerts_controller.py
@@ -15,67 +15,11 @@ def authenticated_session_2(fake_auth):
     fake_auth.login(advisor_2_uid)
 
 
-@pytest.fixture()
-def create_alerts(db_session):
-    alert_1 = Alert.create(
-        sid='11667051',
-        alert_type='late_assignment',
-        key='800900300',
-        message='Week 5 homework in RUSSIAN 13 is late.',
-    )
-    alert_2 = Alert.create(
-        sid='11667051',
-        alert_type='missing_assignment',
-        key='500600700',
-        message='Week 6 homework in PORTUGUESE 12 is missing.',
-    )
-    alert_3 = Alert.create(
-        sid='2345678901',
-        alert_type='late_assignment',
-        key='100200300',
-        message='Week 5 homework in BOSCRSR 27B is late.',
-    )
-
-    alert_1.add_viewer(advisor_1_uid)
-    alert_2.add_viewer(advisor_1_uid)
-    alert_3.add_viewer(advisor_1_uid)
-
-    alert_1.add_viewer(advisor_2_uid)
-    alert_2.add_viewer(advisor_2_uid)
-
-
 class TestAlertsController:
 
     def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
-        assert client.get('/api/alerts/current').status_code == 401
-
-    def test_current_alerts(self, create_alerts, fake_auth, client):
-        """Returns current_user's current alert counts, grouped by sid."""
-        fake_auth.login(advisor_1_uid)
-        response = client.get('/api/alerts/current')
-        assert response.status_code == 200
-        assert len(response.json) == 2
-        assert response.json[0]['sid'] == '2345678901'
-        assert response.json[0]['uid'] == '2040'
-        assert response.json[0]['first_name'] == 'Oliver'
-        assert response.json[0]['last_name'] == 'Heyer'
-        assert response.json[0]['alert_count'] == 1
-        assert response.json[1]['sid'] == '11667051'
-        assert response.json[1]['uid'] == '61889'
-        assert response.json[1]['first_name'] == 'Brigitte'
-        assert response.json[1]['last_name'] == 'Lin'
-        assert response.json[1]['alert_count'] == 2
-
-        fake_auth.login(advisor_2_uid)
-        response = client.get('/api/alerts/current')
-        assert response.status_code == 200
-        assert len(response.json) == 1
-        assert response.json[0]['sid'] == '11667051'
-        assert response.json[0]['uid'] == '61889'
-        assert response.json[0]['first_name'] == 'Brigitte'
-        assert response.json[0]['last_name'] == 'Lin'
-        assert response.json[0]['alert_count'] == 2
+        assert client.get('/api/alerts/current/11667051').status_code == 401
 
     def test_current_alerts_for_sid(self, create_alerts, fake_auth, client):
         """Returns current_user's current alerts for a given sid."""
@@ -90,13 +34,6 @@ class TestAlertsController:
         assert response.json[1]['key'] == '500600700'
         assert response.json[1]['message'] == 'Week 6 homework in PORTUGUESE 12 is missing.'
 
-    def test_current_alerts_empty(self, create_alerts, fake_auth, client):
-        """Returns empty when no active alerts found."""
-        fake_auth.login(advisor_1_uid)
-        response = client.get('/api/alerts/current/9999999')
-        assert response.status_code == 200
-        assert response.json == []
-
     def test_dismiss_alerts(self, create_alerts, fake_auth, client):
         """Can dismiss alerts for one user without affecting visibility for other users."""
         fake_auth.login(advisor_1_uid)
@@ -109,44 +46,38 @@ class TestAlertsController:
 
         advisor_1_brigitte_alerts = client.get('/api/alerts/current/11667051').json
         assert len(advisor_1_brigitte_alerts) == 1
-        advisor_1_current_alerts = client.get('/api/alerts/current').json
-        assert advisor_1_current_alerts[1]['sid'] == '11667051'
-        assert advisor_1_current_alerts[1]['alert_count'] == 1
 
         fake_auth.login(advisor_2_uid)
-        advisor_2_current_alerts = client.get('/api/alerts/current').json
-        assert advisor_2_current_alerts[0]['sid'] == '11667051'
-        assert advisor_2_current_alerts[0]['alert_count'] == 2
         advisor_2_brigitte_alerts = client.get('/api/alerts/current/11667051').json
         assert len(advisor_2_brigitte_alerts) == 2
 
     def test_duplicate_dismiss_alerts(self, create_alerts, fake_auth, client):
-        """Politely handles duplicate dismissal."""
+        """Shrugs off duplicate dismissals."""
         fake_auth.login(advisor_1_uid)
         advisor_1_brigitte_alerts = client.get('/api/alerts/current/11667051').json
         alert_id = advisor_1_brigitte_alerts[0]['id']
         response = client.get('/api/alerts/' + str(alert_id) + '/dismiss')
         assert response.status_code == 200
         response = client.get('/api/alerts/' + str(alert_id) + '/dismiss')
+        assert response.status_code == 200
+
+    def test_dismiss_nonexistent_alerts(self, create_alerts, fake_auth, client):
+        """Politely handles nonexistent alert dismissals."""
+        fake_auth.login(advisor_1_uid)
+        response = client.get('/api/alerts/99999999/dismiss')
         assert response.status_code == 400
-        assert response.json['message'] == 'No current alert view found for alert ' + str(alert_id) + ' and UID 2040'
+        assert response.json['message'] == 'No alert found for id 99999999'
 
     def test_deactivate_alerts(self, create_alerts, fake_auth, client):
         """Can programmatically deactivate alerts, removing them for all users."""
         Alert.query.filter_by(key='800900300').first().deactivate()
 
         fake_auth.login(advisor_1_uid)
-        advisor_1_current_alerts = client.get('/api/alerts/current').json
-        assert advisor_1_current_alerts[1]['sid'] == '11667051'
-        assert advisor_1_current_alerts[1]['alert_count'] == 1
         advisor_1_brigitte_alerts = client.get('/api/alerts/current/11667051').json
         assert len(advisor_1_brigitte_alerts) == 1
         assert advisor_1_brigitte_alerts[0]['key'] == '500600700'
 
         fake_auth.login(advisor_2_uid)
-        advisor_2_current_alerts = client.get('/api/alerts/current').json
-        assert advisor_2_current_alerts[0]['sid'] == '11667051'
-        assert advisor_2_current_alerts[0]['alert_count'] == 1
         advisor_2_brigitte_alerts = client.get('/api/alerts/current/11667051').json
         assert len(advisor_2_brigitte_alerts) == 1
         assert advisor_2_brigitte_alerts[0]['key'] == '500600700'


### PR DESCRIPTION
As arrived at in https://jira.ets.berkeley.edu/jira/browse/BOAC-441, this more or less flips the role of our "AlertView" association objects. Instead of explicitly associating advisors with displayed alerts, they are now used only to explicitly dismiss alerts for a particular advisor.

Since the latest designs bundle in alert counts on the homepage with cohort and list displays, we can use cohort and list memberships to work out alert visibility logic on the fly, and can dispense with a separate '/api/alerts/current' feed. (Per-student alert feeds are still useful and present.)