### PR TITLE
BOAC-583, commit the db delete before proceeding to db inserts

### DIFF
--- a/boac/models/normalized_cache_enrollment.py
+++ b/boac/models/normalized_cache_enrollment.py
@@ -51,11 +51,13 @@ class NormalizedCacheEnrollment(Base):
 
     @classmethod
     def update_enrollments(cls, term_id, sid, sections):
+        term_id = int(term_id)
         # Previous enrollments might have been dropped
         cls.query.filter_by(term_id=term_id, sid=sid).delete()
+        std_commit()
         # Add fresh enrollment data
         for section in sections:
-            enrollment = cls(term_id=int(term_id), section_id=int(section['id']), sid=sid)
+            enrollment = cls(term_id=term_id, section_id=int(section['id']), sid=sid)
             db.session.add(enrollment)
         std_commit()
         cls._refresh_course_enrollments(term_id=term_id, sections=sections)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-583

Bulk deletion with SQL Alchemy has some gotchas according to [their own docs](http://docs.sqlalchemy.org/en/latest/orm/query.html#orm-specific-query-constructs) (see section on `delete synchronize_session=False`). I've encountered no such `IntegrityError` locally but boac-dev is a much better load test on this code. We want guaranteed order of operations: delete then add.
