### PR TITLE
BOAC-580, if demo-mode then exclude student name from page title and breadcrumb

### DIFF
--- a/boac/static/app/course/courseController.js
+++ b/boac/static/app/course/courseController.js
@@ -30,6 +30,7 @@
   angular.module('boac').controller('CourseController', function(
     boxplotService,
     cohortService,
+    config,
     courseFactory,
     googleAnalyticsService,
     utilService,
@@ -42,6 +43,7 @@
     $stateParams
   ) {
 
+    $scope.demoMode = config.demoMode;
     $scope.isLoading = true;
     $scope.tab = 'list';
 

--- a/boac/static/app/shared/utilService.js
+++ b/boac/static/app/shared/utilService.js
@@ -27,7 +27,14 @@
 
   'use strict';
 
-  angular.module('boac').service('utilService', function($anchorScroll, $base64, $location, $rootScope, $timeout) {
+  angular.module('boac').service('utilService', function(
+    config,
+    $anchorScroll,
+    $base64,
+    $location,
+    $rootScope,
+    $timeout
+  ) {
 
     var anchorScroll = function(anchorId) {
       $timeout(function() {
@@ -144,7 +151,7 @@
       var label = null;
       if (returnUrl) {
         var name = $location.search().referringPageName;
-        if (name) {
+        if (name && !config.demoMode) {
           label = 'Return to ' + name;
           $location.search('referringPageName', null).replace();
         } else if (returnUrl.includes('student')) {

--- a/boac/static/app/student/studentController.js
+++ b/boac/static/app/student/studentController.js
@@ -73,15 +73,19 @@
 
     $scope.toCourseWithReturnUrl = function(event, termId, sectionId) {
       event.stopPropagation();
-      utilService.goTo('/course/' + termId + '/' + sectionId, getPreferredName());
+      var name = config.demoMode ? null : getPreferredName();
+      utilService.goTo('/course/' + termId + '/' + sectionId, name);
     };
 
     var loadStudent = function(uid, callback) {
       $scope.student.isLoading = true;
       studentFactory.analyticsPerUser(uid).then(function(analytics) {
         $scope.student = analytics.data;
-        var preferredName = $rootScope.pageTitle = getPreferredName();
+        var preferredName = getPreferredName();
 
+        if (!config.demoMode) {
+          $rootScope.pageTitle = preferredName;
+        }
         // Track view event
         _.each($scope.student.enrollmentTerms, function(term) {
           // Merge in unmatched canvas sites


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-580

`course.html` has blur-in-demo-mode logic but controller was missing `$scope.debugMode = ...`