### PR TITLE
BOAC-626 No-op mock needs no-op kwargs

### DIFF
--- a/boac/lib/mockingbird.py
+++ b/boac/lib/mockingbird.py
@@ -305,7 +305,7 @@ def _get_fixtures_path():
 
 
 @contextmanager
-def _noop_mock(url):
+def _noop_mock(url, **kwargs):
     yield None
 
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-626

Small but important follow-up to #508; the no-op mock (used in non-test environments) has to take `kwargs` or the `method` keyword will blow it up.