### PR TITLE
BOAC-488 De-duplicate sids within students query

### DIFF
--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -14,13 +14,6 @@ def get(_dict, key, default_value=None):
     return _dict[key] if key in _dict else default_value
 
 
-def get_distinct_with_order(sequence):
-    """Remove duplicates from list whilst preserving order (see https://www.peterbe.com/plog/uniqifiers-benchmark)."""
-    seen = set()
-    seen_add = seen.add
-    return [x for x in sequence if not (x in seen or seen_add(x))]
-
-
 def vacuum_whitespace(str):
     """Collapse multiple-whitespace sequences into a single space; remove leading and trailing whitespace."""
     if not str:

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -111,17 +111,18 @@ class Student(Base):
             diff = {by_first_name, by_last_name} - {o, o_secondary}
             o_tertiary = diff.pop() if diff else 's.sid'
             sql = f"""SELECT
-                DISTINCT(s.sid), {o}, {o_secondary}, {o_tertiary}
+                s.sid, MIN({o}), MIN({o_secondary}), MIN({o_tertiary})
                 {query_tables}
                 {query_filter}
-                ORDER BY {o}, {o_secondary}, {o_tertiary}
+                GROUP BY s.sid
+                ORDER BY MIN({o}), MIN({o_secondary}), MIN({o_tertiary})
                 OFFSET {offset}
             """
             sql += f' LIMIT {limit}' if limit else ''
             # SQLAlchemy will escape parameter values
             result = connection.execute(text(sql), **all_bindings)
             # Model query using list of SIDs
-            sid_list = util.get_distinct_with_order([row['sid'] for row in result])
+            sid_list = [row['sid'] for row in result]
             connection.close()
             students = cls.query.filter(cls.sid.in_(sid_list)).all() if sid_list else []
             # Order of students from query (above) might not match order of sid_list.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-488

Using GROUP BY instead of DISTINCT preserves our ordering logic but de-duplicates within SQL. This eliminates the need for an extra function and ensures that de-duplication works across pagination offsets.