### PR TITLE
BOAC-581, class page > filter canvas_sites per section id

### DIFF
--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -193,3 +193,10 @@ def degree_program_url_for_major(plan_description):
         return f'http://guide.berkeley.edu/undergraduate/degree-programs/{ACADEMIC_PLAN_TO_DEGREE_PROGRAM_PAGE[matched]}/'
     else:
         return None
+
+
+def extract_canvas_ccn(canvas_course_section):
+    # Manually created site sections will have no integration ID.
+    canvas_sis_section_id = canvas_course_section.get('sis_section_id') or ''
+    ccn_match = re.match(r'\ASEC:20\d{2}-[BCD]-(\d{5})', canvas_sis_section_id)
+    return ccn_match.group(1) if ccn_match else None

--- a/boac/merged/member_details.py
+++ b/boac/merged/member_details.py
@@ -67,6 +67,7 @@ def _merged_data(uid, csid, term_id):
         data['majors'] = sorted(plan.get('description') for plan in sis_profile.get('plans', []))
     canvas_profile = canvas.get_user_for_uid(uid)
     if canvas_profile:
+        data['canvasUserId'] = canvas_profile['id']
         term_name = term_name_for_sis_id(term_id)
         student_courses = canvas.get_student_courses(uid) or []
         student_courses_in_term = [course for course in student_courses if course.get('term', {}).get('name') == term_name]

--- a/boac/merged/sis_enrollments.py
+++ b/boac/merged/sis_enrollments.py
@@ -24,11 +24,9 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 
-import re
-
 import boac.api.util as api_util
 from boac.externals import canvas, sis_enrollments_api
-from boac.lib.berkeley import sis_term_id_for_name
+from boac.lib.berkeley import extract_canvas_ccn, sis_term_id_for_name
 from boac.models.alert import Alert
 from boac.models.json_cache import stow
 from boac.models.normalized_cache_enrollment import NormalizedCacheEnrollment
@@ -189,12 +187,7 @@ def merge_canvas_course_site(term_feed, site):
     if not sections:
         return
     for section in sections:
-        # Manually created site sections will have no integration ID.
-        canvas_sis_section_id = section.get('sis_section_id') or ''
-        ccn_match = re.match(r'\ASEC:20\d{2}-[BCD]-(\d{5})', canvas_sis_section_id)
-        if not ccn_match:
-            continue
-        canvas_ccn = ccn_match.group(1)
+        canvas_ccn = extract_canvas_ccn(section)
         if not canvas_ccn:
             continue
         for enrollment in term_feed['enrollments']:

--- a/boac/static/app/course/course.css
+++ b/boac/static/app/course/course.css
@@ -84,8 +84,9 @@
 
 .course-student-name-container {
   flex: 0.8;
-  margin-left: 20px;
-  min-width: 200px;
+  margin-left: 10px;
+  margin-right: 20px;
+  max-width: 150px;
 }
 
 .course-student-name-container button {

--- a/boac/static/app/course/course.html
+++ b/boac/static/app/course/course.html
@@ -114,7 +114,8 @@
               </div>
               <div class="student-column course-column-assignment-data">
                 <div data-ng-repeat="canvasSite in student.enrollment.canvasSites">
-                  <strong class="no-wrap" data-ng-bind="canvasSite.courseCode"></strong>
+                  <strong data-ng-if="student.enrollment.canvasSites.length > 1"
+                          data-ng-bind="canvasSite.courseCode"></strong>
                   <div class="no-wrap" data-ng-if="canvasSite.analytics.assignmentsOnTime.displayPercentile">
                     Score: <strong data-ng-bind="canvasSite.analytics.assignmentsOnTime.student.raw"></strong>
                     <span class="faint-text">
@@ -130,14 +131,16 @@
                 <div class="profile-boxplot-container"
                      data-ng-repeat="canvasSite in student.enrollment.canvasSites">
                   <boxplot-draw class="profile-boxplot"
-                                data-dataset="canvasSite.analytics.courseCurrentScore"></boxplot-draw>
+                                data-dataset="canvasSite.analytics.courseCurrentScore"
+                                data-ng-if="canvasSite.analytics.courseCurrentScore"></boxplot-draw>
                 </div>
               </div>
               <div class="student-column">
                 <div class="profile-boxplot-container"
                      data-ng-repeat="canvasSite in student.enrollment.canvasSites">
                   <boxplot-draw class="profile-boxplot"
-                                data-dataset="canvasSite.analytics.pageViews"></boxplot-draw>
+                                data-dataset="canvasSite.analytics.pageViews"
+                                data-ng-if="canvasSite.analytics.pageViews"></boxplot-draw>
                 </div>
               </div>
               <div class="student-column-grade">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-581

Do not show canvas-course-code if section id maps to a single canvas course site (ccn). Such filtering is used when calculating 'Average Student' numbers – still a work in progress.

![image](https://user-images.githubusercontent.com/7606442/37497676-09cb3e04-2877-11e8-86e7-aae2735cc2ff.png)
