### PR TITLE
BOAC-411 Derive student status alerts from assignment analytics

### DIFF
--- a/boac/__init__.py
+++ b/boac/__init__.py
@@ -16,6 +16,8 @@ def std_commit(allow_test_environment=False):
     """
     # Give a hoot, don't pollute.
     if app.config['TESTING'] and not allow_test_environment:
+        # When running tests, a session flush generates the id and timestamps that would otherwise show up during a commit.
+        db.session.flush()
         return
     successful_commit = False
     try:

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -94,8 +94,8 @@ def user_analytics(uid):
     for term in enrollment_terms:
         term_id = sis_term_id_for_name(term['termName'])
         for enrollment in term['enrollments']:
-            merge_analytics_for_user(enrollment['canvasSites'], uid, canvas_id, term_id)
-        merge_analytics_for_user(term['unmatchedCanvasSites'], uid, canvas_id, term_id)
+            merge_analytics_for_user(enrollment['canvasSites'], uid, student.sid, canvas_id, term_id)
+        merge_analytics_for_user(term['unmatchedCanvasSites'], uid, student.sid, canvas_id, term_id)
 
     return tolerant_jsonify({
         'uid': uid,

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -1,18 +1,19 @@
 """Utility module containing standard API-feed translations of data objects."""
 
 
+def canvas_course_api_feed(course):
+    return {
+        'canvasCourseId': course.get('id'),
+        'courseName': course.get('name'),
+        'courseCode': course.get('course_code'),
+        'courseTerm': course.get('term', {}).get('name'),
+    }
+
+
 def canvas_courses_api_feed(courses):
     if not courses:
         return []
-
-    def course_api_values(course):
-        return {
-            'canvasCourseId': course.get('id'),
-            'courseName': course.get('name'),
-            'courseCode': course.get('course_code'),
-            'courseTerm': course.get('term', {}).get('name'),
-        }
-    return [course_api_values(course) for course in courses]
+    return [canvas_course_api_feed(course) for course in courses]
 
 
 def sis_enrollment_class_feed(enrollment):

--- a/boac/merged/member_details.py
+++ b/boac/merged/member_details.py
@@ -45,7 +45,7 @@ def merged_data(uid, csid):
         student_courses_in_current_term = [course for course in student_courses if course.get('term', {}).get('name') == current_term]
         canvas_courses = canvas_courses_api_feed(student_courses_in_current_term)
         # Decorate the Canvas courses list with per-course statistics, and return summary statistics.
-        data['analytics'] = mean_course_analytics_for_user(canvas_courses, uid, canvas_profile['id'], term_id)
+        data['analytics'] = mean_course_analytics_for_user(canvas_courses, uid, csid, canvas_profile['id'], term_id)
         # Associate those course sites with campus enrollments.
         data['currentTerm'] = merge_sis_enrollments_for_term(canvas_courses, csid, current_term)
     return data

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -1,0 +1,64 @@
+from boac.externals import canvas
+from boac.lib.mockingbird import MockResponse, register_mock
+from boac.models.alert import Alert
+import pytest
+
+
+def get_current_alerts():
+    return Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')['shown']
+
+
+term_id = '2178'
+
+
+@pytest.mark.usefixtures('db_session')
+class TestCacheUtils:
+    """Cache utils."""
+
+    def test_assignment_alerts_created_on_cache_load(self):
+        """Creates assignment alerts from fixtures on cache load."""
+        from boac.api.cache_utils import load_term
+        load_term(term_id)
+        alerts = get_current_alerts()
+        assert len(alerts) == 2
+        assert alerts[0]['alertType'] == 'late_assignment'
+        assert alerts[0]['message'] == 'MED ST 205 assignment due on Oct 6, 2017.'
+        assert alerts[1]['alertType'] == 'missing_assignment'
+        assert alerts[1]['message'] == 'MED ST 205 assignment due on Nov 3, 2017.'
+
+    def test_assignment_alerts_updated_on_cache_reload(self, app, db_session):
+        """Updates assignment alerts on cache reload."""
+        from boac.api.cache_utils import load_term, refresh_term
+        load_term(term_id)
+        assert len(get_current_alerts()) == 2
+
+        with open(app.config['BASE_DIR'] + '/fixtures/canvas_course_assignments_analytics_7654321_61889.json') as file:
+            # History is rewritten, so that the late assignment turns out to have been on time...
+            modified_response_body = file.read().replace('"status": "late"', '"status": "on_time"')
+            # ...meanwhile, the missing assignment shows up late.
+            modified_response_body = modified_response_body.replace('"status": "missing"', '"status": "late"')
+
+            def modified_assignment_analytics_fixture(course_id, uid, **kwargs):
+                if str(course_id) == '7654321' and str(uid) == '61889':
+                    return MockResponse(200, {}, modified_response_body)
+                else:
+                    return MockResponse(404, {}, '')
+            with register_mock(canvas._get_assignments_analytics, modified_assignment_analytics_fixture):
+                refresh_term(term_id)
+
+                db_alerts = db_session.query(Alert).order_by(Alert.created_at).all()
+                assert len(db_alerts) == 3
+                assert db_alerts[0].alert_type == 'late_assignment'
+                assert db_alerts[0].key == '2178_331896'
+                assert db_alerts[0].active is False
+                assert db_alerts[1].alert_type == 'missing_assignment'
+                assert db_alerts[1].key == '2178_331897'
+                assert db_alerts[1].active is False
+                assert db_alerts[2].alert_type == 'late_assignment'
+                assert db_alerts[2].key == '2178_331897'
+                assert db_alerts[2].active is True
+
+                api_alerts = get_current_alerts()
+                assert len(api_alerts) == 1
+                assert api_alerts[0]['alertType'] == 'late_assignment'
+                assert api_alerts[0]['message'] == 'MED ST 205 assignment due on Nov 3, 2017.'

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -51,9 +51,16 @@ class TestAnalytics:
     def test_canvas_course_assignments(self, app):
         """Summarizes the student assignment statuses from fixture."""
         uid = '61889'
+        sid = '11667051'
         canvas_course_id = 7654321
-        feed = canvas.get_assignments_analytics(canvas_course_id, uid, '2178')
-        digested = analytics.analytics_from_canvas_course_assignments(feed)
+        canvas_course_code = 'MED ST 205'
+        digested = analytics.analytics_from_canvas_course_assignments(
+            course_id=canvas_course_id,
+            course_code=canvas_course_code,
+            uid=uid,
+            sid=sid,
+            term_id='2178',
+        )
         assert digested['assignmentTotals']['floating'] == 2
         assert digested['assignmentTotals']['missing'] == 1
         assert digested['assignmentTotals']['onTime'] == 3

--- a/tests/test_models/test_alert.py
+++ b/tests/test_models/test_alert.py
@@ -1,0 +1,59 @@
+from boac.models.alert import Alert
+import pytest
+
+
+def get_current_alerts():
+    return Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')['shown']
+
+
+alert_props = {
+    'sid': '11667051',
+    'term_id': '2178',
+    'assignment_id': '987654321',
+    'due_at': '2017-10-31T12:00:00Z',
+    'status': 'missing',
+    'course_site_name': 'MED ST 205',
+}
+
+
+@pytest.mark.usefixtures('db_session')
+class TestAlert:
+    """Student status alerts."""
+
+    def test_update_assignment_alerts(self):
+        """Can be created from assignment data."""
+        assert len(get_current_alerts()) == 0
+        Alert.update_assignment_alerts(**alert_props)
+        alerts = get_current_alerts()
+        assert len(alerts) == 1
+        assert alerts[0]['id'] > 0
+        assert alerts[0]['alertType'] == 'missing_assignment'
+        assert alerts[0]['key'] == '2178_987654321'
+        assert alerts[0]['message'] == 'MED ST 205 assignment due on Oct 31, 2017.'
+
+    def test_no_duplicate_alerts(self):
+        """If an alert exists with the same key, updates the message rather than creating a duplicate."""
+        assert len(get_current_alerts()) == 0
+        Alert.update_assignment_alerts(**alert_props)
+        updated_alert_props = dict(alert_props, due_at='2017-12-25T12:00:00Z')
+        Alert.update_assignment_alerts(**updated_alert_props)
+        alerts = get_current_alerts()
+        assert len(alerts) == 1
+        assert alerts[0]['key'] == '2178_987654321'
+        assert alerts[0]['message'] == 'MED ST 205 assignment due on Dec 25, 2017.'
+
+    def test_deactivate_reactivate_alerts(self):
+        """Can be deactivated and reactivated, preserving id."""
+        assert len(get_current_alerts()) == 0
+        Alert.update_assignment_alerts(**alert_props)
+        alerts = get_current_alerts()
+        assert len(alerts) == 1
+        alert_id = alerts[0]['id']
+
+        Alert.deactivate_all(sid='11667051', term_id='2178', alert_types=['missing_assignment'])
+        assert len(get_current_alerts()) == 0
+
+        Alert.update_assignment_alerts(**alert_props)
+        alerts = get_current_alerts()
+        assert len(alerts) == 1
+        assert alerts[0]['id'] == alert_id


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-411 has subtasks, but I could figure out no clever and clean way to split up the work into separate PRs.