### PR TITLE
[QA] BOAC-760, auto-create 'My Students' if not exists, for all users

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -50,18 +50,17 @@ def user_profile():
         'uid': False,
     }
     if current_user.is_active:
-        user_id = current_user.get_id()
-        profile = calnet.get_calnet_user_for_uid(app, user_id)
-        # The following is required/rendered in all BOAC views
-        profile['myCohorts'] = CohortFilter.all_owned_by(user_id, include_alerts=True)
+        uid = current_user.get_id()
+        profile = calnet.get_calnet_user_for_uid(app, uid)
+        # All BOAC views require group and cohort lists
+        profile['myCohorts'] = CohortFilter.all_owned_by(uid, include_alerts=True)
         all_groups = StudentGroup.get_groups_by_owner_id(current_user.id)
+        my_primary = StudentGroup.get_or_create_my_primary(current_user.id)
+        profile['myPrimaryGroup'] = _decorate_student_group(my_primary)
         profile['myGroups'] = []
         for group in all_groups:
-            decorated = _decorate_student_group(group)
-            if group.name == PRIMARY_GROUP_NAME:
-                profile['myPrimaryGroup'] = decorated
-            else:
-                profile['myGroups'].append(decorated)
+            if group.name != PRIMARY_GROUP_NAME:
+                profile['myGroups'].append(_decorate_student_group(group))
     return tolerant_jsonify(profile)
 
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -60,14 +60,16 @@ class TestUserProfile:
         assert response.status_code == 200
         assert not response.json['uid']
 
-    def test_profile_includes_lack_of_canvas_account(self, client, fake_auth):
-        test_uid = '1133399'
-        fake_auth.login(test_uid)
+    def test_profile_auto_create_primary_group(self, client, fake_auth):
+        uid = '6446'
+        fake_auth.login(uid)
         response = client.get('/api/profile')
         assert response.status_code == 200
-        assert response.json['uid'] == test_uid
-        assert 'firstName' in response.json
-        assert 'lastName' in response.json
+        profile = response.json
+        assert profile['uid'] == uid
+        assert 'firstName' in profile
+        assert 'lastName' in profile
+        assert profile['myPrimaryGroup']
 
     def test_includes_canvas_profile_if_available(self, client, fake_auth):
         test_uid = '2040'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-760

BOAC assumes 'My Students' is _always_ present. This PR does not change the `/api/profile` contract; it simply instantiates `myPrimaryGroup` in a more certain way. 