### PR TITLE
[QA] BOAC-622, cohort 'level' dropdown must pre-pop with 'value' compare

### DIFF
--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -351,7 +351,7 @@
       var selectedCodes = $scope.cohort.groupCodes ? _.map($scope.cohort.groupCodes, 'groupCode') : getCohortCriteria('groupCodes');
       initFilter('groupCodes', 'groupCode', selectedCodes, onClickOption);
       // Levels
-      initFilter('levels', 'name', getCohortCriteria('levels'), onClickOption);
+      initFilter('levels', 'value', getCohortCriteria('levels'), onClickOption);
       // Majors (the 'Declared' and 'Undeclared' options are special)
       _.map($scope.search.options.majors, function(option) {
         if (option) {

--- a/boac/static/app/cohort/cohortFilterDropdown.html
+++ b/boac/static/app/cohort/cohortFilterDropdown.html
@@ -11,13 +11,11 @@
     <span class="cohort-filter-label">
       {{menuLabel}}
       <span data-ng-if="!isLoading && !isSaving">(<span data-ng-bind="search.count[menuType]"></span>)</span>
-      <i class="fa fa-chevron-down"
-         data-ng-if="!isLoading && !isSaving && !search.dropdown[isOpen]"></i>
+      <i class="fa"
+         data-ng-class="{'fa-spinner fa-spin': isLoading || isSaving, 'fa-chevron-down': !isLoading && !isSaving}"
+         data-ng-if="!search.dropdown[isOpen]"></i>
       <i class="fa fa-chevron-up"
          data-ng-if="!isLoading && !isSaving && search.dropdown[isOpen]"></i>
-      <i class="fa fa-spinner fa-spin"
-         aria-hidden="true"
-         data-ng-if="isLoading || isSaving"></i>
     </span>
   </button>
   <ul aria-labelledby="search-filter-{{id}}"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-622

Sneaky bonus fix: `fa-spinner` and `fa-chevron-down` cannot coexist on the page.