### PR TITLE
BOAC-485 Drop "Participations" metrics from the UX

### DIFF
--- a/boac/static/app/student/courseSiteMetricsDirective.js
+++ b/boac/static/app/student/courseSiteMetricsDirective.js
@@ -31,12 +31,6 @@
             id: 'pageViews',
             label: 'Page Views',
             missingLabel: 'No Page Views'
-          },
-          {
-            dataset: scope.canvasSite.analytics.participations,
-            id: 'participations',
-            label: 'Participations',
-            missingLabel: 'No Participations'
           }
         ];
       }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-485

Sometimes I feel AngularJS 1 pushes us into unnecessary replication. This isn't one of those times.