### PR TITLE
BOAC-528 Display feedback link

### DIFF
--- a/boac/static/app/main.css
+++ b/boac/static/app/main.css
@@ -156,6 +156,12 @@
   padding: 17px 20px 10px 10px;
 }
 
+.header-feedback {
+  font-size: 14px;
+  padding: 10px 0 0 0;
+  text-align: right;
+}
+
 .loading-spinner-large {
   position: fixed;
   top: 0;

--- a/boac/static/app/shared/header.html
+++ b/boac/static/app/shared/header.html
@@ -25,3 +25,6 @@
     </li>
   </ul>
 </div>
+<div data-ng-if="!hideFeedbackLink" class="header-feedback">
+  Questions or feedback? Contact us at <a href="mailto:ascpilot@lists.berkeley.edu">ascpilot@lists.berkeley.edu</a>
+</div>

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -10,6 +10,9 @@
       <a data-ng-href="{{returnUrl}}">
         <i class="fa fa-arrow-left" aria-hidden="true"></i> Return to cohort
       </a>
+      <div class="container-right">
+        Questions or feedback? Contact us at <a href="mailto:ascpilot@lists.berkeley.edu">ascpilot@lists.berkeley.edu</a>
+      </div>
     </div>
     <div class="student-profile-header">
       <div class="student-profile-avatar-container">

--- a/boac/static/app/student/studentController.js
+++ b/boac/static/app/student/studentController.js
@@ -57,6 +57,7 @@
         var url = $base64.decode(decodeURIComponent(encodedReturnUrl));
         var separator = _.includes(url, '?') ? '&' : '?';
         $scope.returnUrl = url + separator + 'a=' + uid;
+        $scope.hideFeedbackLink = true;
       }
     };
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-528

The `hideFeedbackLink` is pretty cheesy, but alternative approaches I considered brought in too many redundancies for comfort. Let me know if you'd rather have the duplications, or if you see a better way.