### PR TITLE
BOAC-466, menu options on cohort view get property-naming convention

### DIFF
--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -68,12 +68,12 @@
           <li class="cohort-filter-list-item"
               role="menuitem"
               data-ng-repeat="option in search.options.teamGroups">
-            <input id="search-option-team-{{option.groupCode}}"
+            <input id="search-option-team-{{option.id}}"
                    type="checkbox"
                    data-ng-model="option.selected"
-                   aria-label="{{option.groupName}}"
+                   aria-label="{{option.name}}"
                    data-ng-click="option.onClick('teamGroups', option)"/>
-            <span data-ng-bind="option.groupName"></span></li>
+            <span data-ng-bind="option.name"></span></li>
         </ul>
       </div>
     </div>
@@ -109,7 +109,7 @@
           <li class="cohort-filter-list-item"
               role="menuitem"
               data-ng-repeat="option in search.options.levels">
-            <input id="search-option-level-{{option.value}}"
+            <input id="search-option-level-{{option.id}}"
                    type="checkbox"
                    data-ng-model="option.selected"
                    aria-label="{{option.name}}"
@@ -151,7 +151,7 @@
               data-ng-class="{'divider': !option}"
               role="menuitem"
               data-ng-repeat="option in search.options.majors">
-            <input id="search-option-major-{{option.name}}"
+            <input id="search-option-major-{{option.id}}"
                    type="checkbox"
                    data-ng-model="option.selected"
                    aria-label="{{option.name}}"
@@ -194,7 +194,7 @@
           <li class="cohort-filter-list-item"
               role="menuitem"
               data-ng-repeat="option in search.options.gpaRanges">
-            <input id="search-option-gpa-range-{{$index}}"
+            <input id="search-option-gpa-range-{{option.id}}"
                    type="checkbox"
                    data-ng-model="option.selected"
                    aria-label="{{option.name}}"
@@ -235,7 +235,7 @@
           <li class="cohort-filter-list-item"
             role="menuitem"
             data-ng-repeat="option in search.options.unitRanges">
-          <input id="search-option-unit-range-{{$index}}"
+          <input id="search-option-unit-range-{{option.id}}"
                  type="checkbox"
                  data-ng-model="option.selected"
                  aria-label="{{option.name}}"
@@ -305,7 +305,7 @@
         <select id="cohort-sort-by"
                 class="form-control"
                 data-ng-model="orderBy.selected"
-                data-ng-options="o.value as o.label for o in orderBy.options">
+                data-ng-options="o.value as o.name for o in orderBy.options">
         </select>
       </div>
     </div>

--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -63,13 +63,13 @@
 
     $scope.orderBy = {
       options: [
-        {value: 'first_name', label: 'First Name'},
-        {value: 'last_name', label: 'Last Name'},
-        {value: 'group_name', label: 'Team'},
-        {value: 'gpa', label: 'GPA'},
-        {value: 'level', label: 'Level'},
-        {value: 'major', label: 'Major'},
-        {value: 'units', label: 'Units'}
+        {name: 'First Name', value: 'first_name'},
+        {name: 'Last Name', value: 'last_name'},
+        {name: 'Team', value: 'group_name'},
+        {name: 'GPA', value: 'gpa'},
+        {name: 'Level', value: 'level'},
+        {name: 'Major', value: 'major'},
+        {name: 'Units', value: 'units'}
       ],
       selected: 'first_name'
     };
@@ -104,11 +104,13 @@
      */
     var getStudents = function(orderBy, offset, limit, updateBrowserLocation) {
       var opts = $scope.search.options;
-      var gpaRanges = cohortService.getSelected(opts.gpaRanges, 'value');
-      var groupCodes = cohortService.getSelected(opts.teamGroups, 'groupCode');
-      var levels = cohortService.getSelected(opts.levels, 'name');
-      var majors = cohortService.getSelected(opts.majors, 'name');
-      var unitRanges = cohortService.getSelected(opts.unitRanges, 'value');
+      var getValues = utilService.getValuesSelected;
+      // Get values where selected=true
+      var gpaRanges = getValues(opts.gpaRanges);
+      var groupCodes = getValues(opts.teamGroups, 'groupCode');
+      var levels = getValues(opts.levels);
+      var majors = getValues(opts.majors);
+      var unitRanges = getValues(opts.unitRanges);
       if (updateBrowserLocation) {
         $location.search('c', 'search');
         $location.search('g', gpaRanges);
@@ -553,12 +555,14 @@
         var teamGroups = teamsResponse.data;
 
         getMajors(function(majors) {
+          var decorate = utilService.decorateOptions;
+          // 'decorate' is used to standardize (eg, assign 'id' property) each set of menu options
           $scope.search.options = {
-            gpaRanges: studentFactory.getGpaRanges(),
-            levels: studentFactory.getStudentLevels(),
-            majors: majors,
-            teamGroups: teamGroups,
-            unitRanges: studentFactory.getUnitRanges()
+            gpaRanges: decorate(studentFactory.getGpaRanges(), 'name'),
+            levels: decorate(studentFactory.getStudentLevels(), 'name'),
+            majors: decorate(majors, 'name'),
+            teamGroups: decorate(teamGroups, 'groupName'),
+            unitRanges: decorate(studentFactory.getUnitRanges(), 'name')
           };
           // Filter options to 'selected' per request args
           presetSearchFilters(args);

--- a/boac/static/app/cohort/cohortService.js
+++ b/boac/static/app/cohort/cohortService.js
@@ -246,10 +246,6 @@
       dot.on('mouseout', onDotDeselected);
     };
 
-    var getSelected = function(filterOptions, property) {
-      return _.map(_.filter(filterOptions, 'selected'), property);
-    };
-
     var validateCohortLabel = function(cohort, callback) {
       if (cohort.label === 'Intensive') {
         return callback('Sorry, \'Intensive\' is a reserved name. Please choose a different name.');
@@ -270,7 +266,6 @@
 
     return {
       drawScatterplot: drawScatterplot,
-      getSelected: getSelected,
       validateCohortLabel: validateCohortLabel
     };
 

--- a/boac/static/app/cohort/createCohortController.js
+++ b/boac/static/app/cohort/createCohortController.js
@@ -20,15 +20,20 @@
     };
   });
 
-  angular.module('boac').controller('CreateCohortModal', function(filters, cohortFactory, cohortService, $rootScope, $scope, $uibModalInstance) {
-
-    // If we use the name '$scope.cohort' then we will collide with model name of underlying /cohort view.
+  angular.module('boac').controller('CreateCohortModal', function(
+    filters,
+    cohortFactory,
+    cohortService,
+    utilService,
+    $rootScope,
+    $scope,
+    $uibModalInstance
+  ) {
     $scope.label = null;
     $scope.error = {
       hide: false,
       message: null
     };
-
     $scope.create = function() {
       // The 'error.hide' flag allows us to hide validation error on-change of form input.
       $scope.error.hide = false;
@@ -42,13 +47,15 @@
           $scope.error.message = errorMessage;
           if (!$scope.error.message) {
             $rootScope.isSaving = true;
+            var getValues = utilService.getValuesSelected;
+            // Get values where selected=true
             cohortFactory.createCohort(
               $scope.label,
-              cohortService.getSelected(filters.gpaRanges, 'value'),
-              cohortService.getSelected(filters.teamGroups, 'groupCode'),
-              cohortService.getSelected(filters.levels, 'name'),
-              cohortService.getSelected(filters.majors, 'name'),
-              cohortService.getSelected(filters.unitRanges, 'value')
+              getValues(filters.gpaRanges),
+              getValues(filters.teamGroups, 'groupCode'),
+              getValues(filters.levels),
+              getValues(filters.majors),
+              getValues(filters.unitRanges)
             ).then(
               function() {
                 $rootScope.isSaving = false;

--- a/boac/static/app/shared/utilService.js
+++ b/boac/static/app/shared/utilService.js
@@ -12,8 +12,39 @@
       return formatted;
     };
 
+    /**
+     * Standard set of menu options per expectations of cohort-view, etc.
+     *
+     * @param  {Array}    options      Set of menu options
+     * @param  {String}   pkRef        Key used to get primary-key of each option in options
+     * @return {Array}                 Enhanced set of menu options (eg, unique 'id' property per option)
+     */
+    var decorateOptions = function(options, pkRef) {
+      return _.map(options, function(option) {
+        if (option && option[pkRef]) {
+          option.name = option.name || option[pkRef];
+          option.value = option.value || option[pkRef];
+          option.id = option.id || _.toLower(option.value.replace(/\W+/g, '-'));
+        }
+        return option;
+      });
+    };
+
+    /**
+     * Extract 'value' property of each selected option in options array.
+     *
+     * @param  {Array}    options      Set of menu options
+     * @param  {String}   [valueRef]   Optional key used to lookup value of menu option. Default key is 'value'.
+     * @return {Array}                 Values (strings) of selected options
+     */
+    var getValuesSelected = function(options, valueRef) {
+      return _.map(_.filter(options, 'selected'), valueRef || 'value');
+    };
+
     return {
-      format: format
+      decorateOptions: decorateOptions,
+      format: format,
+      getValuesSelected: getValuesSelected
     };
   });
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-466

The goal: Angular directive to render cohort-view dropdown. In order to have such a directive we must standardize property naming in menu options. Eg, `option.id` that plays nice in `<input id="team-{{option.id}}" />`