### PR TITLE
BOAC-496 Tighten permissions on local config file

### DIFF
--- a/.ebextensions/03_download_local_configuration.config
+++ b/.ebextensions/03_download_local_configuration.config
@@ -6,3 +6,5 @@ container_commands:
     command: |
       aws s3 cp s3://boac-config/${EB_ENVIRONMENT}.py config/production-local.py
       printf "\nEB_ENVIRONMENT = '${EB_ENVIRONMENT}'\n\n" >> config/production-local.py
+      chown wsgi config/production-local.py
+      chmod 400 config/production-local.py

--- a/scripts/deploy_boac_config.sh
+++ b/scripts/deploy_boac_config.sh
@@ -42,6 +42,8 @@ echo "Use CTRL-C to abort..."; echo
 sleep 5
 
 AWS_REGION=us-west-2 aws s3 cp ${config_location} "${local_config}"
+chown wsgi "${local_config}"
+chmod 400 "${local_config}"
 
 # Add EB_ENVIRONMENT to new config file
 printf "\nEB_ENVIRONMENT = '${eb_env}'\n\n" >> "${local_config}"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-496

This change should go unnoticed, except that one will have to use `sudo` to view the file when logged into an instance as ec2-user.