### PR TITLE
BOAC-497, 'name' is 'groupName' in team_groups feed

### DIFF
--- a/boac/models/athletics.py
+++ b/boac/models/athletics.py
@@ -34,6 +34,7 @@ class Athletics(Base):
             return {
                 'groupCode': row[0],
                 'groupName': row[1],
+                'name': row[1],
                 'teamCode': row[2],
                 'teamName': row[3],
                 'totalMemberCount': row[4],
@@ -91,6 +92,7 @@ class Athletics(Base):
         return {
             'groupCode': self.group_code,
             'groupName': self.group_name,
+            'name': self.group_name,
             'teamCode': self.team_code,
             'teamName': self.team_name,
         }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-497

On the front-end, if feed does not have 'name' property then it defaults to 'value'. So, name = groupName (according to feed).