### PR TITLE
BOAC-782, an authorized_user can belong to zero or more university_depts

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -61,6 +61,7 @@ def user_profile():
         for group in all_groups:
             if group.name != PRIMARY_GROUP_NAME:
                 profile['myGroups'].append(_decorate_student_group(group))
+        profile['departmentMemberships'] = [api_util.department_membership_to_json(m) for m in current_user.department_memberships]
     return tolerant_jsonify(profile)
 
 

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -83,6 +83,15 @@ def student_to_json(student):
     }
 
 
+def department_membership_to_json(department_membership):
+    return {
+        'deptCode': department_membership.university_dept.dept_code,
+        'deptName': department_membership.university_dept.dept_name,
+        'isAdvisor': department_membership.is_advisor,
+        'isDirector': department_membership.is_director,
+    }
+
+
 def translate_grading_basis(code):
     bases = {
         'CNC': 'C/NC',

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -26,9 +26,9 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from datetime import datetime
 
-from boac import db
+from boac import db, std_commit
 from boac.models.base import Base
-
+from boac.models.university_dept import UniversityDept
 
 student_athletes = db.Table(
     'student_athletes',
@@ -52,6 +52,29 @@ student_group_members = db.Table(
     db.Column('student_group_id', db.Integer, db.ForeignKey('student_groups.id'), primary_key=True),
     db.Column('sid', db.String(80), db.ForeignKey('students.sid'), primary_key=True),
 )
+
+
+class UniversityDeptMember(Base):
+    __tablename__ = 'university_dept_members'
+
+    university_dept_id = db.Column(db.Integer, db.ForeignKey('university_depts.id'), primary_key=True)
+    authorized_user_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), primary_key=True)
+    is_advisor = db.Column(db.Boolean, nullable=False)
+    is_director = db.Column(db.Boolean, nullable=False)
+    authorized_user = db.relationship('AuthorizedUser', back_populates='department_memberships')
+    # Pre-load UniversityDept below to avoid 'failed to locate', as seen during routes.py init phase
+    university_dept = db.relationship(UniversityDept.__name__, back_populates='authorized_users')
+
+    @classmethod
+    def create_membership(cls, university_dept, authorized_user, is_advisor, is_director):
+        if not len(authorized_user.department_memberships):
+            mapping = cls(is_advisor=is_advisor, is_director=is_director)
+            mapping.authorized_user = authorized_user
+            mapping.university_dept = university_dept
+            authorized_user.department_memberships.append(mapping)
+            university_dept.authorized_users.append(mapping)
+            db.session.add(mapping)
+        std_commit()
 
 
 # Alert views are represented as a model class because they contain 'created_at' and 'dismissed_at' metadata in

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -32,12 +32,6 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
 
--- TODO: remove legacy indices
-ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_sid_fkey;
-ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_watchlist_owner_uid_fkey;
-ALTER TABLE IF EXISTS ONLY public.advisor_watchlists DROP CONSTRAINT IF EXISTS advisor_watchlists_pkey;
-DROP TABLE IF EXISTS public.advisor_watchlists;
-
 --
 
 ALTER TABLE IF EXISTS ONLY public.student_athletes DROP CONSTRAINT IF EXISTS student_athletes_sid_fkey;
@@ -54,6 +48,8 @@ ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXIST
 ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_sid_fkey;
 ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_owner_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_owner_id_name_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.university_dept_members DROP CONSTRAINT IF EXISTS university_dept_members_authorized_user_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.university_dept_members DROP CONSTRAINT IF EXISTS university_dept_members_university_dept_id_fkey;
 
 --
 
@@ -89,6 +85,8 @@ ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_vi
 ALTER TABLE IF EXISTS ONLY public.alembic_version DROP CONSTRAINT IF EXISTS alembic_version_pkc;
 ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_pkey;
 ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_pkey;
+ALTER TABLE IF EXISTS ONLY public.university_dept_members DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
+ALTER TABLE IF EXISTS ONLY public.university_depts DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
 ALTER TABLE IF EXISTS public.json_cache ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.cohort_filters ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.authorized_users ALTER COLUMN id DROP DEFAULT;
@@ -116,3 +114,6 @@ DROP TABLE IF EXISTS public.alembic_version;
 DROP TABLE IF EXISTS public.student_group_members;
 DROP TABLE IF EXISTS public.student_groups;
 DROP SEQUENCE IF EXISTS public.student_groups_id_seq;
+DROP TABLE IF EXISTS public.university_dept_members;
+DROP TABLE IF EXISTS public.university_depts;
+DROP SEQUENCE IF EXISTS public.university_depts_id_seq

--- a/scripts/db/migrate/20180418-BOAC-782/post_deploy_01_drop_authorized_users_column_is_advisor.sql
+++ b/scripts/db/migrate/20180418-BOAC-782/post_deploy_01_drop_authorized_users_column_is_advisor.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE authorized_users DROP COLUMN IF EXISTS is_advisor;
+ALTER TABLE authorized_users DROP COLUMN IF EXISTS is_director;
+
+COMMIT;

--- a/scripts/db/migrate/20180418-BOAC-782/pre_deploy_01_create_university_depts_table.sql
+++ b/scripts/db/migrate/20180418-BOAC-782/pre_deploy_01_create_university_depts_table.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+-- The ASC dept_code is UWASC; the College of Engineering includes EHEEC and more.
+
+CREATE TABLE university_depts (
+  id SERIAL PRIMARY KEY,
+  dept_code character varying(80) NOT NULL UNIQUE,
+  dept_name character varying(255) NOT NULL UNIQUE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+ALTER TABLE university_depts ADD CONSTRAINT university_depts_code_unique_constraint UNIQUE (dept_code, dept_name);
+
+-- An authorized_user can belong to zero or more departments
+
+CREATE TABLE university_dept_members (
+  university_dept_id INTEGER NOT NULL REFERENCES university_depts (id) ON DELETE CASCADE,
+  authorized_user_id INTEGER NOT NULL REFERENCES authorized_users (id) ON DELETE CASCADE,
+  is_advisor BOOLEAN DEFAULT false NOT NULL,
+  is_director BOOLEAN DEFAULT false NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  PRIMARY KEY (university_dept_id, authorized_user_id)
+);
+
+-- Done
+
+COMMIT;

--- a/scripts/db/migrate/20180418-BOAC-782/pre_deploy_02_migrate_asc_advisors.py
+++ b/scripts/db/migrate/20180418-BOAC-782/pre_deploy_02_migrate_asc_advisors.py
@@ -1,0 +1,65 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
+
+from boac import db
+from boac.lib import scriptify
+from sqlalchemy import text
+
+
+@scriptify.in_app
+def main(app):
+    from boac.models.authorized_user import AuthorizedUser
+
+    connection = db.engine.connect()
+    sql = """INSERT
+        INTO university_depts (dept_code, dept_name, created_at, updated_at)
+        VALUES ('UWASC', 'Athletic Study Center', now(), now())
+    """
+    connection.execute(text(sql))
+    result = connection.execute(text('SELECT id FROM university_depts WHERE dept_code = \'UWASC\''))
+    university_dept_id = result.fetchall()[0][0]
+
+    print(f'[INFO] Inserted \'Athletic Study Center\' department in db (university_dept_id = {university_dept_id})')
+
+    for user in AuthorizedUser.query.all():
+        if user.is_advisor or user.is_director:
+            sql = f"""INSERT
+                INTO university_dept_members
+                    (university_dept_id, authorized_user_id, is_advisor, is_director, created_at, updated_at)
+                VALUES
+                    ({university_dept_id}, {user.id}, {user.is_advisor}, {user.is_director}, now(), now())
+            """
+            connection.execute(text(sql))
+            print(f'[INFO] User {user.uid} added to \'Athletic Study Center\' with is_advisor={user.is_advisor} and is_director={user.is_director}')
+    connection.close()
+    print('\nDone.\n')
+
+
+main()

--- a/scripts/db/migrate/20180418-BOAC-782/pre_deploy_02_migrate_asc_advisors.sh
+++ b/scripts/db/migrate/20180418-BOAC-782/pre_deploy_02_migrate_asc_advisors.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------
+#
+# Script must be run with sudo
+#
+# -------------------------------------------------------------------
+
+# Abort immediately if a command fails
+set -e
+
+# Load env variables
+[ -e /opt/python/current/env ] && source /opt/python/current/env && env
+
+[ -d /opt/python/current/app ] && cd /opt/python/current/app
+
+# Run Python script
+python3 scripts/db/migrate/20180418-BOAC-782/pre_deploy_02_migrate_asc_advisors.py
+
+echo 'Done.'
+
+exit 0

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -101,9 +101,7 @@ CREATE TABLE authorized_users (
     updated_at timestamp with time zone NOT NULL,
     id integer NOT NULL,
     uid character varying(255) NOT NULL,
-    is_advisor boolean,
-    is_admin boolean,
-    is_director boolean
+    is_admin boolean
 );
 ALTER TABLE authorized_users OWNER TO boac;
 CREATE SEQUENCE authorized_users_id_seq
@@ -188,6 +186,44 @@ ALTER TABLE ONLY student_group_members
     ADD CONSTRAINT student_group_members_pkey PRIMARY KEY (student_group_id, sid);
 CREATE INDEX student_group_members_student_group_id_idx ON student_group_members USING btree (student_group_id);
 CREATE INDEX student_group_members_sid_idx ON student_group_members USING btree (sid);
+
+--
+
+CREATE TABLE university_depts (
+  id INTEGER NOT NULL,
+  dept_code VARCHAR(80) NOT NULL,
+  dept_name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+ALTER TABLE university_depts OWNER TO boac;
+CREATE SEQUENCE university_depts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE university_depts_id_seq OWNER TO boac;
+ALTER SEQUENCE university_depts_id_seq OWNED BY university_depts.id;
+ALTER TABLE ONLY university_depts ALTER COLUMN id SET DEFAULT nextval('university_depts_id_seq'::regclass);
+ALTER TABLE ONLY university_depts
+    ADD CONSTRAINT university_depts_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY university_depts
+    ADD CONSTRAINT university_depts_code_unique_constraint UNIQUE (dept_code, dept_name);
+
+--
+
+CREATE TABLE university_dept_members (
+  university_dept_id INTEGER,
+  authorized_user_id INTEGER,
+  is_advisor BOOLEAN DEFAULT false NOT NULL,
+  is_director BOOLEAN DEFAULT false NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+ALTER TABLE university_dept_members OWNER TO boac;
+ALTER TABLE ONLY university_dept_members
+    ADD CONSTRAINT university_dept_members_pkey PRIMARY KEY (university_dept_id, authorized_user_id);
 
 --
 
@@ -297,6 +333,13 @@ ALTER TABLE ONLY student_group_members
 
 ALTER TABLE ONLY student_groups
     ADD CONSTRAINT student_groups_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
+
+--
+
+ALTER TABLE ONLY university_dept_members
+    ADD CONSTRAINT university_dept_members_university_dept_id_fkey FOREIGN KEY (university_dept_id) REFERENCES university_depts(id) ON DELETE CASCADE;
+ALTER TABLE ONLY university_dept_members
+    ADD CONSTRAINT university_dept_members_authorized_user_id_fkey FOREIGN KEY (authorized_user_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
 
 --
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -79,6 +79,24 @@ class TestUserProfile:
         assert 'firstName' in response.json
         assert 'lastName' in response.json
 
+    def test_user_with_no_dept_membership(self, client, fake_auth):
+        """Returns zero or more departments."""
+        test_uid = '2040'
+        fake_auth.login(test_uid)
+        response = client.get('/api/profile')
+        assert response.status_code == 200
+        profile = response.json
+        assert not len(profile['departmentMemberships'])
+
+    def test_user_with_dept_memberships(self, client, fake_auth):
+        """Returns one or more departments."""
+        test_uid = '1081940'
+        fake_auth.login(test_uid)
+        response = client.get('/api/profile')
+        assert response.status_code == 200
+        profile = response.json
+        assert len(profile['departmentMemberships'])
+
 
 class TestUserPhoto:
     """User Photo API."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-782

The `authorized_users` table remains but `is_advisor` and `is_director` have been moved to `university_dept_members` table, which maps users to departments (code, name). ASC advisors will map to 'UWASC',  EE/CompSci to 'EHEEC', etc. Admin users (eg, PDGers) are in with `authorized_users.is_admin=true` and no dept mapping.