### PR TITLE
[QA] BOAC-581, only primary-section related Canvas course sites are shown on /course page

### DIFF
--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -82,9 +82,9 @@ def get_section(term_id, section_id):
     return tolerant_jsonify(section)
 
 
-@app.route('/api/sections/ids_per_term')
+@app.route('/api/sections/cached')
 @login_required
-def summarize_sections_in_cache():
+def get_cached_sections():
     return tolerant_jsonify(NormalizedCacheEnrollment.summarize_sections_in_cache())
 
 

--- a/boac/static/app/course/courseController.js
+++ b/boac/static/app/course/courseController.js
@@ -94,9 +94,24 @@
 
       var args = _.clone($location.search());
       // For now, exclude 'Average Student'
-      courseFactory.getSection($stateParams.termId, $stateParams.sectionId, false).then(function(response) {
+      var includeAverage = false;
+
+      courseFactory.getSection($stateParams.termId, $stateParams.sectionId, includeAverage).then(function(response) {
         $rootScope.pageTitle = response.data.displayName;
         $scope.section = response.data;
+        _.each($scope.section.students, function(student) {
+          var canvasSites = _.get(student, 'enrollment.canvasSites');
+          if (canvasSites) {
+            // Only primary-section related Canvas course sites are shown on /course page
+            var primaries = [];
+            _.each(canvasSites, function(canvasSite) {
+              if (_.includes(canvasSite.courseCode, 'LEC')) {
+                primaries.push(canvasSite);
+              }
+            });
+            student.enrollment.canvasSites = primaries;
+          }
+        });
         // averageStudent has averages of ALL students, not just athletes
         var averageStudent = $scope.section.averageStudent;
         if (averageStudent) {

--- a/boac/static/app/course/courseFactory.js
+++ b/boac/static/app/course/courseFactory.js
@@ -29,8 +29,8 @@
 
   angular.module('boac').factory('courseFactory', function(utilService, $http) {
 
-    var getSectionIdsPerTerm = function() {
-      return $http.get('/api/sections/ids_per_term');
+    var getCachedCourseSections = function() {
+      return $http.get('/api/sections/cached');
     };
 
     var getSection = function(termId, sectionId, includeAverage) {
@@ -42,7 +42,7 @@
     };
 
     return {
-      getSectionIdsPerTerm: getSectionIdsPerTerm,
+      getCachedCourseSections: getCachedCourseSections,
       getSection: getSection
     };
   });

--- a/boac/static/app/shared/utilService.js
+++ b/boac/static/app/shared/utilService.js
@@ -57,6 +57,16 @@
       return formatted;
     };
 
+    var decorateEnrollments = function(enrollments, cachedSectionIds) {
+      _.each(enrollments, function(enrollment) {
+        _.each(enrollment.sections, function(section) {
+          enrollment.waitlisted = enrollment.waitlisted || section.enrollmentStatus === 'W';
+          section.displayName = section.component + ' ' + section.sectionNumber;
+          section.isViewableOnCoursePage = section.component === 'LEC' && cachedSectionIds && cachedSectionIds.indexOf(section.ccn) >= 0;
+        });
+      });
+    };
+
     /**
      * Standard set of menu options per expectations of cohort-view, etc.
      *
@@ -189,6 +199,7 @@
       anchorScroll: anchorScroll,
       camelCaseToDashes: camelCaseToDashes,
       constructReturnToLabel: constructReturnToLabel,
+      decorateEnrollments: decorateEnrollments,
       decorateOptions: decorateOptions,
       format: format,
       getEncodedAbsUrl: getEncodedAbsUrl,

--- a/boac/static/app/student/studentController.js
+++ b/boac/static/app/student/studentController.js
@@ -83,8 +83,8 @@
         $scope.student = analytics.data;
         preferredName = getPreferredName();
 
-        courseFactory.getSectionIdsPerTerm().then(function(response) {
-          var sectionIdsPerTerm = response.data;
+        courseFactory.getCachedCourseSections().then(function(response) {
+          var cachedSections = response.data;
 
           _.each($scope.student.enrollmentTerms, function(term) {
             // Merge in unmatched canvas sites
@@ -98,13 +98,7 @@
               });
             });
             term.enrollments = _.concat(term.enrollments, unmatched);
-            _.each(term.enrollments, function(course) {
-              _.each(course.sections, function(section) {
-                course.waitlisted = course.waitlisted || section.enrollmentStatus === 'W';
-                section.displayName = section.component + ' ' + section.sectionNumber;
-                section.isViewableOnCoursePage = (section.component === 'LEC') && sectionIdsPerTerm[term.termId].indexOf(section.ccn) >= 0;
-              });
-            });
+            utilService.decorateEnrollments(term.enrollments, cachedSections[term.termId]);
           });
         });
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-581

For the sake of clarity: `/api/sections/ids_per_term` ->  `/api/sections/cached`