### PR TITLE
BOAC-469 No global regex in user search filter

### DIFF
--- a/boac/static/app/student/findStudentFilter.js
+++ b/boac/static/app/student/findStudentFilter.js
@@ -11,7 +11,7 @@
         var words = _.split(phrase, ' ');
         var regex;
         if (words.length === 1) {
-          regex = RegExp('\\b' + words[0], 'gi');
+          regex = RegExp('\\b' + words[0], 'i');
         } else {
           var p = '';
           _.each(words, function(word) {
@@ -19,7 +19,7 @@
               p = p.concat('\\b(' + word + ').* ');
             }
           });
-          regex = RegExp(_.trimEnd(p), 'gi');
+          regex = RegExp(_.trimEnd(p), 'i');
         }
         _.each(options, function(option) {
           if (regex.test(option.name)) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-469

See https://siderite.blogspot.com/2011/11/careful-when-reusing-javascript-regexp.html on this gotcha when using JavaScript global regexes; a secret index state persists from one test to the next and leads to all kinds of unexpected behavior. Since our filter is performing a simple yes-or-no test, it shouldn't need to worry about multiple matches.