### PR TITLE
BOAC-472 Move tooltip from icon to button element

### DIFF
--- a/boac/static/app/user/watchlistToggle.html
+++ b/boac/static/app/user/watchlistToggle.html
@@ -1,13 +1,13 @@
 <button id="watchlist-toggle-{{sid}}"
         class="btn btn-link btn-watchlist-{{faSize}}"
         type="button"
+        uib-tooltip="{{faSize === 'text' ? '' : buttonLabel}}"
+        tooltip-animation="false"
+        tooltip-popup-close-delay="100"
+        tooltip-placement="bottom"
         data-ng-click="toggle($event)">
   <i class="{{faSize}}"
      data-ng-class="{'fa fa-minus-circle': onWatchlist, 'fa fa-plus-circle': !onWatchlist}"
-     uib-tooltip="{{buttonLabel}}"
-     tooltip-animation="false"
-     tooltip-popup-close-delay="100"
-     tooltip-placement="bottom"
      data-ng-if="faSize !== 'text'"></i>
   <span class="sr-only"
         data-ng-bind="buttonAltText"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-472

Per https://github.com/twbs/bootstrap/issues/11359, Firefox doesn't like tooltips on elements within buttons.