### PR TITLE
BOAC-807, consistent naming fix: cohorts have students and depts have members

### DIFF
--- a/boac/api/athletics_controller.py
+++ b/boac/api/athletics_controller.py
@@ -27,7 +27,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from boac.api.errors import ResourceNotFoundError
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
-from boac.merged import member_details
+from boac.merged import student_details
 from boac.models.athletics import Athletics
 from flask import current_app as app, request
 from flask_login import login_required
@@ -40,7 +40,7 @@ def get_team(code):
     team = Athletics.get_team(code, order_by)
     if team is None:
         raise ResourceNotFoundError('No team found with code ' + code)
-    member_details.merge_all(team['members'])
+    student_details.merge_all(team['students'])
     return tolerant_jsonify(team)
 
 

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -28,7 +28,7 @@ from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotF
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
 from boac.merged import calnet
-from boac.merged import member_details
+from boac.merged import student_details
 from boac.models.cohort_filter import CohortFilter
 from flask import current_app as app, request
 from flask_login import current_user, login_required
@@ -59,7 +59,7 @@ def all_cohorts():
 def my_cohorts():
     cohorts = CohortFilter.all_owned_by(current_user.get_id(), include_alerts=True)
     for cohort in cohorts:
-        member_details.merge_all(cohort['alerts'], include_analytics=False)
+        student_details.merge_all(cohort['alerts'], include_analytics=False)
     return tolerant_jsonify(cohorts)
 
 
@@ -72,7 +72,7 @@ def get_cohort(cohort_id):
     cohort = CohortFilter.find_by_id(int(cohort_id), order_by, int(offset), int(limit))
     if not cohort:
         raise ResourceNotFoundError('No cohort found with identifier: {}'.format(cohort_id))
-    member_details.merge_all(cohort['members'])
+    student_details.merge_all(cohort['students'])
     return tolerant_jsonify(cohort)
 
 

--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -31,7 +31,7 @@ from boac.lib import analytics
 from boac.lib import util
 from boac.lib.berkeley import extract_canvas_ccn
 from boac.lib.http import tolerant_jsonify
-from boac.merged import member_details
+from boac.merged import student_details
 from boac.models.normalized_cache_enrollment import NormalizedCacheEnrollment
 from flask import current_app as app, request
 from flask_login import login_required
@@ -45,7 +45,7 @@ def get_section(term_id, section_id):
         raise ResourceNotFoundError(f'No section {section_id} in term {term_id}')
     section = api_util.course_section_to_json(term_id=term_id, section=row)
     students = section.get('students', [])
-    member_details.merge_all(students, section['termId'])
+    student_details.merge_all(students, section['termId'])
     for student in students:
         # Cherry-pick enrollment of section requested
         for enrollment in student.get('term', {}).get('enrollments', []):

--- a/boac/api/student_groups_controller.py
+++ b/boac/api/student_groups_controller.py
@@ -27,7 +27,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
 import boac.api.util as api_util
 from boac.lib.http import tolerant_jsonify
-from boac.merged import member_details
+from boac.merged import student_details
 from boac.models.student_group import StudentGroup
 from flask import current_app as app, request
 from flask_login import current_user, login_required
@@ -133,7 +133,7 @@ def update_group():
 
 def _decorate_groups(groups, include_analytics, remove_students_without_alerts=False):
     for group in groups:
-        member_details.merge_all(group['students'], include_analytics=include_analytics)
+        student_details.merge_all(group['students'], include_analytics=include_analytics)
     return api_util.decorate_student_groups(
         current_user_id=current_user.id,
         groups=groups,

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -34,7 +34,7 @@ from boac.lib.analytics import merge_analytics_for_user
 from boac.lib.berkeley import is_department_advisor, sis_term_id_for_name
 from boac.lib.http import tolerant_jsonify
 from boac.merged import calnet
-from boac.merged import member_details
+from boac.merged import student_details
 from boac.merged.sis_enrollments import merge_sis_enrollments
 from boac.merged.sis_profile import merge_sis_profile
 from boac.models.cohort_filter import CohortFilter
@@ -104,10 +104,10 @@ def get_students():
         offset=offset,
         limit=limit,
     )
-    member_details.merge_all(results['students'])
+    student_details.merge_all(results['students'])
     return tolerant_jsonify({
-        'members': results['students'],
-        'totalMemberCount': results['totalStudentCount'],
+        'students': results['students'],
+        'totalStudentCount': results['totalStudentCount'],
     })
 
 
@@ -127,7 +127,7 @@ def search_for_students():
         offset=offset,
         limit=limit,
     )
-    member_details.merge_all(results['students'])
+    student_details.merge_all(results['students'])
     return tolerant_jsonify({
         'students': results['students'],
         'totalStudentCount': results['totalStudentCount'],

--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -42,12 +42,12 @@ def get_calnet_user_for_uid(app, uid):
 
 
 def refresh_cohort_attributes(app, cohorts=None):
-    members = cohorts or Student.query.all()
+    students = cohorts or Student.query.all()
     # Students who play more than one sport will have multiple records.
-    member_map = {}
-    for m in members:
-        member_map.setdefault(m.sid, []).append(m)
-    csids = list(member_map.keys())
+    student_map = {}
+    for student in students:
+        student_map.setdefault(student.sid, []).append(student)
+    csids = list(student_map.keys())
 
     # Search LDAP.
     all_attrs = calnet.client(app).search_csids(csids)
@@ -60,13 +60,13 @@ def refresh_cohort_attributes(app, cohorts=None):
         csid = attrs['csid']
         name_split = attrs['sortable_name'].split(',') if 'sortable_name' in attrs else ''
         full_name = [name.strip() for name in reversed(name_split)]
-        for m in member_map[csid]:
-            m.uid = attrs['uid']
+        for student in student_map[csid]:
+            student.uid = attrs['uid']
             # A manually-entered ASC name may be more nicely formatted than a student's CalNet default.
             # For now, don't overwrite it.
-            m.first_name = m.first_name or (full_name[0] if len(full_name) else '')
-            m.last_name = m.last_name or (full_name[1] if len(full_name) > 1 else '')
-    return members
+            student.first_name = student.first_name or (full_name[0] if len(full_name) else '')
+            student.last_name = student.last_name or (full_name[1] if len(full_name) > 1 else '')
+    return students
 
 
 def fill_cohort_uids(app):

--- a/boac/merged/student_details.py
+++ b/boac/merged/student_details.py
@@ -34,18 +34,18 @@ from flask import current_app as app
 """Helper utils for cohort controller."""
 
 
-def merge_all(member_feeds, term_id=None, include_analytics=True):
+def merge_all(students, term_id=None, include_analytics=True):
     if not term_id:
         term_name = app.config.get('CANVAS_CURRENT_ENROLLMENT_TERM')
         term_id = sis_term_id_for_name(term_name)
-    for member_feed in member_feeds:
-        _merge(member_feed, term_id, include_analytics)
-    return member_feeds
+    for student in students:
+        _merge(student, term_id, include_analytics)
+    return students
 
 
-def _merge(member_feed, term_id, include_analytics):
-    uid = member_feed['uid']
-    csid = member_feed['sid']
+def _merge(student, term_id, include_analytics):
+    uid = student['uid']
+    csid = student['sid']
     cache_key = f'merged_data/{term_id}/{uid}'
     data = app.cache.get(cache_key) if app.cache else None
     if not data:
@@ -58,8 +58,8 @@ def _merge(member_feed, term_id, include_analytics):
             # The enrolled units count is the one piece of term data we want to preserve.
             if data.get('term'):
                 data['term'] = {'enrolledUnits': data['term'].get('enrolledUnits')}
-        member_feed.update(data)
-    return member_feed
+        student.update(data)
+    return student
 
 
 def _merged_data(uid, csid, term_id):

--- a/boac/models/athletics.py
+++ b/boac/models/athletics.py
@@ -63,7 +63,7 @@ class Athletics(Base):
                 'name': row[1],
                 'teamCode': row[2],
                 'teamName': row[3],
-                'totalMemberCount': row[4],
+                'totalStudentCount': row[4],
             }
         return [translate_row(row) for row in results]
 
@@ -84,7 +84,7 @@ class Athletics(Base):
             return {
                 'code': row[0],
                 'name': row[1],
-                'totalMemberCount': row[2],
+                'totalStudentCount': row[2],
             }
         return [translate_row(row) for row in results]
 
@@ -109,15 +109,15 @@ class Athletics(Base):
                     'groupName': row[3],
                 })
             group_codes = [group['groupCode'] for group in team['teamGroups']]
-            students = Student.get_students(
+            results = Student.get_students(
                 group_codes=group_codes,
                 is_active_asc=True,
                 order_by=order_by,
                 offset=0,
                 limit=None,
             )
-            team['members'] = students['students']
-            team['totalMemberCount'] = students['totalStudentCount']
+            team['students'] = results['students']
+            team['totalStudentCount'] = results['totalStudentCount']
         return team
 
     def to_api_json(self):

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -216,11 +216,11 @@ def construct_cohort(cf, order_by=None, offset=0, limit=50, include_students=Tru
             'isInactive': is_inactive,
         },
         'teamGroups': team_groups,
-        'totalMemberCount': results['totalStudentCount'],
+        'totalStudentCount': results['totalStudentCount'],
     })
     if include_students:
         cohort.update({
-            'members': results['students'],
+            'students': results['students'],
         })
     if include_alerts_for_uid:
         viewer = AuthorizedUser.find_by_uid(include_alerts_for_uid)

--- a/boac/static/app/cohort/all.html
+++ b/boac/static/app/cohort/all.html
@@ -13,7 +13,7 @@
       <ul>
         <li data-ng-repeat="cohort in owner.cohorts">
           <a data-ng-bind="cohort.label" data-ng-href="/cohort?c={{cohort.id}}"></a>
-          (<span data-ng-bind="cohort.totalMemberCount"></span>)
+          (<span data-ng-bind="cohort.totalStudentCount"></span>)
         </li>
       </ul>
     </div>

--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -9,13 +9,13 @@
       <span data-ng-if="!error.message">Sorry, there was an error retrieving data.</span>
     </div>
   </div>
-  <div class="cohort-label" data-ng-if="!error && !isCreateCohortMode && !isLoading && !isSaving && (cohort.totalMemberCount >= 0)">
+  <div class="cohort-label" data-ng-if="!error && !isCreateCohortMode && !isLoading && !isSaving && (cohort.totalStudentCount >= 0)">
     <h1 class="page-section-header" data-ng-if="cohort.name">
       <span data-ng-bind="cohort.name"></span>
-      <span class="faint-text">(<span data-ng-bind="cohort.totalMemberCount"></span> members)</span>
+      <span class="faint-text">(<span data-ng-bind="cohort.totalStudentCount"></span> students)</span>
     </h1>
     <h1 data-ng-if="!cohort.name">
-      <span data-ng-pluralize count="cohort.totalMemberCount" when="{'one': '1 Result', 'other': '{} Results'}"></span>
+      <span data-ng-pluralize count="cohort.totalStudentCount" when="{'one': '1 Result', 'other': '{} Results'}"></span>
     </h1>
   </div>
   <div class="cohort-column-results" data-ng-if="!isLoading && !error && !isSaving && isCreateCohortMode">
@@ -78,7 +78,7 @@
   </div>
 
   <hr class="filters-section-separator"
-      data-ng-if="!isLoading && !error && !isCreateCohortMode && cohort.totalMemberCount"/>
+      data-ng-if="!isLoading && !error && !isCreateCohortMode && cohort.totalStudentCount"/>
 
   <div class="loading-spinner-large" data-ng-if="isLoading && !error">
     <i class="fa fa-refresh fa-spin fa-5x fa-fw"></i>
@@ -87,10 +87,10 @@
 
   <div class="cohort-column-results">
     <div class="cohort-tabs-container"
-         data-ng-if="!isLoading && !error && (tab === 'matrix' || cohort.totalMemberCount)">
+         data-ng-if="!isLoading && !error && (tab === 'matrix' || cohort.totalStudentCount)">
 
       <div class="cohort-tabs-container-column-01">
-        <groups-selector data-students="cohort.members" data-ng-if="tab === 'list'"></groups-selector>
+        <groups-selector data-students="cohort.students" data-ng-if="tab === 'list'"></groups-selector>
       </div>
       <div class="cohort-tabs-container-column-02">
         <div data-ng-include="'/static/app/shared/tabs.html'"></div>
@@ -107,11 +107,11 @@
       </div>
     </div>
     <div data-ng-show="tab === 'list'"
-         data-ng-if="!isLoading && !error && cohort.totalMemberCount">
-      <ul id="cohort-members-list" class="list-group">
+         data-ng-if="!isLoading && !error && cohort.totalStudentCount">
+      <ul id="cohort-students-list" class="list-group">
         <div class="list-group-item cohort-student-list-item"
              data-ng-class="{'list-group-item-info': anchor===student.uid}"
-             data-ng-repeat="student in cohort.members">
+             data-ng-repeat="student in cohort.students">
 
           <div class="cohort-list-view-column-00">
             <div class="student-checkbox-add-to-group">
@@ -156,8 +156,8 @@
             <div class="student-text" data-ng-bind="major" data-ng-repeat="major in student.majors"></div>
             <div class="student-teams-container">
               <div class="student-teams"
-                   data-ng-bind="membership.groupName"
-                   data-ng-repeat="membership in student.athletics"></div>
+                   data-ng-bind="team.groupName"
+                   data-ng-repeat="team in student.athletics"></div>
             </div>
           </div>
 
@@ -209,10 +209,10 @@
       <ul uib-pagination
           direction-links="false"
           items-per-page="pagination.itemsPerPage"
-          total-items="cohort.totalMemberCount"
+          total-items="cohort.totalStudentCount"
           ng-model="pagination.currentPage"
           data-ng-click="nextPage()"
-          data-ng-if="pagination.enabled && !isCreateCohortMode && (cohort.totalMemberCount > pagination.itemsPerPage)"></ul>
+          data-ng-if="pagination.enabled && !isCreateCohortMode && (cohort.totalStudentCount > pagination.itemsPerPage)"></ul>
     </div>
     <div id="matrix-outer" data-ng-show="tab === 'matrix' && !isLoading && !error">
       <div data-ng-include="'/static/app/shared/matrix.html'"></div>

--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -73,8 +73,8 @@
 
     $scope.cohort = {
       code: null,
-      members: [],
-      totalMemberCount: null
+      students: [],
+      totalStudentCount: null
     };
 
     $scope.search = {
@@ -209,7 +209,7 @@
      * @return {void}
      */
     var listViewRefresh = function(callback) {
-      // Pagination is not used on teams because the member count is always reasonable.
+      // Pagination is not used on teams because student count is within reason.
       $scope.pagination.enabled = isPaginationEnabled();
       var page = $scope.pagination.enabled ? $scope.pagination.currentPage : 1;
       var limit = $scope.pagination.enabled ? $scope.pagination.itemsPerPage : Number.MAX_SAFE_INTEGER;
@@ -379,7 +379,7 @@
           // The intervening visualizationService code moves out of Angular and into d3 thus the extra kick of $apply.
           $scope.$apply();
         };
-        visualizationService.scatterplotRefresh($scope.cohort.members, goToUserPage, function(yAxisMeasure, studentsWithoutData) {
+        visualizationService.scatterplotRefresh($scope.cohort.students, goToUserPage, function(yAxisMeasure, studentsWithoutData) {
           $scope.yAxisMeasure = yAxisMeasure;
           // List of students-without-data is rendered below the scatterplot.
           $scope.studentsWithoutData = studentsWithoutData;
@@ -495,9 +495,9 @@
       } else if (tabName === 'list') {
         // Restore pagination; fortunately, 'currentPage' persists.
         $scope.pagination.enabled = isPaginationEnabled();
-        if ($scope.pagination.enabled && $scope.pagination.currentPage > 1 && $scope.cohort.members.length > 50) {
+        if ($scope.pagination.enabled && $scope.pagination.currentPage > 1 && $scope.cohort.students.length > 50) {
           var start = ($scope.pagination.currentPage - 1) * 50;
-          $scope.cohort.members = _.slice($scope.cohort.members, start, start + 50);
+          $scope.cohort.students = _.slice($scope.cohort.students, start, start + 50);
         }
       }
     };

--- a/boac/static/app/cohort/manageCohorts.html
+++ b/boac/static/app/cohort/manageCohorts.html
@@ -27,7 +27,7 @@
                data-ui-sref-opts="{reload: true}"><span id="cohort-name-{{$index}}"
                                                         data-ng-bind="cohort.name"></span></a>
           </strong>
-          <span class="faint-text">(<span id="cohort-member-count-{{$index}}" data-ng-bind="cohort.totalMemberCount"></span>)</span>
+          <span class="faint-text">(<span id="cohort-student-count-{{$index}}" data-ng-bind="cohort.totalStudentCount"></span>)</span>
         </div>
         <div>
           <span data-ng-controller="DeleteCohortController">

--- a/boac/static/app/cohort/teams.html
+++ b/boac/static/app/cohort/teams.html
@@ -13,7 +13,7 @@
       <ul data-ng-if="!isLoading" class="home-list">
         <li data-ng-repeat="team in teams">
           <a data-ng-bind="team.name" data-ng-href="/cohort?c={{team.code}}"></a>
-          (<span data-ng-bind="team.totalMemberCount"></span>)
+          (<span data-ng-bind="team.totalStudentCount"></span>)
         </li>
       </ul>
     </div>

--- a/boac/static/app/group/group.html
+++ b/boac/static/app/group/group.html
@@ -16,7 +16,7 @@
       <span data-ng-bind="group.name"></span>
       <span class="faint-text">(<span data-ng-pluralize
                                       count="group.students.length"
-                                      when="{'one': '1 Member', 'other': '{} Members'}"></span>)</span>
+                                      when="{'one': 'One student', 'other': '{} students'}"></span>)</span>
     </h1>
     <div data-ng-if="!group.students.length">
       This curated cohort has no students.
@@ -82,8 +82,8 @@
             <div class="student-text" data-ng-bind="major" data-ng-repeat="major in student.majors"></div>
             <div class="student-teams-container">
               <div class="student-teams"
-                   data-ng-bind="membership.groupName"
-                   data-ng-repeat="membership in student.athletics"></div>
+                   data-ng-bind="team.groupName"
+                   data-ng-repeat="team in student.athletics"></div>
             </div>
           </div>
 

--- a/boac/static/app/group/groupsSelectorDirective.js
+++ b/boac/static/app/group/groupsSelectorDirective.js
@@ -140,8 +140,8 @@
         $rootScope.checkboxForStudentGroupsSelector = function(student) {
           if (student.selectedForStudentGroups) {
             var allStudentsSelected = true;
-            _.each(scope.students, function(member) {
-              if (!member.selectedForStudentGroups) {
+            _.each(scope.students, function(_student) {
+              if (!_student.selectedForStudentGroups) {
                 // We found a checkbox not checked. The 'all' checkbox must be false.
                 allStudentsSelected = false;
                 // Break out of loop.

--- a/boac/static/app/group/manageGroups.html
+++ b/boac/static/app/group/manageGroups.html
@@ -29,7 +29,7 @@
                data-ng-bind="group.name"
                data-ng-href="/group/{{group.id}}"></a>
           </strong>
-          <span class="faint-text">(<span id="group-member-count-{{$index}}" data-ng-bind="group.students.length"></span>)</span>
+          <span class="faint-text">(<span id="group-student-count-{{$index}}" data-ng-bind="group.students.length"></span>)</span>
         </div>
         <div>
           <span data-ng-controller="DeleteGroupController">

--- a/boac/static/app/home/home.html
+++ b/boac/static/app/home/home.html
@@ -34,7 +34,7 @@
         <h2 class="page-section-header-sub">
           <a id="home-cohort-{{$index}}"
              data-ng-bind="cohort.label"
-             data-ng-href="/cohort?c={{cohort.id}}"></a> (<span data-ng-bind="cohort.totalMemberCount"></span>)
+             data-ng-href="/cohort?c={{cohort.id}}"></a> (<span data-ng-bind="cohort.totalStudentCount"></span>)
         </h2>
         <sortable-alerts-table data-group="cohort.alerts"
                                data-ng-if="cohort.alerts.students.length"></sortable-alerts-table>

--- a/boac/static/app/nav/sidebar.html
+++ b/boac/static/app/nav/sidebar.html
@@ -5,8 +5,8 @@
     <input id="search-students-input"
            type="text"
            class="search-students-input"
-           data-ng-model="search.input"
-           data-ng-readonly="search.isSearching"
+           data-ng-model="searchPhrase"
+           data-ng-readonly="searchResultsLoading"
            maxlength="255"
            placeholder="Search for Students">
   </form>
@@ -54,7 +54,7 @@
     </a>
     <span id="sidebar-cohort-{{$index}}-count"
           class="sidebar-pill"
-          data-ng-bind="cohort.totalMemberCount"></span>
+          data-ng-bind="cohort.totalStudentCount"></span>
   </div>
 </div>
 

--- a/boac/static/app/nav/sidebarNavController.js
+++ b/boac/static/app/nav/sidebarNavController.js
@@ -41,22 +41,19 @@
       $scope.demoMode = config.demoMode;
       $scope.myCohorts = _.clone(me.myCohorts);
       $scope.myGroups = _.clone(me.myGroups);
-      $scope.search = {
-        input: null,
-        isSearching: false
-      };
+      $scope.searchPhrase = null;
       $scope.showAthletics = !!_.get(me.personalization, 'showAthletics');
     };
 
     init();
 
     $rootScope.$on('$viewContentLoaded', function() {
-      $scope.search.input = null;
+      $scope.searchPhrase = null;
     });
 
     $scope.searchForStudents = function() {
-      $scope.search.isSearching = true;
-      $location.path('/search').search({q: $scope.search.input});
+      $scope.searchResultsLoading = true;
+      $location.path('/search').search({q: $scope.searchPhrase});
     };
 
     var findGroupInScope = function(groupId) {

--- a/boac/static/app/search/searchResults.html
+++ b/boac/static/app/search/searchResults.html
@@ -1,7 +1,7 @@
 <div class="group-container">
   <div class="loading-spinner-large" data-ng-if="isLoading && !error">
     <i class="fa fa-refresh fa-spin fa-5x fa-fw"></i>
-    <span class="sr-only">Loading...</span>
+    <span class="sr-only">Searching for '<span data-ng-bind="search.phrase"></span>'...</span>
   </div>
   <div data-ng-if="error">
     <h1 class="page-section-header">Error</h1>
@@ -13,7 +13,7 @@
   <div data-ng-if="!isLoading && !error">
     <h1 class="page-section-header">
       <span data-ng-pluralize count="searchResults.totalStudentCount" when="{'one': 'One student', 'other': '{} students'}"></span>
-      matching: <span data-ng-bind="search.phrase"></span>
+      matching '<span data-ng-bind="search.phrase"></span>'
     </h1>
     <sortable-alerts-table data-group="searchResults"
                            data-ng-if="searchResults.totalStudentCount"></sortable-alerts-table>

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -55,7 +55,7 @@ class TestAthletics:
         team_groups = response.json
         group_codes = [team_group['groupCode'] for team_group in team_groups]
         group_names = [team_group['groupName'] for team_group in team_groups]
-        total_member_counts = [team_group['totalMemberCount'] for team_group in team_groups]
+        total_student_counts = [team_group['totalStudentCount'] for team_group in team_groups]
         assert ['MFB-DB', 'MFB-DL', 'MBB', 'MTE', 'WFH', 'WTE'] == group_codes
         assert [
             'Football, Defensive Backs',
@@ -65,7 +65,7 @@ class TestAthletics:
             'Women\'s Field Hockey',
             'Women\'s Tennis',
         ] == group_names
-        assert [2, 3, 1, 1, 1, 1] == total_member_counts
+        assert [2, 3, 1, 1, 1, 1] == total_student_counts
 
     def test_get_all_teams(self, authenticated_session, client):
         """Returns all teams if authenticated."""
@@ -75,14 +75,14 @@ class TestAthletics:
         assert len(teams) == 5
         team_codes = [team['code'] for team in teams]
         team_names = [team['name'] for team in teams]
-        total_member_counts = [team['totalMemberCount'] for team in teams]
+        total_student_counts = [team['totalStudentCount'] for team in teams]
         assert ['FBM', 'BAM', 'TNM', 'FHW', 'TNW'] == team_codes
         assert ['Football', 'Men\'s Baseball', 'Men\'s Tennis', 'Women\'s Field Hockey', 'Women\'s Tennis'] == team_names
-        assert [3, 1, 1, 1, 1] == total_member_counts
+        assert [3, 1, 1, 1, 1] == total_student_counts
         football = teams[0]
         assert football['code'] == 'FBM'
         assert football['name'] == 'Football'
-        assert football['totalMemberCount'] == 3
+        assert football['totalStudentCount'] == 3
 
     def test_team_not_found(self, authenticated_session, client):
         """Returns code as name when no code-to-name translation exists."""
@@ -101,12 +101,12 @@ class TestAthletics:
         assert 'teamGroups' in team
         group_codes = [team_group['groupCode'] for team_group in team['teamGroups']]
         assert ['MFB-DB', 'MFB-DL'] == group_codes
-        assert team['totalMemberCount'] == 3
-        members = team['members']
-        assert len(members) == 3
-        sid_list = [member['sid'] for member in members]
+        assert team['totalStudentCount'] == 3
+        students = team['students']
+        assert len(students) == 3
+        sid_list = [student['sid'] for student in students]
         assert ['2345678901', '5678901234', '3456789012'] == sid_list
-        athlete = members[0]
+        athlete = students[0]
         assert athlete['name'] == 'Dave Doolittle'
         assert athlete['sid'] == '2345678901'
         assert athlete['inIntensiveCohort'] is False
@@ -114,7 +114,7 @@ class TestAthletics:
     def test_includes_student_sis_data(self, authenticated_session, client):
         """Includes SIS data for team members."""
         response = client.get('/api/team/FHW')
-        athlete = response.json['members'][0]
+        athlete = response.json['students'][0]
         assert athlete['cumulativeGPA'] == 3.8
         assert athlete['cumulativeUnits'] == 101.3
         assert athlete['level'] == 'Junior'
@@ -123,7 +123,7 @@ class TestAthletics:
     def test_includes_student_current_enrollments(self, authenticated_session, client):
         """Includes current-term active enrollments and analytics for team members."""
         response = client.get('/api/team/FHW')
-        athlete = response.json['members'][0]
+        athlete = response.json['students'][0]
         term = athlete['term']
         assert term['termName'] == 'Fall 2017'
         assert term['enrolledUnits'] == 12.5
@@ -145,6 +145,6 @@ class TestAthletics:
             response = client.get(f'/api/team/FBM?orderBy={order_by}')
             assert response.status_code == 200, f'Non-200 response where order_by={order_by}'
             cohort = json.loads(response.data)
-            assert cohort['totalMemberCount'] == 3, f'Wrong count where order_by={order_by}'
-            sid_list = [s['sid'] for s in cohort['members']]
+            assert cohort['totalStudentCount'] == 3, f'Wrong count where order_by={order_by}'
+            sid_list = [s['sid'] for s in cohort['students']]
             assert sid_list == expected[order_by], f'Unmet expectation where order_by={order_by}'

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -519,8 +519,8 @@ class TestUserAnalytics:
         response = client.post('/api/students', data=json.dumps(data), content_type='application/json')
 
         assert response.status_code == 200
-        assert 'members' in response.json
-        students = response.json['members']
+        assert 'students' in response.json
+        students = response.json['students']
         assert 2 == len(students)
         # Offset of 1, ordered by lastName
         assert ['1133399', '242881'] == [student['uid'] for student in students]
@@ -537,10 +537,10 @@ class TestUserAnalytics:
         response = client.post('/api/students', data=json.dumps({'inIntensiveCohort': True}), content_type='application/json')
         assert response.status_code == 200
         cohort = json.loads(response.data)
-        assert 'members' in cohort
-        assert cohort['totalMemberCount'] == len(cohort['members']) == 5
+        assert 'students' in cohort
+        assert cohort['totalStudentCount'] == len(cohort['students']) == 5
         assert 'teamGroups' not in cohort
-        for student in cohort['members']:
+        for student in cohort['students']:
             assert student['inIntensiveCohort']
 
     def test_order_by_with_intensive_cohort(self, authenticated_session, client):
@@ -562,17 +562,17 @@ class TestUserAnalytics:
             response = client.post('/api/students', data=json.dumps(args), content_type='application/json')
             assert response.status_code == 200, f'Non-200 response where order_by={order_by}'
             cohort = json.loads(response.data)
-            assert cohort['totalMemberCount'] == 5, f'Wrong count where order_by={order_by}'
-            uid_list = [s['uid'] for s in cohort['members']]
+            assert cohort['totalStudentCount'] == 5, f'Wrong count where order_by={order_by}'
+            uid_list = [s['uid'] for s in cohort['students']]
             assert uid_list == expected_uid_list, f'Unmet expectation where order_by={order_by}'
 
     def test_get_inactive_cohort(self, authenticated_session, client):
         response = client.post('/api/students', data=json.dumps({'isInactive': True}), content_type='application/json')
         assert response.status_code == 200
         cohort = json.loads(response.data)
-        assert 'members' in cohort
-        assert cohort['totalMemberCount'] == len(cohort['members']) == 1
+        assert 'students' in cohort
+        assert cohort['totalStudentCount'] == len(cohort['students']) == 1
         assert 'teamGroups' not in cohort
-        inactive_student = response.json['members'][0]
+        inactive_student = response.json['students'][0]
         assert not inactive_student['isActiveAsc']
         assert inactive_student['statusAsc'] == 'Trouble'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-807

We have filtered cohorts and curated cohorts; let's have consistent naming given that they both contain students.  The word 'member' is reserved for `university_dept_members` usage.