### PR TITLE
BOAC-613, backend support for student_groups to replace 'watchlist'

### DIFF
--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -25,9 +25,9 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 
 """This package integrates with Flask-Login. Determine who can use the app and which privileges they have."""
-from boac import db, std_commit
+from boac import db
 from boac.models.base import Base
-from boac.models.db_relationships import advisor_watchlists, cohort_filter_owners
+from boac.models.db_relationships import cohort_filter_owners
 from flask_login import UserMixin
 
 
@@ -43,11 +43,6 @@ class AuthorizedUser(Base, UserMixin):
         'CohortFilter',
         secondary=cohort_filter_owners,
         back_populates='owners',
-        lazy=True,
-    )
-    watchlist = db.relationship(
-        'Student',
-        secondary=advisor_watchlists,
         lazy=True,
     )
     alert_views = db.relationship(
@@ -74,15 +69,6 @@ class AuthorizedUser(Base, UserMixin):
     def get_id(self):
         """Override UserMixin, since our DB conventionally reserves 'id' for generated keys."""
         return self.uid
-
-    def append_to_watchlist(self, student):
-        self.watchlist.append(student)
-        std_commit()
-
-    def remove_from_watchlist(self, sid):
-        watchlist = [s for s in self.watchlist if not s.sid == sid]
-        self.watchlist = watchlist
-        std_commit()
 
     @classmethod
     def find_by_uid(cls, uid):

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -30,14 +30,6 @@ from boac import db
 from boac.models.base import Base
 
 
-advisor_watchlists = db.Table(
-    'advisor_watchlists',
-    Base.metadata,
-    db.Column('watchlist_owner_uid', db.String(80), db.ForeignKey('authorized_users.uid'), primary_key=True),
-    db.Column('sid', db.String(80), db.ForeignKey('students.sid'), primary_key=True),
-)
-
-
 student_athletes = db.Table(
     'student_athletes',
     Base.metadata,
@@ -51,6 +43,14 @@ cohort_filter_owners = db.Table(
     Base.metadata,
     db.Column('cohort_filter_id', db.Integer, db.ForeignKey('cohort_filters.id'), primary_key=True),
     db.Column('user_id', db.Integer, db.ForeignKey('authorized_users.id'), primary_key=True),
+)
+
+
+student_group_members = db.Table(
+    'student_group_members',
+    Base.metadata,
+    db.Column('student_group_id', db.Integer, db.ForeignKey('student_groups.id'), primary_key=True),
+    db.Column('sid', db.String(80), db.ForeignKey('students.sid'), primary_key=True),
 )
 
 

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -30,6 +30,7 @@ from boac.models.athletics import Athletics
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
 from boac.models.student import Student
+from boac.models.student_group import StudentGroup
 # Models below are included so that db.create_all will find them.
 from boac.models.alert import Alert # noqa
 from boac.models.db_relationships import AlertView, cohort_filter_owners, student_athletes # noqa
@@ -250,13 +251,9 @@ def load_student_athletes():
     schlemiel.status_asc = 'Trouble'
     db.session.merge(schlemiel)
     advisor = AuthorizedUser.find_by_uid('6446')
-    advisor.watchlist = [
-        paul_kerschen,
-        sandeep,
-        brigitte,
-        paul_farestveit,
-    ]
-    db.session.add(advisor)
+    group = StudentGroup.get_or_create_my_watchlist(advisor.id)
+    for student in [paul_kerschen, sandeep, brigitte, paul_farestveit]:
+        StudentGroup.add_student(group.id, student.sid)
     std_commit(allow_test_environment=True)
 
 

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -28,7 +28,7 @@ from boac import db, std_commit
 import boac.api.util as api_util
 from boac.lib import util
 from boac.models.base import Base
-from boac.models.db_relationships import student_athletes
+from boac.models.db_relationships import student_athletes, student_group_members
 from sqlalchemy import text
 from sqlalchemy.orm import joinedload
 
@@ -52,6 +52,11 @@ class Student(Base):
     athletics = db.relationship('Athletics', secondary=student_athletes, back_populates='athletes')
     is_active_asc = db.Column(db.Boolean, nullable=False, default=True)
     status_asc = db.Column(db.String(80))
+    group_memberships = db.relationship(
+        'StudentGroup',
+        secondary=student_group_members,
+        lazy=True,
+    )
 
     def __repr__(self):
         return f"""<Athlete sid={self.sid}, uid={self.uid}, first_name={self.first_name}, last_name={self.last_name},

--- a/boac/models/student_group.py
+++ b/boac/models/student_group.py
@@ -1,0 +1,110 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from boac import db, std_commit
+from boac.models.base import Base
+from boac.models.db_relationships import student_group_members
+from boac.models.student import Student
+
+
+class StudentGroup(Base):
+    __tablename__ = 'student_groups'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
+    owner_id = db.Column(db.String(80), db.ForeignKey('authorized_users.id'), nullable=False)
+    name = db.Column(db.String(255), nullable=False)
+    students = db.relationship(
+        'Student',
+        secondary=student_group_members,
+        back_populates='group_memberships',
+    )
+
+    __table_args__ = (db.UniqueConstraint(
+        'owner_id',
+        'name',
+        name='student_groups_owner_id_name_unique_constraint',
+    ),)
+
+    def __init__(self, name, owner_id):
+        self.name = name
+        self.owner_id = owner_id
+
+    @classmethod
+    def get_or_create_my_watchlist(cls, owner_id):
+        # TODO: remove legacy support
+        name = 'My Students'
+        group = cls.query.filter_by(owner_id=owner_id, name=name).first()
+        if not group:
+            group = cls.create(owner_id, name)
+            std_commit()
+        return group
+
+    @classmethod
+    def find_by_id(cls, group_id):
+        return cls.query.filter_by(id=group_id).first()
+
+    @classmethod
+    def get_groups_by_owner_id(cls, owner_id):
+        return cls.query.filter_by(owner_id=owner_id).order_by(cls.name).all()
+
+    @classmethod
+    def create(cls, owner_id, name):
+        group = cls(name, owner_id)
+        db.session.add(group)
+        std_commit()
+        return group
+
+    @classmethod
+    def add_student(cls, group_id, sid):
+        group = cls.query.filter_by(id=group_id).first()
+        student = Student.find_by_sid(sid)
+        group.students.append(student)
+        std_commit()
+
+    @classmethod
+    def remove_student(cls, group_id, sid):
+        student = Student.find_by_sid(sid)
+        if student:
+            group = cls.find_by_id(group_id)
+            group.students.remove(student)
+            std_commit()
+
+    @classmethod
+    def delete(cls, group_id):
+        group = cls.query.filter_by(id=group_id).first()
+        if group:
+            db.session.delete(group)
+            std_commit()
+
+    def to_api_json(self):
+        _json = {
+            'id': self.id,
+            'ownerId': self.owner_id,
+            'name': self.name,
+        }
+        if self.students:
+            _json['students'] = [student.to_api_json() for student in self.students]
+        return _json

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -32,6 +32,14 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
 
+-- TODO: remove legacy indices
+ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_sid_fkey;
+ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_watchlist_owner_uid_fkey;
+ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_pkey;
+DROP TABLE IF EXISTS public.advisor_watchlists;
+
+--
+
 ALTER TABLE IF EXISTS ONLY public.student_athletes DROP CONSTRAINT IF EXISTS student_athletes_sid_fkey;
 ALTER TABLE IF EXISTS ONLY public.student_athletes DROP CONSTRAINT IF EXISTS student_athletes_group_code_fkey;
 ALTER TABLE IF EXISTS ONLY public.normalized_cache_students DROP CONSTRAINT IF EXISTS normalized_cache_students_sid_fkey;
@@ -42,8 +50,13 @@ ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS
 ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_sid_fkey;
 ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_viewer_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_alert_id_fkey;
-ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_watchlist_owner_uid_fkey;
-ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_sid_fkey;
+ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_student_group_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_sid_fkey;
+ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_owner_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_owner_id_name_unique_constraint;
+
+--
+
 DROP INDEX IF EXISTS public.normalized_cache_students_units_idx;
 DROP INDEX IF EXISTS public.normalized_cache_students_level_idx;
 DROP INDEX IF EXISTS public.normalized_cache_students_gpa_idx;
@@ -55,6 +68,10 @@ DROP INDEX IF EXISTS public.normalized_cache_enrollments_sid_idx;
 DROP INDEX IF EXISTS public.alerts_sid_idx;
 DROP INDEX IF EXISTS public.alert_views_viewer_id_idx;
 DROP INDEX IF EXISTS public.alert_views_alert_id_idx;
+DROP INDEX IF EXISTS public.student_groups_owner_id_idx;
+
+--
+
 ALTER TABLE IF EXISTS ONLY public.students DROP CONSTRAINT IF EXISTS students_pkey;
 ALTER TABLE IF EXISTS ONLY public.student_athletes DROP CONSTRAINT IF EXISTS student_athletes_pkey;
 ALTER TABLE IF EXISTS ONLY public.normalized_cache_students DROP CONSTRAINT IF EXISTS normalized_cache_students_pkey;
@@ -70,11 +87,15 @@ ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_sid_al
 ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_pkey;
 ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_pkey;
 ALTER TABLE IF EXISTS ONLY public.alembic_version DROP CONSTRAINT IF EXISTS alembic_version_pkc;
-ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_pkey;
+ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_pkey;
+ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_pkey;
 ALTER TABLE IF EXISTS public.json_cache ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.cohort_filters ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.authorized_users ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.alerts ALTER COLUMN id DROP DEFAULT;
+
+--
+
 DROP TABLE IF EXISTS public.students;
 DROP TABLE IF EXISTS public.student_athletes;
 DROP TABLE IF EXISTS public.normalized_cache_students;
@@ -92,4 +113,6 @@ DROP SEQUENCE IF EXISTS public.alerts_id_seq;
 DROP TABLE IF EXISTS public.alerts;
 DROP TABLE IF EXISTS public.alert_views;
 DROP TABLE IF EXISTS public.alembic_version;
-DROP TABLE IF EXISTS public.advisor_watchlists;
+DROP TABLE IF EXISTS public.student_group_members;
+DROP TABLE IF EXISTS public.student_groups;
+DROP SEQUENCE IF EXISTS public.student_groups_id_seq;

--- a/scripts/db/migrate/20180327-BOAC-613/01_create_student_groups_tables.sql
+++ b/scripts/db/migrate/20180327-BOAC-613/01_create_student_groups_tables.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+-- Groups have a name and an owner
+
+CREATE TABLE student_groups (
+  id SERIAL PRIMARY KEY,
+  owner_id INTEGER NOT NULL REFERENCES authorized_users (id) ON DELETE CASCADE,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX student_groups_owner_id_idx ON student_groups (owner_id);
+
+ALTER TABLE student_groups ADD CONSTRAINT student_groups_owner_id_name_unique_constraint UNIQUE (owner_id, name);
+
+-- Create linking table
+
+CREATE TABLE student_group_members (
+  student_group_id INTEGER NOT NULL REFERENCES student_groups (id) ON DELETE CASCADE,
+  sid VARCHAR(80) NOT NULL REFERENCES students (sid) ON DELETE CASCADE,
+
+  PRIMARY KEY (student_group_id, sid)
+);
+
+-- Export legacy data prior to step 02
+
+\copy advisor_watchlists TO '/tmp/advisor_watchlists.csv' DELIMITER ',' CSV HEADER;
+
+-- Done
+
+COMMIT;

--- a/scripts/db/migrate/20180327-BOAC-613/02_copy_advisor_lists_to_student_groups_table.py
+++ b/scripts/db/migrate/20180327-BOAC-613/02_copy_advisor_lists_to_student_groups_table.py
@@ -1,0 +1,57 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+import csv
+import os
+from boac.models.authorized_user import AuthorizedUser
+from boac.models.student_group import StudentGroup
+from scriptpath import scriptify
+
+
+@scriptify.in_app
+def main(app):
+    advisor_watchlists_data = '/tmp/advisor_watchlists.csv'
+    if os.path.isfile(advisor_watchlists_data):
+        with open(advisor_watchlists_data) as csv_file:
+            rows = csv.reader(csv_file)
+            # Skip first row
+            next(rows, None)
+            for row in rows:
+                owner_uid = row[0]
+                sid = row[1]
+                owner = AuthorizedUser.find_by_uid(owner_uid)
+                group = StudentGroup.find_by_owner_id(owner.id)
+                if not group:
+                    group = StudentGroup.create(owner.id, 'My Students')
+                StudentGroup.add_student(group.id, sid)
+                print(f'[INFO] Student {sid} added to the \'My Students\' group owned by UID {owner.uid}')
+    else:
+        print(f'[ERROR] File not found: {advisor_watchlists_data}')
+
+    print('\nDone. Enjoy the rest of your day.\n')
+
+
+main()

--- a/scripts/db/migrate/20180327-BOAC-613/03_drop_advisor_watchlists_table.sql
+++ b/scripts/db/migrate/20180327-BOAC-613/03_drop_advisor_watchlists_table.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE advisor_watchlists DROP CONSTRAINT advisor_watchlists_sid_fkey;
+ALTER TABLE advisor_watchlists DROP CONSTRAINT advisor_watchlists_watchlist_owner_uid_fkey;
+ALTER TABLE advisor_watchlists DROP CONSTRAINT advisor_watchlists_pkey;
+
+DROP TABLE advisor_watchlists CASCADE;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -38,14 +38,7 @@ SET default_tablespace = '';
 
 SET default_with_oids = false;
 
-CREATE TABLE advisor_watchlists (
-    watchlist_owner_uid character varying(80) NOT NULL,
-    sid character varying(80) NOT NULL
-);
-ALTER TABLE advisor_watchlists OWNER TO boac;
-ALTER TABLE ONLY advisor_watchlists
-    ADD CONSTRAINT advisor_watchlists_pkey PRIMARY KEY (watchlist_owner_uid, sid);
-
+--
 
 CREATE TABLE alert_views (
     alert_id integer NOT NULL,
@@ -59,6 +52,7 @@ ALTER TABLE ONLY alert_views
 CREATE INDEX alert_views_alert_id_idx ON alert_views USING btree (alert_id);
 CREATE INDEX alert_views_viewer_id_idx ON alert_views USING btree (viewer_id);
 
+--
 
 CREATE TABLE alerts (
     id integer NOT NULL,
@@ -86,6 +80,7 @@ ALTER TABLE ONLY alerts
     ADD CONSTRAINT alerts_sid_alert_type_key_unique_constraint UNIQUE (sid, alert_type, key);
 CREATE INDEX alerts_sid_idx ON alerts USING btree (sid);
 
+--
 
 CREATE TABLE athletics (
     group_code character varying(80) NOT NULL,
@@ -99,6 +94,7 @@ ALTER TABLE athletics OWNER TO boac;
 ALTER TABLE ONLY athletics
     ADD CONSTRAINT athletics_pkey PRIMARY KEY (group_code);
 
+--
 
 CREATE TABLE authorized_users (
     created_at timestamp with time zone NOT NULL,
@@ -124,6 +120,7 @@ ALTER TABLE ONLY authorized_users
 ALTER TABLE ONLY authorized_users
     ADD CONSTRAINT authorized_users_uid_key UNIQUE (uid);
 
+--
 
 CREATE TABLE cohort_filter_owners (
     cohort_filter_id integer NOT NULL,
@@ -133,6 +130,7 @@ ALTER TABLE cohort_filter_owners OWNER TO boac;
 ALTER TABLE ONLY cohort_filter_owners
     ADD CONSTRAINT cohort_filter_owners_pkey PRIMARY KEY (cohort_filter_id, user_id);
 
+--
 
 CREATE TABLE cohort_filters (
     id integer NOT NULL,
@@ -154,6 +152,44 @@ ALTER TABLE ONLY cohort_filters ALTER COLUMN id SET DEFAULT nextval('cohort_filt
 ALTER TABLE ONLY cohort_filters
     ADD CONSTRAINT cohort_filters_pkey PRIMARY KEY (id);
 
+--
+
+CREATE TABLE student_groups (
+  id INTEGER NOT NULL,
+  owner_id INTEGER NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+ALTER TABLE student_groups OWNER TO boac;
+CREATE SEQUENCE student_groups_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE student_groups_id_seq OWNER TO boac;
+ALTER SEQUENCE student_groups_id_seq OWNED BY student_groups.id;
+ALTER TABLE ONLY student_groups ALTER COLUMN id SET DEFAULT nextval('student_groups_id_seq'::regclass);
+ALTER TABLE ONLY student_groups
+    ADD CONSTRAINT student_groups_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY student_groups
+    ADD CONSTRAINT student_groups_owner_id_name_unique_constraint UNIQUE (owner_id, name);
+CREATE INDEX student_groups_owner_id_idx ON student_groups USING btree (owner_id);
+
+--
+
+CREATE TABLE student_group_members (
+  student_group_id INTEGER,
+  sid VARCHAR(80) NOT NULL
+);
+ALTER TABLE student_group_members OWNER TO boac;
+ALTER TABLE ONLY student_group_members
+    ADD CONSTRAINT student_group_members_pkey PRIMARY KEY (student_group_id, sid);
+CREATE INDEX student_group_members_student_group_id_idx ON student_group_members USING btree (student_group_id);
+CREATE INDEX student_group_members_sid_idx ON student_group_members USING btree (sid);
+
+--
 
 CREATE TABLE json_cache (
     created_at timestamp with time zone NOT NULL,
@@ -177,6 +213,7 @@ ALTER TABLE ONLY json_cache
 ALTER TABLE ONLY json_cache
     ADD CONSTRAINT json_cache_pkey PRIMARY KEY (id);
 
+--
 
 CREATE TABLE normalized_cache_student_majors (
     sid character varying(80) NOT NULL,
@@ -206,6 +243,7 @@ CREATE INDEX normalized_cache_students_gpa_idx ON normalized_cache_students USIN
 CREATE INDEX normalized_cache_students_level_idx ON normalized_cache_students USING btree (level);
 CREATE INDEX normalized_cache_students_units_idx ON normalized_cache_students USING btree (units);
 
+--
 
 CREATE TABLE normalized_cache_enrollments (
     term_id INTEGER NOT NULL,
@@ -221,6 +259,7 @@ CREATE INDEX normalized_cache_enrollments_term_id_idx ON normalized_cache_enroll
 CREATE INDEX normalized_cache_enrollments_section_id_idx ON normalized_cache_enrollments USING btree (section_id);
 CREATE INDEX normalized_cache_enrollments_sid_idx ON normalized_cache_enrollments USING btree (sid);
 
+--
 
 CREATE TABLE student_athletes (
     group_code character varying(80) NOT NULL,
@@ -230,6 +269,7 @@ ALTER TABLE student_athletes OWNER TO boac;
 ALTER TABLE ONLY student_athletes
     ADD CONSTRAINT student_athletes_pkey PRIMARY KEY (group_code, sid);
 
+--
 
 CREATE TABLE students (
     sid character varying(80) NOT NULL,
@@ -246,28 +286,38 @@ ALTER TABLE students OWNER TO boac;
 ALTER TABLE ONLY students
     ADD CONSTRAINT students_pkey PRIMARY KEY (sid);
 
+--
 
-ALTER TABLE ONLY advisor_watchlists
-    ADD CONSTRAINT advisor_watchlists_sid_fkey FOREIGN KEY (sid) REFERENCES students(sid) ON DELETE CASCADE;
-ALTER TABLE ONLY advisor_watchlists
-    ADD CONSTRAINT advisor_watchlists_watchlist_owner_uid_fkey FOREIGN KEY (watchlist_owner_uid) REFERENCES authorized_users(uid) ON DELETE CASCADE;
+ALTER TABLE ONLY student_group_members
+    ADD CONSTRAINT student_group_members_student_group_id_fkey FOREIGN KEY (student_group_id) REFERENCES student_groups(id) ON DELETE CASCADE;
+ALTER TABLE ONLY student_group_members
+    ADD CONSTRAINT student_group_members_sid_fkey FOREIGN KEY (sid) REFERENCES students(sid) ON DELETE CASCADE;
 
+--
+
+ALTER TABLE ONLY student_groups
+    ADD CONSTRAINT student_groups_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
+
+--
 
 ALTER TABLE ONLY alert_views
     ADD CONSTRAINT alert_views_alert_id_fkey FOREIGN KEY (alert_id) REFERENCES alerts(id) ON DELETE CASCADE;
 ALTER TABLE ONLY alert_views
     ADD CONSTRAINT alert_views_viewer_id_fkey FOREIGN KEY (viewer_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
 
+--
 
 ALTER TABLE ONLY alerts
     ADD CONSTRAINT alerts_sid_fkey FOREIGN KEY (sid) REFERENCES students(sid) ON DELETE CASCADE;
 
+--
 
 ALTER TABLE ONLY cohort_filter_owners
     ADD CONSTRAINT cohort_filter_owners_cohort_filter_id_fkey FOREIGN KEY (cohort_filter_id) REFERENCES cohort_filters(id) ON DELETE CASCADE;
 ALTER TABLE ONLY cohort_filter_owners
     ADD CONSTRAINT cohort_filter_owners_user_id_fkey FOREIGN KEY (user_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
 
+--
 
 ALTER TABLE ONLY normalized_cache_student_majors
     ADD CONSTRAINT normalized_cache_student_majors_sid_fkey FOREIGN KEY (sid) REFERENCES students(sid) ON DELETE CASCADE;
@@ -276,8 +326,11 @@ ALTER TABLE ONLY normalized_cache_students
 ALTER TABLE ONLY normalized_cache_enrollments
     ADD CONSTRAINT normalized_cache_enrollments_sid_fkey FOREIGN KEY (sid) REFERENCES students(sid) ON DELETE CASCADE;
 
+--
 
 ALTER TABLE ONLY student_athletes
     ADD CONSTRAINT student_athletes_group_code_fkey FOREIGN KEY (group_code) REFERENCES athletics(group_code) ON DELETE CASCADE;
 ALTER TABLE ONLY student_athletes
     ADD CONSTRAINT student_athletes_sid_fkey FOREIGN KEY (sid) REFERENCES students(sid) ON DELETE CASCADE;
+
+--

--- a/tests/test_api/test_advisor_watchlist_controller.py
+++ b/tests/test_api/test_advisor_watchlist_controller.py
@@ -24,8 +24,8 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 
-from boac.models.authorized_user import AuthorizedUser
 import pytest
+import simplejson as json
 
 test_uid = '6446'
 
@@ -39,42 +39,44 @@ class TestAdvisorWatchlist:
 
     def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
-        assert client.get('/api/watchlist/my').status_code == 401
+        assert client.get('/api/groups/my').status_code == 401
 
     def test_my_watchlist(self, authenticated_session, client):
         """Returns current_user's watchlist."""
-        response = client.get('/api/watchlist/my')
+        response = client.get('/api/groups/my')
         assert response.status_code == 200
-        watchlist = response.json
-        assert len(watchlist) == 4
-        names = [student['firstName'] + ' ' + student['lastName'] for student in response.json]
+        groups = response.json
+        assert len(groups) == 1
+        students = groups[0]['students']
+        names = [student['firstName'] + ' ' + student['lastName'] for student in students]
         assert ['Brigitte Lin', 'Paul Farestveit', 'Paul Kerschen', 'Sandeep Jayaprakash'] == names
 
     def test_watchlist_includes_alert_counts(self, create_alerts, authenticated_session, client):
-        watchlist = client.get('/api/watchlist/my').json
-        assert watchlist[0]['alertCount'] == 2
-        assert 'alertCount' not in watchlist[1]
-        assert 'alertCount' not in watchlist[2]
-        assert 'alertCount' not in watchlist[3]
+        groups = client.get('/api/groups/my').json
+        students = groups[0]['students']
+        assert students[0]['alertCount'] == 2
+        assert 'alertCount' not in students[1]
+        assert 'alertCount' not in students[2]
+        assert 'alertCount' not in students[3]
 
         alert_to_dismiss = client.get('/api/alerts/current/11667051').json['shown'][0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
-        watchlist = client.get('/api/watchlist/my').json
-        assert watchlist[0]['alertCount'] == 1
+        groups = client.get('/api/groups/my').json
+        assert groups[0]['students'][0]['alertCount'] == 1
 
-    def test_watchlist_add_and_remove(self, authenticated_session, client):
+    def test_create_add_and_remove(self, authenticated_session, client):
         """Add student to current_user's watchlist and then remove him."""
+        response = client.post(
+            '/api/group/create',
+            data=json.dumps({'name': 'Fun Boy Three'}),
+            content_type='application/json',
+        )
+        group = json.loads(response.data)
+        group_id = group['id']
         sid = '2345678901'
-        response = client.get(f'/api/watchlist/add/{sid}')
+        response = client.get(f'/api/group/{group_id}/add_student/{sid}')
         assert response.status_code == 200
-        current_user = AuthorizedUser.find_by_uid(test_uid)
-        watchlist = current_user.watchlist
-        assert len(watchlist) == 5
-        assert sid in [s.sid for s in watchlist]
-
-        # Next, remove from watchlist
-        client.get(f'/api/watchlist/remove/{sid}')
-        current_user = AuthorizedUser.find_by_uid(test_uid)
-        watchlist = current_user.watchlist
-        assert len(watchlist) == 4
-        assert sid not in [s.sid for s in watchlist]
+        groups = client.get('/api/groups/my').json
+        # Expect two groups because 'My Students' was created previously
+        assert len(groups) == 2
+        assert groups[0]['students'][0]['sid'] == sid


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-613

* Flint and l settled on `student_groups`. Using `list` in the name is vague and overlaps with `cohort` def'n
* Although we're dropping the `advisor_watchlists` table, the `/api/watchlist*` endpoints will be supported in the interim.
* All the TODOs will be dealt with soon.