### PR TITLE
BOAC-468 CAS redirect: parse URLs right

### DIFF
--- a/boac/auth/cas_auth.py
+++ b/boac/auth/cas_auth.py
@@ -27,7 +27,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from urllib.parse import urlencode
 
 from boac.api.errors import ForbiddenRequestError
-from boac.lib.http import tolerant_jsonify
+from boac.lib.http import add_param_to_url, tolerant_jsonify
 import cas
 from flask import (
     current_app as app, flash, redirect, request, url_for,
@@ -58,8 +58,11 @@ def cas_login():
         raise ForbiddenRequestError('Unknown account')
     login_user(user)
     flash('Logged in successfully.')
+    if not target_url:
+        target_url = '/'
     # The 'casLogin' marker is used by googleAnalyticsService to track CAS login events
-    return redirect((target_url or '/') + '?casLogin=true')
+    redirect_url = add_param_to_url(target_url, ('casLogin', 'true'))
+    return redirect(redirect_url)
 
 
 @app.route('/logout')

--- a/boac/lib/http.py
+++ b/boac/lib/http.py
@@ -42,6 +42,13 @@ class ResponseExceptionWrapper:
         return False
 
 
+def add_param_to_url(url, param):
+    parsed_url = urllib.parse.urlparse(url)
+    parsed_query = urllib.parse.parse_qsl(parsed_url.query)
+    parsed_query.append(param)
+    return urllib.parse.urlunparse(parsed_url._replace(query=urllib.parse.urlencode(parsed_query)))
+
+
 def build_url(url, query=None):
     encoded_query = urllib.parse.urlencode(query, doseq=True) if query else ''
     url_components = urllib.parse.urlparse(url)

--- a/boac/static/app/student/studentController.js
+++ b/boac/static/app/student/studentController.js
@@ -205,10 +205,20 @@
     var prepareReturnUrl = function(uid) {
       var encodedReturnUrl = $location.search().r;
       if (!_.isEmpty(encodedReturnUrl)) {
+        // Parse referring URL, remove CAS login param if present, and add anchor param with current UID.
         $location.search('r', null).replace();
         var url = $base64.decode(decodeURIComponent(encodedReturnUrl));
-        var separator = _.includes(url, '?') ? '&' : '?';
-        $scope.returnUrl = url + separator + 'a=' + uid;
+        var anchorParam = 'a=' + uid;
+        var urlComponents = url.split('?');
+        if (urlComponents.length > 1) {
+          url = urlComponents.shift();
+          var query = urlComponents.join('?');
+          query = query.replace(/&?casLogin=true/, '');
+          if (query.length) {
+            anchorParam = query + '&' + anchorParam;
+          }
+        }
+        $scope.returnUrl = url + '?' + anchorParam;
         $scope.hideFeedbackLink = true;
       }
     };


### PR DESCRIPTION
Fix for the reopened https://jira.ets.berkeley.edu/jira/browse/BOAC-468; and because there's always something extra, make sure the added CAS login param doesn't leak into constructed return URLs.