### PR TITLE
BOAC-533, class page > list view gets columns similar to cohort view

### DIFF
--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -42,7 +42,7 @@ def get_section(term_id, section_id):
 
     section = api_util.course_section_to_json(term_id=term_id, section=row)
     if 'students' in section:
-        member_details.merge_all(section['students'])
+        member_details.merge_all(section['students'], section['termId'])
     return tolerant_jsonify(section)
 
 

--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -155,7 +155,7 @@
             <div class="student-text">GPA (Cumulative)</div>
           </div>
           <div class="student-column">
-            <div class="student-gpa" data-ng-bind="student.currentTerm.enrolledUnits || '0'"></div>
+            <div class="student-gpa" data-ng-bind="student.term.enrolledUnits || '0'"></div>
             <div class="student-text">Units (In Progress)</div>
             <div class="student-gpa" data-ng-bind="student.cumulativeUnits || '--'"></div>
             <div class="student-text">Total Units</div>
@@ -167,7 +167,7 @@
               <div class="student-column-grade student-text">MID</div>
               <div class="student-column-grade student-text">FINAL</div>
             </div>
-            <div class="student-course-activity-row" data-ng-repeat="enrollment in student.currentTerm.enrollments">
+            <div class="student-course-activity-row" data-ng-repeat="enrollment in student.term.enrollments">
               <div class="student-column">
                 <div data-ng-bind="enrollment.displayName"></div>
               </div>

--- a/boac/static/app/course/course.html
+++ b/boac/static/app/course/course.html
@@ -55,6 +55,15 @@
         <div data-ng-show="tab === 'list'"
              data-ng-if="!isLoading && !error && section.students.length">
           <ul id="section-students-list" class="list-group">
+            <div class="list-group-item student-list-item">
+              <div class="student-avatar-container"></div>
+              <div class="student-name-container"></div>
+              <div class="student-text wrap-hard">ASSIGNMENTS ON TIME</div>
+              <div class="student-text wrap-hard">ASSIGNMENT GRADES</div>
+              <div class="student-text wrap-hard">PAGE VIEWS</div>
+              <div class="student-column-grade student-text">MID</div>
+              <div class="student-column-grade student-text">FINAL</div>
+            </div>
             <a class="list-group-item student-list-item"
                data-ng-class="{'list-group-item-info': anchor===student.uid}"
                id="{{student.uid}}"
@@ -88,6 +97,53 @@
                        data-ng-bind="membership.groupName"
                        data-ng-repeat="membership in student.athletics"></div>
                 </div>
+              </div>
+              <div class="student-column">
+                <ul class="flex-container flex-space-between" data-ng-repeat="canvasSite in student.enrollment.canvasSites">
+                  <li>
+                    <div class="btn-nowrap">
+                      Score: <strong data-ng-bind="canvasSite.analytics.assignmentsOnTime.student.raw"></strong>
+                    </div>
+                    <span class="profile-course-site-metrics-maximum btn-nowrap">
+                      (Maximum: <span data-ng-bind="canvasSite.analytics.assignmentsOnTime.courseDeciles[10]"></span>)
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div class="student-column">
+                <ul class="flex-container flex-space-between" data-ng-repeat="canvasSite in student.enrollment.canvasSites">
+                  <li>
+                    <div id="boxplot-{{student.uid}}-courseCurrentScore"
+                       class="profile-boxplot"
+                       data-ng-init="drawBoxplot(canvasSite, student.uid, 'courseCurrentScore')"></div>
+                  </li>
+                </ul>
+              </div>
+              <div class="student-column">
+                <div class="cohort-boxplot-container"
+                     data-ng-repeat="canvasSite in student.enrollment.canvasSites">
+                  <div id="boxplot-{{canvasSite.canvasCourseId}}-{{student.uid}}-pageviews"
+                       class="cohort-boxplot">
+                  </div>
+                </div>
+              </div>
+              <div class="student-column-grade">
+                <span class="cohort-grade"
+                      data-ng-bind="student.enrollment.midtermGrade"
+                      data-ng-if="student.enrollment.midtermGrade"></span>
+                <i class="fa fa-exclamation-triangle boac-exclamation"
+                   data-ng-if="isAlertGrade(student.enrollment.midtermGrade)"></i>
+                <span data-ng-if="!student.enrollment.midtermGrade">&mdash;</span>
+              </div>
+              <div class="student-column-grade">
+                <span class="cohort-grade"
+                      data-ng-bind="student.enrollment.grade"
+                      data-ng-if="student.enrollment.grade"></span>
+                <i class="fa fa-exclamation-triangle boac-exclamation"
+                   data-ng-if="isAlertGrade(student.enrollment.grade)"></i>
+                <span class="cohort-grading-basis"
+                      data-ng-bind="student.enrollment.gradingBasis"
+                      data-ng-if="!student.enrollment.grade"></span>
               </div>
             </a>
           </ul>

--- a/boac/static/app/shared/boxplotService.js
+++ b/boac/static/app/shared/boxplotService.js
@@ -203,6 +203,27 @@
     };
 
     /**
+     * @param  {Student[]}      students        Draw boxplots for students in list view.
+     * @return {Function}                       We recommend giving this function to $$postDigest
+     */
+    var drawBoxplots = function(students) {
+      return function() {
+        _.each(students, function(student) {
+          _.each(_.get(student, 'term.enrollments'), function(enrollment) {
+            _.each(_.get(enrollment, 'canvasSites'), function(canvasSite) {
+              var elementId = 'boxplot-' + canvasSite.canvasCourseId + '-' + student.uid + '-pageviews';
+              var dataset = _.get(canvasSite, 'analytics.pageViews');
+              // If the course site has not yet been viewed, then there is nothing to plot.
+              if (dataset && _.get(dataset, 'courseDeciles')) {
+                drawBoxplotCohort(elementId, dataset);
+              }
+            });
+          });
+        });
+      };
+    };
+
+    /**
      * Render a student-view boxplot from a given dataset to a given element.
      *
      * @param  {String}  elementId     Element id where the boxplot should be rendered
@@ -265,6 +286,7 @@
 
     return {
       drawBoxplotCohort: drawBoxplotCohort,
+      drawBoxplots: drawBoxplots,
       drawBoxplotStudent: drawBoxplotStudent
     };
   });

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -125,11 +125,12 @@ class TestAthletics:
         """Includes current-term active enrollments and analytics for team members."""
         response = client.get('/api/team/FHW')
         athlete = response.json['members'][0]
-        assert athlete['currentTerm']['termName'] == 'Fall 2017'
-        assert athlete['currentTerm']['enrolledUnits'] == 12.5
-        assert len(athlete['currentTerm']['enrollments']) == 3
-        assert athlete['currentTerm']['enrollments'][0]['displayName'] == 'BURMESE 1A'
-        assert len(athlete['currentTerm']['enrollments'][0]['canvasSites']) == 1
+        term = athlete['term']
+        assert term['termName'] == 'Fall 2017'
+        assert term['enrolledUnits'] == 12.5
+        assert len(term['enrollments']) == 3
+        assert term['enrollments'][0]['displayName'] == 'BURMESE 1A'
+        assert len(term['enrollments'][0]['canvasSites']) == 1
 
     def test_get_team_order_by(self, authenticated_session, client):
         expected = {

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -144,11 +144,13 @@ class TestCohortDetail:
         response = client.get('/api/cohort/{}?orderBy=firstName'.format(cohort_id))
         assert response.status_code == 200
         athlete = next(m for m in response.json['members'] if m['lastName'] == 'Lin')
-        assert athlete['currentTerm']['termName'] == 'Fall 2017'
-        assert athlete['currentTerm']['enrolledUnits'] == 12.5
-        assert len(athlete['currentTerm']['enrollments']) == 3
-        assert athlete['currentTerm']['enrollments'][0]['displayName'] == 'BURMESE 1A'
-        assert len(athlete['currentTerm']['enrollments'][0]['canvasSites']) == 1
+
+        term = athlete['term']
+        assert term['termName'] == 'Fall 2017'
+        assert term['enrolledUnits'] == 12.5
+        assert len(term['enrollments']) == 3
+        assert term['enrollments'][0]['displayName'] == 'BURMESE 1A'
+        assert len(term['enrollments'][0]['canvasSites']) == 1
         analytics = athlete['analytics']
         for metric in ['assignmentsOnTime', 'pageViews', 'participations', 'courseCurrentScore']:
             assert analytics[metric]['percentile'] > 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-533

* `member_details.merge_all` now has optional `term_id` arg (relevant to cache-key)
* front-end `drawBoxplot` logic is now shared 
* designs: https://jira.ets.berkeley.edu/jira/browse/BOAC-394