### PR TITLE
BOAC-521 Tighten criteria for assignment alerts

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -1,6 +1,9 @@
+from datetime import datetime
 import math
 from statistics import mean
+
 from boac.externals import canvas
+from boac.lib.util import localize_datetime, utc_timestamp_to_localtime
 from boac.models.alert import Alert
 from boac.models.json_cache import stow
 from flask import current_app as app
@@ -111,15 +114,7 @@ def analytics_from_canvas_course_assignments(course_id, course_code, uid, sid, t
             },
         )
 
-        if assignment['status'] in ['late', 'missing']:
-            Alert.update_assignment_alerts(
-                sid=sid,
-                term_id=term_id,
-                assignment_id=assignment['assignment_id'],
-                due_at=assignment['due_at'],
-                status=assignment['status'],
-                course_site_name=course_code,
-            )
+        generate_assignment_alerts(assignment, submission, course_code, sid, term_id)
 
         assignment_data = {
             'id': assignment['assignment_id'],
@@ -192,6 +187,42 @@ def analytics_for_column(df, student_row, column_name):
         'courseDeciles': column_quantiles,
         'displayPercentile': display_percentile,
     }
+
+
+def generate_assignment_alerts(assignment, submission, course_code, sid, term_id):
+    # Only assignments with due dates and nonzero median scores inspire enough confidence for us to potentially
+    # generate a late or missing alert.
+    if not assignment['due_at'] or not assignment['median']:
+        return
+
+    due_date = utc_timestamp_to_localtime(assignment['due_at']).date()
+    # Late assignments generate an alert only if the submission date is later than the due date by local
+    # timezone.
+    if (assignment['status'] == 'late' and
+            submission['submitted_at'] and
+            due_date < utc_timestamp_to_localtime(submission['submitted_at']).date()):
+        Alert.update_assignment_alerts(
+            sid=sid,
+            term_id=term_id,
+            assignment_id=assignment['assignment_id'],
+            due_at=assignment['due_at'],
+            status='late',
+            course_site_name=course_code,
+        )
+    # Missing assignments generate an alert only if submission and score data really is absent, and the due
+    # date by local timezone was earlier than today.
+    elif (assignment['status'] == 'missing' and
+            not submission['submitted_at'] and
+            not submission['score'] and
+            due_date < localize_datetime(datetime.utcnow()).date()):
+        Alert.update_assignment_alerts(
+            sid=sid,
+            term_id=term_id,
+            assignment_id=assignment['assignment_id'],
+            due_at=assignment['due_at'],
+            status='missing',
+            course_site_name=course_code,
+        )
 
 
 def ordinal(nbr):

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -1,3 +1,9 @@
+from datetime import datetime
+
+from flask import current_app as app
+import pytz
+
+
 """Generic utilities."""
 
 
@@ -14,11 +20,8 @@ def get(_dict, key, default_value=None):
     return _dict[key] if key in _dict else default_value
 
 
-def vacuum_whitespace(str):
-    """Collapse multiple-whitespace sequences into a single space; remove leading and trailing whitespace."""
-    if not str:
-        return None
-    return ' '.join(str.split())
+def localize_datetime(dt):
+    return dt.astimezone(pytz.timezone(app.config['TIMEZONE']))
 
 
 def tolerant_remove(_list, item):
@@ -44,3 +47,15 @@ def to_bool_or_none(arg):
         s = False if s == 'false' else s
         s = None if s not in [True, False] else s
     return None if s is None else bool(s)
+
+
+def utc_timestamp_to_localtime(str):
+    utc_datetime = pytz.utc.localize(datetime.strptime(str, '%Y-%m-%dT%H:%M:%SZ'))
+    return localize_datetime(utc_datetime)
+
+
+def vacuum_whitespace(str):
+    """Collapse multiple-whitespace sequences into a single space; remove leading and trailing whitespace."""
+    if not str:
+        return None
+    return ' '.join(str.split())

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -3,11 +3,9 @@ from datetime import datetime
 from boac import db, std_commit
 from boac.api.errors import BadRequestError
 from boac.lib.berkeley import current_term_id
-from boac.lib.util import camelize
+from boac.lib.util import camelize, utc_timestamp_to_localtime
 from boac.models.base import Base
 from boac.models.db_relationships import AlertView
-from flask import current_app as app
-import pytz
 from sqlalchemy import text
 
 
@@ -164,8 +162,7 @@ class Alert(Base):
     def update_assignment_alerts(cls, sid, term_id, assignment_id, due_at, status, course_site_name):
         alert_type = status + '_assignment'
         key = f'{term_id}_{assignment_id}'
-        due_at_datetime = pytz.utc.localize(datetime.strptime(due_at, '%Y-%m-%dT%H:%M:%SZ'))
-        due_at_date = due_at_datetime.astimezone(pytz.timezone(app.config['TIMEZONE'])).strftime('%b %-d, %Y')
+        due_at_date = utc_timestamp_to_localtime(due_at).strftime('%b %-d, %Y')
         message = f'{course_site_name} assignment due on {due_at_date}.'
         cls.create_or_activate(sid=sid, alert_type=alert_type, key=key, message=message)
 

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -39,6 +39,7 @@ class TestCacheUtils:
             modified_response_body = file.read().replace('"status": "late"', '"status": "on_time"')
             # ...meanwhile, the missing assignment shows up late.
             modified_response_body = modified_response_body.replace('"status": "missing"', '"status": "late"')
+            modified_response_body = modified_response_body.replace('"submitted_at": null', '"submitted_at": "2017-11-04T01:00:00Z"')
 
             def modified_assignment_analytics_fixture(course_id, uid, **kwargs):
                 if str(course_id) == '7654321' and str(uid) == '61889':

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -1,5 +1,7 @@
 from boac.externals import canvas
 from boac.lib import analytics
+from boac.lib.mockingbird import MockResponse, register_mock
+from boac.models.alert import Alert
 
 
 class TestAnalytics:
@@ -237,3 +239,136 @@ class TestAnalyticsFromSummaryFeed:
         assert digested['participations']['courseDeciles'][10] == 11
         assert digested['pageViews']['displayPercentile'] == '0th'
         assert digested['pageViews']['boxPlottable'] is True
+
+
+class TestAssignmentAlerts:
+    """Canvas course assignment alerts."""
+
+    canvas_course_id = 7654321
+    canvas_course_code = 'BURMESE 1A'
+    uid = '61889'
+    sid = '11667051'
+    term_id = '2178'
+    viewer_id = '2040'
+
+    late_assignment_feed = """[{
+        "assignment_id": 331896,
+        "title": "Hard Job",
+        "unlock_at": null,
+        "points_possible": 1.0,
+        "non_digital_submission": false,
+        "multiple_due_dates": false,
+        "due_at": "2017-10-06T06:00:00Z",
+        "status": "late",
+        "muted": false,
+        "max_score": 1.0,
+        "min_score": 0.0,
+        "first_quartile": 1.0,
+        "median": 1.0,
+        "third_quartile": 1.0,
+        "module_ids": [],
+        "excused": false,
+        "submission": {
+            "score": 0.75,
+            "submitted_at": "2017-10-06T20:17:50Z"
+        }
+    }]"""
+
+    missing_assignment_feed = """[{
+        "assignment_id": 331897,
+        "title": "Impossible Job",
+        "unlock_at": null,
+        "points_possible": 1.0,
+        "non_digital_submission": false,
+        "multiple_due_dates": false,
+        "due_at": "2017-10-06T06:00:00Z",
+        "status": "missing",
+        "muted": false,
+        "max_score": 1.0,
+        "min_score": 0.0,
+        "first_quartile": 1.0,
+        "median": 1.0,
+        "third_quartile": 1.0,
+        "module_ids": [],
+        "excused": false,
+        "submission": {
+            "score": null,
+            "submitted_at": null
+        }
+    }]"""
+
+    def generate_assignment_alerts(self):
+        analytics.analytics_from_canvas_course_assignments(self.canvas_course_id, self.canvas_course_code, self.uid, self.sid, self.term_id)
+        return Alert.current_alerts_for_sid(sid=self.sid, viewer_id=self.viewer_id)['shown']
+
+    def test_late_assignment_alert_generated(self):
+        """Generates an alert for a late assignment."""
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, self.late_assignment_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 1
+            assert alerts[0]['alertType'] == 'late_assignment'
+            assert alerts[0]['message'] == 'BURMESE 1A assignment due on Oct 5, 2017.'
+
+    def test_slightly_late_assignment_alert_ignored(self):
+        """Generates no alerts for slightly late assignments."""
+        modified_feed = self.late_assignment_feed.replace('2017-10-06T20:17:50Z', '2017-10-06T06:59:00Z')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0
+
+    def test_late_assignment_alert_with_zero_median_ignored(self):
+        """Generates no alerts for a late assignment with class median of zero."""
+        modified_feed = self.late_assignment_feed.replace('"median": 1.0', '"median": 0.0')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0
+
+    def test_late_assignment_alert_with_null_median_ignored(self):
+        """Generates no alerts for a late assignment with null class median."""
+        modified_feed = self.late_assignment_feed.replace('"median": 1.0', '"median": null')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0
+
+    def test_missing_assignment_alert_generated(self):
+        """Generates an alert for a missing assignment."""
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, self.missing_assignment_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 1
+            assert alerts[0]['alertType'] == 'missing_assignment'
+            assert alerts[0]['message'] == 'BURMESE 1A assignment due on Oct 5, 2017.'
+
+    def test_missing_assignment_alert_with_zero_median_ignored(self):
+        """Generates no alerts for a missing assignment with class median of zero."""
+        modified_feed = self.missing_assignment_feed.replace('"median": 1.0', '"median": 0.0')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0
+
+    def test_missing_assignment_alert_with_null_median_ignored(self):
+        """Generates no alerts for a missing assignment with null class median."""
+        modified_feed = self.missing_assignment_feed.replace('"median": 1.0', '"median": null')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0
+
+    def test_missing_assignment_alert_with_score_ignored(self):
+        """Generates no alerts for a missing assignment with a score."""
+        modified_feed = self.missing_assignment_feed.replace('"score": null', '"score": 1.0')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0
+
+    def test_missing_assignment_alert_with_submission_date_ignored(self):
+        """Generates no alerts for a missing assignment with a submission date."""
+        modified_feed = self.missing_assignment_feed.replace('"submitted_at": null', '"submitted_at": "2017-10-06T06:01:00Z"')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0
+
+    def test_missing_assignment_alert_with_no_due_date_ignored(self):
+        """Generates no alerts for a missing assignment with no due date."""
+        modified_feed = self.missing_assignment_feed.replace('"due_at": "2017-10-06T06:00:00Z"', '"due_at": null')
+        with register_mock(canvas._get_assignments_analytics, MockResponse(200, {}, modified_feed)):
+            alerts = self.generate_assignment_alerts()
+            assert len(alerts) == 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-521

This PR inserts more stringent criteria for what counts as a late or missing assignment, in an attempt to screen out false positives as discovered in https://jira.ets.berkeley.edu/jira/browse/BOAC-519.

If the code passes muster and is merged, I'd like to follow it up with a cache refresh on boac-dev. We should then be able to take a broad look at which alerts survived the cull, and decide on this feature's fate for the sprint.