### PR TITLE
BOAC-715 Styling tweak for sidebar links

### DIFF
--- a/boac/static/app/nav/nav.css
+++ b/boac/static/app/nav/nav.css
@@ -160,7 +160,6 @@
 
 .sidebar-row-link-label {
   padding-left: 8px;
-  white-space: nowrap;
 }
 
 .sidebar-row-without-link {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-715

Since truncation and ellipsis-izing are happening in JS, not CSS, we should be okay without this whitespace property that seems to be confusing Firefox.