### PR TITLE
BOAC-592 Restrict cohort boxplot directive to draw in list mode only

### DIFF
--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -175,7 +175,8 @@
                 <div class="cohort-boxplot-container" data-ng-repeat="canvasSite in enrollment.canvasSites">
                   <boxplot-draw class="cohort-boxplot"
                                 data-compact-tooltip="true"
-                                data-dataset="canvasSite.analytics.pageViews"></boxplot-draw>
+                                data-dataset="canvasSite.analytics.pageViews"
+                                data-ng-if="tab === 'list'"></boxplot-draw>
                 </div>
               </div>
               <div class="student-column-grade">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-592

Because the matrix/list toggle is a `data-ng-show` for d3 reasons, the boxplot directive needs an extra `data-ng-if` so it knows not to draw when it's not there.