### PR TITLE
BOAC-780, give '/api/status' a conventional and sensible response.json

### DIFF
--- a/boac/api/status_controller.py
+++ b/boac/api/status_controller.py
@@ -55,14 +55,9 @@ def app_status():
 
 @app.route('/api/status')
 def user_status():
-    uid = current_user.get_id()
-    authn_state = {
-        'is_authenticated': current_user.is_authenticated,
-        'is_active': current_user.is_active,
-        'is_anonymous': current_user.is_anonymous,
-        'uid': uid,
-    }
-    resp = {
-        'authenticated_as': authn_state,
-    }
-    return tolerant_jsonify(resp)
+    return tolerant_jsonify({
+        'isActive': current_user.is_active,
+        'isAnonymous': current_user.is_anonymous,
+        'isAuthenticated': current_user.is_authenticated,
+        'uid': current_user.get_id(),
+    })

--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -28,7 +28,7 @@
   <hr class="filters-section-separator" data-ng-if="!isLoading && !error && !isCreateCohortMode"/>
 
   <div class="flex-container flex-space-between" data-ng-if="!error">
-    <div class="cohort-filters-column flex-column-btn">
+    <div class="cohort-filters-column flex-column-btn" data-ng-if="me.personalization.showAthletics">
       <cohort-filter data-menu-type="groupCodes" data-label="Teams"></cohort-filter>
     </div>
     <div class="cohort-filters-column flex-column-btn">

--- a/boac/static/app/course/course.css
+++ b/boac/static/app/course/course.css
@@ -37,7 +37,6 @@
 }
 
 .course-container {
-  padding: 0 10px 0 10px;
   width: 100%;
 }
 

--- a/boac/static/app/course/course.html
+++ b/boac/static/app/course/course.html
@@ -10,7 +10,7 @@
     </a>
   </div>
 
-  <div class="container-left" data-ng-if="!isLoading && error">
+  <div class="container-error" data-ng-if="!isLoading && error">
     <h1 class="page-section-header">Error</h1>
     <div class="faint-text">
       <span data-ng-bind="error.message" data-ng-if="error.message"></span>

--- a/boac/static/app/main.css
+++ b/boac/static/app/main.css
@@ -54,8 +54,8 @@
   vertical-align: middle;
 }
 
-.container-left {
-  float: left;
+.container-error {
+  padding: 0 10px 0 10px;
 }
 
 .container-right {

--- a/boac/static/app/routes.js
+++ b/boac/static/app/routes.js
@@ -49,7 +49,7 @@
     // Authentication dependency for private states only; return a rejection if authenticated user not present.
     var resolveAuthentication = function(me, $q) {
       var deferred = $q.defer();
-      if (me.is_authenticated) {
+      if (me.isAuthenticated) {
         deferred.resolve({});
       } else {
         deferred.reject({message: 'unauthenticated'});
@@ -60,7 +60,7 @@
     // Return a rejection if authenticated user is present.
     var splashAuthentication = function(me, $q) {
       var deferred = $q.defer();
-      if (me.is_authenticated) {
+      if (me.isAuthenticated) {
         deferred.reject({message: 'authenticated'});
       } else {
         deferred.resolve({});
@@ -99,7 +99,7 @@
     // Default route
     $urlRouterProvider.otherwise(function($injector, $location) {
       $injector.get('authService').reloadMe().then(function(me) {
-        var uri = me && me.is_authenticated ? '/404' : '/';
+        var uri = me && me.isAuthenticated ? '/404' : '/';
         $location.replace().path(uri);
       });
     });

--- a/boac/static/app/shared/googleAnalyticsService.js
+++ b/boac/static/app/shared/googleAnalyticsService.js
@@ -60,9 +60,8 @@
       if (id) {
         ga('send', 'pageview', $location.path());
 
-        var me = $rootScope.me && $rootScope.me.authenticated_as;
-        if (me && me.is_authenticated) {
-          ga('set', 'uid', me.uid);
+        if ($rootScope.me && $rootScope.me.isAuthenticated) {
+          ga('set', 'uid', $rootScope.me.uid);
         }
       }
     };

--- a/boac/static/app/student/student.css
+++ b/boac/static/app/student/student.css
@@ -134,17 +134,6 @@
   flex: 3;
 }
 
-.student-section-header {
-  font-size: 24px;
-  font-weight: bold;
-}
-
-.student-preferred-name {
-  font-size: 20px;
-  font-weight: 400;
-  margin: 0 0 10px 0;
-}
-
 .student-bio-status-box {
   background: #fff;
   border: solid 1px #999;
@@ -198,7 +187,6 @@
 .student-container {
   display: flex;
   flex-direction: column;
-  padding: 0 10px 0 10px;
   width: 100%;
 }
 
@@ -311,6 +299,22 @@
   margin: 0;
 }
 
+.student-preferred-name {
+  font-size: 20px;
+  font-weight: 400;
+  margin: 0 0 10px 0;
+}
+
+.student-profile-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.student-section-header {
+  font-size: 24px;
+  font-weight: bold;
+}
+
 .student-search {
   font-family: FontAwesome, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
@@ -333,11 +337,6 @@
 .student-text {
   color: #aaa;
   font-size: 13px;
-}
-
-.student-profile-container {
-  display: flex;
-  flex-direction: row;
 }
 
 .student-term {

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -4,7 +4,7 @@
     <span class="sr-only">Loading...</span>
   </div>
 
-  <div class="container-left" data-ng-if="!student.isLoading && error">
+  <div class="container-error" data-ng-if="!student.isLoading && error">
     <h1 class="page-section-header">{{error.status === 404 ? 'Not Found' : 'Error'}}</h1>
     <div class="faint-text">
       <span data-ng-bind="error.message" data-ng-if="error.message"></span>

--- a/boac/static/app/user/authFactory.js
+++ b/boac/static/app/user/authFactory.js
@@ -35,9 +35,9 @@
       $rootScope.me = me;
       $rootScope.$broadcast('userStatusChange');
       // Load user profile if authenticated
-      if (me.authenticated_as.is_authenticated) {
+      if (me.isAuthenticated) {
         return $http.get('/api/profile').then(function(response) {
-          _.extend($rootScope.me.authenticated_as, response.data);
+          _.extend($rootScope.me, response.data);
         });
       }
       return results;

--- a/boac/static/app/user/authService.js
+++ b/boac/static/app/user/authService.js
@@ -37,16 +37,17 @@
   ) {
 
     var getMe = function() {
-      return _.cloneDeep($rootScope.me.authenticated_as);
+      return _.cloneDeep($rootScope.me);
     };
 
     var reloadMe = function() {
       return $http.get('/api/status').then(authFactory.loadUserProfile).then(function() {
-        var me = $rootScope.me.authenticated_as;
-        if (me.is_authenticated) {
+        var me = $rootScope.me;
+        if ($rootScope.me.isAuthenticated) {
           if ($location.search().casLogin) {
             // Track CAS login event
-            googleAnalyticsService.track('user', 'login', me.uid, parseInt(me.uid, 10));
+            var uid = $rootScope.me.uid;
+            googleAnalyticsService.track('user', 'login', uid, parseInt(uid, 10));
           }
         }
         return me;
@@ -54,22 +55,22 @@
     };
 
     $rootScope.$on('groupCreated', function(event, data) {
-      if (_.get($rootScope, 'me.authenticated_as.myGroups')) {
-        $rootScope.me.authenticated_as.myGroups.push(data.group);
+      if (_.get($rootScope, 'me.myGroups')) {
+        $rootScope.me.myGroups.push(data.group);
       }
     });
 
     $rootScope.$on('groupDeleted', function(event, data) {
-      if (_.get($rootScope, 'me.authenticated_as.myGroups')) {
-        $rootScope.me.authenticated_as.myGroups = _.remove($rootScope.me.authenticated_as.myGroups, function(group) {
+      if (_.get($rootScope, 'me.myGroups')) {
+        $rootScope.me.myGroups = _.remove($rootScope.me.myGroups, function(group) {
           return data.groupId !== group.id;
         });
       }
     });
 
     $rootScope.$on('groupNameChanged', function(event, data) {
-      if (_.get($rootScope, 'me.authenticated_as.myGroups')) {
-        _.each($rootScope.me.authenticated_as.myGroups, function(group) {
+      if (_.get($rootScope, 'me.myGroups')) {
+        _.each($rootScope.me.myGroups, function(group) {
           if (data.group.id === group.id) {
             group.name = data.group.name;
           }

--- a/tests/test_api/test_status_controller.py
+++ b/tests/test_api/test_status_controller.py
@@ -31,16 +31,15 @@ class TestStatusController:
         """Returns a well-formed response."""
         response = client.get('/api/status')
         assert response.status_code == 200
-        assert 'authenticated_as' in response.json
-        assert not response.json['authenticated_as']['is_authenticated']
+        assert response.json['isAuthenticated'] is False
 
     def test_when_authenticated(self, client, fake_auth):
         test_uid = '1133399'
         fake_auth.login(test_uid)
         response = client.get('/api/status')
         assert response.status_code == 200
-        assert response.json['authenticated_as']['is_authenticated']
-        assert response.json['authenticated_as']['uid'] == test_uid
+        assert response.json['isAuthenticated'] is True
+        assert response.json['uid'] == test_uid
 
     def test_ping(self, client):
         """Answers the phone when pinged."""

--- a/tests/test_auth/test_dev_auth.py
+++ b/tests/test_auth/test_dev_auth.py
@@ -63,9 +63,9 @@ class TestDevAuth:
         assert response.status_code == 302
         response = client.get('/api/status')
         assert response.status_code == 200
-        assert response.json['authenticated_as']['uid'] == self.authorized_uid
+        assert response.json['uid'] == self.authorized_uid
         response = client.get('/logout')
         assert response.status_code == 200
         response = client.get('/api/status')
         assert response.status_code == 200
-        assert response.json['authenticated_as']['is_anonymous']
+        assert response.json['isAnonymous']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-780

Tossing `authenticated_as` out of the `/api/status` response reduces front-end confusion a bit.