### PR TITLE
[QA] BOAC-550, group dropped sections in last row of course list, per term

### DIFF
--- a/boac/static/app/student/student.css
+++ b/boac/static/app/student/student.css
@@ -267,11 +267,15 @@
 }
 
 .student-profile-class .panel-heading {
-  padding: 10px 0;
+  padding: 5px 0 10px 0;
 }
 
 .student-profile-dropped-section {
   margin-top: 15px;
+}
+
+.student-profile-dropped-section-icon {
+  color: #f0ad4e;
 }
 
 .student-profile-dropped-section-title {
@@ -505,6 +509,10 @@
 
 .student-profile-term {
   border-bottom: 1px solid #999;
+}
+
+.student-profile-term .panel-group {
+  margin-bottom: 10px;
 }
 
 .student-profile-terms {

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -226,16 +226,19 @@
                   </course-site-metrics>
                 </div>
               </div>
-              <div data-ng-if="term.droppedSections.length">
-                <div data-ng-repeat="droppedSection in term.droppedSections" class="student-profile-dropped-section">
-                  <div class="student-profile-dropped-section-title">
-                    <span data-ng-bind="droppedSection.displayName"></span> -
-                    <span data-ng-bind="droppedSection.component"></span>
-                    <span data-ng-bind="droppedSection.sectionNumber"></span>
-                  </div>
-                  <div class="student-profile-class-notation">
-                    <i class="fa fa-exclamation-triangle student-profile-dropped-section-icon"></i> Dropped
-                  </div>
+            </div>
+            <div uib-accordion-group
+                 class="student-profile-class"
+                 is-open="true"
+                 data-ng-if="term.droppedSections.length">
+              <div data-ng-repeat="droppedSection in term.droppedSections">
+                <div class="student-profile-dropped-section-title">
+                  <span data-ng-bind="droppedSection.displayName"></span> -
+                  <span data-ng-bind="droppedSection.component"></span>
+                  <span data-ng-bind="droppedSection.sectionNumber"></span>
+                </div>
+                <div class="student-profile-class-notation">
+                  <i class="fa fa-exclamation-triangle student-profile-dropped-section-icon"></i> Dropped
                 </div>
               </div>
             </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-550

I used "always open" accordion block as seen at https://angular-ui.github.io/bootstrap/

![image](https://user-images.githubusercontent.com/7606442/36764777-08cba7fa-1be3-11e8-9aa5-6f3ea3fd2bb6.png)
