### PR TITLE
BOAC-626 Add library support for non-GET HTTP methods

### DIFF
--- a/boac/lib/http.py
+++ b/boac/lib/http.py
@@ -69,7 +69,7 @@ def get_next_page(response):
         return None
 
 
-def request(url, headers={}, auth=None, auth_params=None):
+def request(url, headers={}, method='get', auth=None, auth_params=None):
     """Exception and error catching wrapper for outgoing HTTP requests.
 
     :param url:
@@ -79,7 +79,9 @@ def request(url, headers={}, auth=None, auth_params=None):
         one was returned.
         Borrowing the Requests convention, successful responses are truthy and failures are falsey.
     """
-    app.logger.debug({'message': 'HTTP request', 'url': url, 'headers': sanitize_headers(headers)})
+    if method not in ['get', 'post', 'put', 'delete']:
+        raise ValueError(f'Unrecognized HTTP method "{method}"')
+    app.logger.debug({'message': 'HTTP request', 'url': url, 'method': method, 'headers': sanitize_headers(headers)})
     response = None
     try:
         # TODO handle methods other than GET
@@ -90,7 +92,8 @@ def request(url, headers={}, auth=None, auth_params=None):
             urllib_logger = logging.getLogger('urllib3')
             saved_level = urllib_logger.level
             urllib_logger.setLevel(logging.INFO)
-        response = requests.get(url, headers=headers, auth=auth, params=auth_params)
+        http_method = getattr(requests, method)
+        response = http_method(url, headers=headers, auth=auth, params=auth_params)
         if auth_params:
             urllib_logger.setLevel(saved_level)
         response.raise_for_status()

--- a/boac/lib/mockingbird.py
+++ b/boac/lib/mockingbird.py
@@ -98,6 +98,10 @@ def mockable(func):
         with mock(url):
             response = requests.get(url)
             ...
+
+    HTTP methods other than GET may be specified by a keyword argument to mock().
+        with mock(url, method='post'):
+            response = requests.post(url)
     """
     _mock_registry[func.__name__] = []
 
@@ -275,11 +279,11 @@ def register_mock(request_function, response):
 
 
 @contextmanager
-def _activate_mock(url, mock_response):
+def _activate_mock(url, mock_response, method='get'):
     if mock_response and _environment_supports_mocks():
         httpretty.enable()
-        # TODO handle methods other than GET
-        httpretty.register_uri(httpretty.GET, url, body=mock_response)
+        http_method = getattr(httpretty, method.upper())
+        httpretty.register_uri(http_method, url, body=mock_response)
         yield
         httpretty.disable()
     else:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-626

Sharing the generic part of ets-berkeley-edu/nessie#6 back to BOAC.