### PR TITLE
BOAC-806 BOAC-808 Further cleanup on cohort/group refactor

### DIFF
--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -131,7 +131,7 @@ def course_section_to_json(term_id, section):
     }
 
 
-def decorate_student_groups(current_user_id, groups):
+def decorate_student_groups(current_user_id, groups, remove_students_without_alerts=False):
     for group in groups:
         students_by_sid = {student['sid']: student for student in group['students']}
         alert_counts = Alert.current_alert_counts_for_sids(current_user_id, list(students_by_sid.keys()))
@@ -140,6 +140,8 @@ def decorate_student_groups(current_user_id, groups):
             student.update({
                 'alertCount': result['alertCount'],
             })
+        if remove_students_without_alerts:
+            group['students'] = [s for s in group['students'] if s.get('alertCount')]
         group['students'] = sorted(group['students'], key=lambda s: (s['firstName'], s['lastName']))
     return groups
 

--- a/boac/static/app/group/group.html
+++ b/boac/static/app/group/group.html
@@ -19,7 +19,7 @@
                                       when="{'one': '1 Member', 'other': '{} Members'}"></span>)</span>
     </h1>
     <div data-ng-if="!group.students.length">
-      This group has no students.
+      This curated cohort has no students.
     </div>
   </div>
 

--- a/boac/static/app/group/studentGroupService.js
+++ b/boac/static/app/group/studentGroupService.js
@@ -33,6 +33,7 @@
       return {
         id: group.id,
         name: group.name,
+        studentCount: group.studentCount,
         students: utilService.extendSortableNames(group.students),
         sortBy: 'sortableName',
         reverse: false

--- a/boac/static/app/home/home.html
+++ b/boac/static/app/home/home.html
@@ -18,7 +18,7 @@
         <h2 class="page-section-header-sub">
           <a id="home-group-{{$index}}"
              data-ng-bind="group.name"
-             data-ng-href="/group/{{group.id}}"></a> (<span data-ng-bind="group.students.length"></span>)
+             data-ng-href="/group/{{group.id}}"></a> (<span data-ng-bind="group.studentCount"></span>)
         </h2>
         <sortable-alerts-table data-group="group"
                                data-ng-if="group.students.length"></sortable-alerts-table>

--- a/boac/static/app/nav/nav.css
+++ b/boac/static/app/nav/nav.css
@@ -112,13 +112,6 @@
   white-space: nowrap;
 }
 
-.sidebar-header-icon {
-  border: 0;
-  object-fit: scale-down;
-  height: 16px;
-  margin: 0 2px 4px 0;
-}
-
 .sidebar-create-link {
   display: inline-block;
   text-align: center;
@@ -174,10 +167,6 @@
   width: 180px;
 }
 
-.sidebar-row-link-label-text-wide {
-  width: 195px;
-}
-
 .sidebar-row-without-link {
   margin-left: 14px;
 }
@@ -196,20 +185,6 @@
 
 .sidebar-section-search {
   margin: 0 12px 12px 12px;
-}
-
-.sidebar-student-alert {
-  color: #f0ad4e;
-  float: right;
-  font-size: 16px;
-  margin-right: 5px;
-  padding: 3px 0 0 1px;
-}
-
-.sidebar-manage-link {
-  color: #8bbdda;
-  font-size: 16px;
-  line-height: 1.4em;
 }
 
 .search-students-icon {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-806
https://jira.ets.berkeley.edu/jira/browse/BOAC-808

Continuing on from #592:
- Remove unused CSS;
- Groups on the homepage only list students with alerts;
- Clear out more obsolete "group" terminology.