### PR TITLE
BOAC-584 Stow and preload merge_enrollments

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -186,6 +186,9 @@ def load_canvas_externals(uid, term_id):
 
 def load_sis_externals(term_id, csid):
     from boac.externals import sis_degree_progress_api, sis_enrollments_api, sis_student_api
+    from boac.merged.sis_enrollments import merge_enrollment
+
+    term_name = berkeley.term_name_for_sis_id(term_id)
 
     success_count = 0
     failures = []
@@ -205,6 +208,8 @@ def load_sis_externals(term_id, csid):
 
     enrollments = sis_enrollments_api.get_enrollments(csid, term_id)
     if enrollments:
+        # Perform higher-level enrollments feed processing; update NormalizedCacheEnrollment.
+        merge_enrollment(csid, enrollments, term_id, term_name)
         success_count += 1
     elif enrollments is None:
         failures.append(f'SIS get_enrollments failed for CSID {csid}, term_id {term_id}')

--- a/boac/merged/sis_enrollments.py
+++ b/boac/merged/sis_enrollments.py
@@ -30,6 +30,7 @@ import boac.api.util as api_util
 from boac.externals import canvas, sis_enrollments_api
 from boac.lib.berkeley import sis_term_id_for_name
 from boac.models.alert import Alert
+from boac.models.json_cache import stow
 from boac.models.normalized_cache_enrollment import NormalizedCacheEnrollment
 from flask import current_app as app
 
@@ -82,6 +83,7 @@ def merge_sis_enrollments_for_term(canvas_course_sites, cs_id, term_name, includ
     return term_feed
 
 
+@stow('merged_enrollment_{cs_id}', for_term=True)
 def merge_enrollment(cs_id, enrollments, term_id, term_name):
     enrollments_by_class = {}
     sections_for_normalized_cache = []


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-584

From local testing, it looks like NormalizedCacheEnrollment logic can get expensive when run in series on many students in a cohort. We should get performance improvements by treating it like other normalized cache tables, updating only when a cache reload updates the source data.