### PR TITLE
BOAC-747 Wide text was still too wide

### DIFF
--- a/boac/static/app/nav/nav.css
+++ b/boac/static/app/nav/nav.css
@@ -172,7 +172,7 @@
 }
 
 .sidebar-row-link-label-text-wide {
-  width: 175px;
+  width: 170px;
 }
 
 .sidebar-row-without-link {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-747

We apologize for the earlier mechanical issue and look forward to serving you in the clouds.

![download](https://user-images.githubusercontent.com/2413467/38631048-798927d2-3d6d-11e8-9b11-59ec2ed9c6e6.jpg)
