### PR TITLE
BOAC-829/BOAC-830, replace term 'group' in text and element ids

### DIFF
--- a/boac/api/student_groups_controller.py
+++ b/boac/api/student_groups_controller.py
@@ -39,7 +39,7 @@ def create_group():
     params = request.get_json()
     name = params.get('name', None)
     if not name:
-        raise BadRequestError('Group creation requires \'name\'')
+        raise BadRequestError('Cohort creation requires \'name\'')
     group = StudentGroup.create(current_user.id, name)
     return tolerant_jsonify(group.to_api_json())
 
@@ -49,11 +49,11 @@ def create_group():
 def add_student_to_group(group_id, sid):
     group = StudentGroup.find_by_id(group_id)
     if not group:
-        raise ResourceNotFoundError(f'No group found with id: {group_id}')
+        raise ResourceNotFoundError(f'No cohort found with id: {group_id}')
     if group.owner_id != current_user.id:
-        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own group {group.id}')
+        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own cohort {group.id}')
     StudentGroup.add_student(group.id, sid)
-    return tolerant_jsonify({'message': f'SID {sid} added to group \'{group_id}\''}), 200
+    return tolerant_jsonify({'message': f'SID {sid} added to cohort \'{group_id}\''}), 200
 
 
 @app.route('/api/group/delete/<group_id>', methods=['DELETE'])
@@ -61,9 +61,9 @@ def add_student_to_group(group_id, sid):
 def delete_group(group_id):
     group = StudentGroup.find_by_id(group_id)
     if group.owner_id != current_user.id:
-        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own group {group.id}')
+        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own cohort {group.id}')
     StudentGroup.delete(group_id)
-    return tolerant_jsonify({'message': f'Group {group_id} has been deleted'}), 200
+    return tolerant_jsonify({'message': f'Cohort {group_id} has been deleted'}), 200
 
 
 @app.route('/api/group/<group_id>')
@@ -71,9 +71,9 @@ def delete_group(group_id):
 def get_group(group_id):
     group = StudentGroup.find_by_id(group_id)
     if not group:
-        raise ResourceNotFoundError(f'Sorry, no group found with id {group_id}.')
+        raise ResourceNotFoundError(f'Sorry, no cohort found with id {group_id}.')
     if group.owner_id != current_user.id:
-        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own group {group.id}')
+        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own cohort {group.id}')
     decorated = _decorate_groups([group.to_api_json()], include_analytics=True)
     return tolerant_jsonify(decorated[0])
 
@@ -83,9 +83,9 @@ def get_group(group_id):
 def remove_student_from_group(group_id, sid):
     group = StudentGroup.find_by_id(group_id)
     if group.owner_id != current_user.id:
-        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own group {group.id}')
+        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own cohort {group.id}')
     StudentGroup.remove_student(group_id, sid)
-    return tolerant_jsonify({'message': f'SID {sid} has been removed from group {group_id}'}), 200
+    return tolerant_jsonify({'message': f'SID {sid} has been removed from cohort {group_id}'}), 200
 
 
 @app.route('/api/groups/my')
@@ -111,11 +111,11 @@ def add_students_to_group():
         raise BadRequestError('The required parameters are \'groupId\' and \'sids\'.')
     group = StudentGroup.find_by_id(group_id)
     if not group:
-        raise ResourceNotFoundError(f'No group found where id={group_id}')
+        raise ResourceNotFoundError(f'No cohort found where id={group_id}')
     if group.owner_id != current_user.id:
-        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own group {group.id}')
+        raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own cohort {group.id}')
     StudentGroup.add_students(group_id, sids)
-    return tolerant_jsonify({'message': f'Successfully added students to group \'{group_id}\''}), 200
+    return tolerant_jsonify({'message': f'Successfully added students to cohort \'{group_id}\''}), 200
 
 
 @app.route('/api/group/update', methods=['POST'])

--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -115,9 +115,9 @@
 
           <div class="cohort-list-view-column-00">
             <div class="student-checkbox-add-to-group">
-              <input id="student-{{student.sid}}-checkbox-add-to-group"
+              <input id="student-{{student.uid}}-curated-cohort-checkbox"
                      type="checkbox"
-                     data-ng-click="checkboxForStudentGroupsSelector(student)"
+                     data-ng-click="curatedCohortStudentToggle(student)"
                      data-ng-model="student.selectedForStudentGroups"/>
             </div>
           </div>

--- a/boac/static/app/cohort/cohortFactory.js
+++ b/boac/static/app/cohort/cohortFactory.js
@@ -109,7 +109,7 @@
       };
       return $http.post('/api/cohort/update', args).then(function(response) {
         $rootScope.$broadcast('myCohortsUpdated');
-        $rootScope.$broadcast('cohortUpdated', {
+        $rootScope.$broadcast('cohortNameChanged', {
           cohort: response.data
         });
       });

--- a/boac/static/app/cohort/cohortFilterDropdown.html
+++ b/boac/static/app/cohort/cohortFilterDropdown.html
@@ -3,7 +3,7 @@
      auto-close="outsideClick"
      is-open="search.dropdown[isOpen]"
      keyboard-nav>
-  <button id="search-filter-{{id}}"
+  <button id="cohort-filter-{{id}}"
           type="button"
           class="btn cohort-filter-dropdown-toggle"
           uib-dropdown-toggle
@@ -27,7 +27,7 @@
         data-ng-class="{'divider': !option}"
         role="menuitem"
         data-ng-repeat="option in search.options[menuType]">
-      <input id="search-option-{{id}}-{{option.id}}"
+      <input id="cohort-filter-option-{{id}}-{{option.id}}"
              type="checkbox"
              data-ng-model="option.selected"
              aria-label="{{option.name}}"

--- a/boac/static/app/cohort/createCohortController.js
+++ b/boac/static/app/cohort/createCohortController.js
@@ -32,8 +32,8 @@
     $scope.openCreateCohortModal = function(opts) {
       $uibModal.open({
         animation: true,
-        ariaLabelledBy: 'create-cohort-header',
-        ariaDescribedBy: 'create-cohort-body',
+        ariaLabelledBy: 'create-filtered-cohort-header',
+        ariaDescribedBy: 'create-filtered-cohort-body',
         templateUrl: '/static/app/cohort/createCohortModal.html',
         controller: 'CreateCohortModal',
         resolve: {
@@ -46,7 +46,6 @@
   });
 
   angular.module('boac').controller('CreateCohortModal', function(
-    authService,
     opts,
     cohortFactory,
     utilService,
@@ -68,7 +67,7 @@
         message: null
       };
       $scope.label = _.trim($scope.label);
-      validationService.validateName({name: $scope.label}, authService.getMe().myCohorts, function(errorMessage) {
+      validationService.validateName({name: $scope.label}, function(errorMessage) {
         if (errorMessage) {
           $scope.error.message = errorMessage;
           $rootScope.isSaving = false;

--- a/boac/static/app/cohort/createCohortModal.html
+++ b/boac/static/app/cohort/createCohortModal.html
@@ -1,11 +1,11 @@
 <div class="modal-header">
-  <h3 id="create-cohort-header">Name Your Saved Cohort</h3>
+  <h3 id="create-filtered-cohort-header">Name Your Filtered Cohort</h3>
 </div>
 <form name="createCohortForm" data-ng-submit="create(cohort)">
-  <div class="modal-body" id="create-cohort-body">
-    <div class="cohort-create-form-label">Cohort Name:</div>
+  <div id="create-filtered-cohort-body" class="modal-body">
+    <div class="cohort-create-form-label">Name:</div>
     <div>
-      <input id="cohort-create-input"
+      <input id="filtered-cohort-create-input"
              class="cohort-create-input-name"
              data-ng-change="error.hide = true"
              data-ng-model="label"
@@ -20,14 +20,14 @@
   </div>
   <div class="modal-footer">
     <button type="button"
-            id="confirm-create-cohort-btn"
+            id="confirm-create-filtered-cohort-btn"
             class="btn btn btn-primary"
             data-ng-disabled="!label.length || isSaving"
             data-ng-click="create(cohort)">
       <i class="fa fa-spinner fa-spin" data-ng-if="isSaving"></i> {{isSaving ? 'Saving' : 'Save'}}
     </button>
     <button type="button"
-            id="cancel-create-cohort-btn"
+            id="cancel-create-filtered-cohort-btn"
             class="btn btn-default"
             data-ng-disabled="isSaving"
             data-ng-click="cancel()">Cancel</button>

--- a/boac/static/app/cohort/deleteCohortModal.html
+++ b/boac/static/app/cohort/deleteCohortModal.html
@@ -1,18 +1,18 @@
 <div class="modal-header">
-  <h3 id="confirm-delete-header">Delete Cohort</h3>
+  <h3 id="confirm-delete-header">Delete Filtered Cohort</h3>
 </div>
 <div class="modal-body cohort-label" id="confirm-delete-body">
   Are you sure you want to delete "<strong><span data-ng-bind="cohort.name"></span></strong>"?
 </div>
 <div class="modal-footer">
-  <form name="deleteCohortForm" data-ng-submit="delete(cohort)">
+  <form data-ng-submit="delete(cohort)">
     <button type="button"
-            id="confirm-delete-cohort-btn"
+            id="confirm-delete-btn"
             class="btn btn btn-primary"
             autofocus
             data-ng-click="delete(cohort)">Delete</button>
     <button type="button"
-            id="cancel-delete-cohort-btn"
+            id="cancel-delete-btn"
             class="btn btn-default"
             data-ng-click="cancel()">Cancel</button>
   </form>

--- a/boac/static/app/cohort/manageCohorts.html
+++ b/boac/static/app/cohort/manageCohorts.html
@@ -24,28 +24,28 @@
         <div class="cohort-manage-name wrap-hard">
           <strong>
             <a data-ui-sref="cohort({c: cohort.id})"
-               data-ui-sref-opts="{reload: true}"><span id="cohort-name-{{$index}}"
+               data-ui-sref-opts="{reload: true}"><span id="filtered-cohort-name-{{$index}}"
                                                         data-ng-bind="cohort.name"></span></a>
           </strong>
-          <span class="faint-text">(<span id="cohort-student-count-{{$index}}" data-ng-bind="cohort.totalStudentCount"></span>)</span>
+          <span class="faint-text">(<span id="filtered-cohort-student-count-{{$index}}" data-ng-bind="cohort.totalStudentCount"></span>)</span>
         </div>
         <div>
           <span data-ng-controller="DeleteCohortController">
             <button type="button"
-                    id="delete-cohort-btn-{{$index}}"
+                    id="delete-filtered-cohort-btn-{{$index}}"
                     class="btn-link cohort-manage-btn-link"
                     data-ng-click="openDeleteCohortModal(cohort)">
               Delete
             </button> <span class="faint-text">|</span>
           </span>
           <button type="button"
-                  id="edit-cohort-btn-{{$index}}"
+                  id="edit-filtered-cohort-btn-{{$index}}"
                   class="btn-link cohort-manage-btn-link"
                   data-ng-click="setEditMode(cohort, true)">
             Rename
           </button> <span class="faint-text">|</span>
           <button type="button"
-                  id="cohort-details-btn-{{$index}}"
+                  id="filtered-cohort-details-btn-{{$index}}"
                   class="btn-link cohort-manage-btn-link"
                   data-ng-click="setShowDetails(cohort, !cohort.detailsShowing)">
             <span data-ng-if="!cohort.detailsShowing">Show Details</span>
@@ -63,7 +63,7 @@
                  data-ng-change="cohort.hideError = true"
                  data-ng-model="cohort.name"
                  focus-on="cohort.editMode"
-                 id="cohort-name-input-{{$index}}"
+                 id="filtered-cohort-name-input-{{$index}}"
                  maxlength="255"
                  name="name"
                  required
@@ -73,14 +73,14 @@
         </div>
         <div class="edit-mode-button-container">
           <button type="button"
-                  id="cohort-save-btn-{{$index}}"
+                  id="filtered-cohort-save-btn-{{$index}}"
                   class="btn btn-sm btn-primary cohort-manage-btn"
                   data-ng-disabled="!cohort.name"
                   data-ng-click="changeCohortName(cohort, cohort.name)">
             Rename
           </button>
           <button type="button"
-                  id="cohort-cancel-btn-{{$index}}"
+                  id="filtered-cohort-cancel-btn-{{$index}}"
                   class="btn btn-sm btn-default cohort-manage-btn"
                   data-ng-click="cancelEdit(cohort)">
             Cancel
@@ -88,7 +88,7 @@
         </div>
       </form>
       <div data-ng-show="cohort.detailsShowing && !cohort.editMode">
-        <div id="cohort-filter-criteria-{{$index}}"
+        <div id="filtered-cohort-criteria-{{$index}}"
              class="cohort-filter-criteria">
           <div data-ng-repeat="name in cohort.filterCriteriaNames track by $index">
             <span class="cohort-filter-criteria-label" data-ng-bind="name"></span>

--- a/boac/static/app/cohort/manageCohortsController.js
+++ b/boac/static/app/cohort/manageCohortsController.js
@@ -28,7 +28,6 @@
   'use strict';
 
   angular.module('boac').controller('ManageCohortsController', function(
-    authService,
     cohortFactory,
     studentFactory,
     utilService,
@@ -74,7 +73,7 @@
     };
 
     $scope.changeCohortName = function(cohort, name) {
-      validationService.validateName({id: cohort.id, name: name}, authService.getMe().myCohorts, function(errorMessage) {
+      validationService.validateName({id: cohort.id, name: name}, function(errorMessage) {
         cohort.error = errorMessage;
         cohort.hideError = false;
         if (!cohort.error) {

--- a/boac/static/app/course/course.html
+++ b/boac/static/app/course/course.html
@@ -94,9 +94,9 @@
             <!-- Column -->
             <div class="course-list-view-column-00" data-ng-if="!$first">
               <div class="student-checkbox-add-to-group">
-                <input id="student-{{student.sid}}-checkbox-add-to-group"
+                <input id="student-{{student.uid}}-curated-cohort-checkbox"
                        type="checkbox"
-                       data-ng-click="checkboxForStudentGroupsSelector(student)"
+                       data-ng-click="curatedCohortStudentToggle(student)"
                        data-ng-model="student.selectedForStudentGroups"/>
               </div>
             </div>
@@ -115,7 +115,7 @@
             <!-- Column -->
             <div class="course-list-view-column-02" data-ng-if="!$first">
               <div>
-                <a id="student-{{student.sid}}"
+                <a id="{{student.uid}}"
                    href
                    data-ng-click="goToStudent(student.uid)">
                   <h3 class="course-student-name"

--- a/boac/static/app/group/createGroupController.js
+++ b/boac/static/app/group/createGroupController.js
@@ -29,11 +29,11 @@
 
   angular.module('boac').controller('CreateGroupController', function($scope, $uibModal) {
 
-    $scope.openCreateGroupModal = function() {
+    $scope.openCreateCuratedCohortModal = function() {
       $uibModal.open({
         animation: true,
-        ariaLabelledBy: 'create-group-header',
-        ariaDescribedBy: 'create-group-body',
+        ariaLabelledBy: 'create-curated-cohort-header',
+        ariaDescribedBy: 'create-curated-cohort-body',
         templateUrl: '/static/app/group/createGroupModal.html',
         controller: 'CreateGroupModal',
         resolve: {}
@@ -42,7 +42,6 @@
   });
 
   angular.module('boac').controller('CreateGroupModal', function(
-    authService,
     studentGroupFactory,
     validationService,
     $scope,
@@ -62,7 +61,7 @@
         message: null
       };
       $scope.name = _.trim($scope.name);
-      validationService.validateName({name: $scope.name}, authService.getMe().myGroups, function(errorMessage) {
+      validationService.validateName({name: $scope.name}, function(errorMessage) {
         if (errorMessage) {
           $scope.isSaving = false;
           $scope.error.message = errorMessage;

--- a/boac/static/app/group/createGroupModal.html
+++ b/boac/static/app/group/createGroupModal.html
@@ -1,11 +1,11 @@
 <div class="modal-header">
-  <h3 id="create-group-header">Name Your Curated Cohort</h3>
+  <h3 id="create-curated-cohort-header">Name Your Curated Cohort</h3>
 </div>
-<form name="createGroupForm" data-ng-submit="create(group)">
-  <div class="modal-body" id="create-group-body">
-    <div class="group-create-form-name">Curated Cohort Name:</div>
+<form data-ng-submit="create(group)">
+  <div id="create-curated-cohort-body" class="modal-body">
+    <div class="group-create-form-name">Name:</div>
     <div>
-      <input id="group-create-input"
+      <input id="curated-cohort-create-input"
              class="group-create-input-name"
              data-ng-change="error.hide = true"
              data-ng-model="name"
@@ -20,14 +20,14 @@
   </div>
   <div class="modal-footer">
     <button type="button"
-            id="confirm-create-group-btn"
+            id="confirm-create-curated-cohort-btn"
             class="btn btn btn-primary"
             data-ng-disabled="!name.length || isSaving"
             data-ng-click="create(group)">
       <i class="fa fa-spinner fa-spin" data-ng-if="isSaving"></i> {{isSaving ? 'Saving' : 'Save'}}
     </button>
     <button type="button"
-            id="cancel-create-group-btn"
+            id="cancel-create-curated-cohort-btn"
             class="btn btn-default"
             data-ng-disabled="isSaving"
             data-ng-click="cancel()">Cancel</button>

--- a/boac/static/app/group/deleteGroupModal.html
+++ b/boac/static/app/group/deleteGroupModal.html
@@ -1,18 +1,18 @@
 <div class="modal-header">
-  <h3 id="confirm-delete-header">Delete Group</h3>
+  <h3 id="confirm-delete-header">Delete Curated Cohort</h3>
 </div>
 <div class="modal-body group-label" id="confirm-delete-body">
   Are you sure you want to delete "<strong><span data-ng-bind="group.name"></span></strong>"?
 </div>
 <div class="modal-footer">
-  <form name="deleteGroupForm" data-ng-submit="delete(group)">
+  <form data-ng-submit="delete(group)">
     <button type="button"
-            id="confirm-delete-group-btn"
+            id="confirm-delete-btn"
             class="btn btn btn-primary"
             autofocus
             data-ng-click="delete(group)">Delete</button>
     <button type="button"
-            id="cancel-delete-group-btn"
+            id="cancel-delete-btn"
             class="btn btn-default"
             data-ng-click="cancel()">Cancel</button>
   </form>

--- a/boac/static/app/group/group.html
+++ b/boac/static/app/group/group.html
@@ -30,7 +30,7 @@
 
       <div class="cohort-sort-column" data-ng-if="tab === 'list'">
         <label class="cohort-sort-label" for="cohort-sort-by">Sort by</label>
-        <select id="cohort-sort-by"
+        <select id="curated-cohort-sort-by"
                 class="form-control"
                 data-ng-model="orderBy.selected"
                 data-ng-options="o.value as o.name for o in orderBy.options">
@@ -38,13 +38,13 @@
       </div>
     </div>
     <div data-ng-show="tab === 'list'" data-ng-if="!isLoading && !error && group.studentCount">
-      <div id="group-students-list" class="list-group">
+      <div id="curated-cohort-students" class="list-group">
         <div class="list-group-item student-list-item"
              data-ng-class="{'list-group-item-info': anchor===student.uid}"
              data-ng-repeat="student in group.students | orderBy:studentComparator track by $index">
 
           <div class="cohort-list-view-column-01">
-            <i id="remove-student-{{student.sid}}-from-group"
+            <i id="student-{{student.uid}}-curated-cohort-remove"
                class="fa fa-times-circle"
                data-ng-click="removeFromGroup(student)"></i>
           </div>

--- a/boac/static/app/group/groupsSelector.html
+++ b/boac/static/app/group/groupsSelector.html
@@ -1,7 +1,7 @@
 <div class="group-selector-container">
   <div>
     <div class="group-selector-checkbox">
-      <input id="group-checkbox-add-all"
+      <input id="curated-cohort-checkbox-add-all"
              type="checkbox"
              data-ng-model="selector.selectAllCheckbox"
              data-ng-click="toggleAllStudentCheckboxes()"/>
@@ -12,20 +12,20 @@
          uib-dropdown
          is-open="selector.isOpen"
          data-ng-if="selector.showGroupsMenu">
-      <button id="added-to-group-confirmation"
+      <button id="added-to-curated-cohort-confirmation"
               type="button"
               data-ng-disabled="true"
               class="btn group-btn-confirmation"
               data-ng-if="isSaving">
         <i class="fa fa-check"></i>
-        Added to Group
+        Added to Curated Cohort
       </button>
-      <button id="add-to-group-button"
+      <button id="add-to-curated-cohort-button"
               type="button"
               class="btn btn-primary"
               uib-dropdown-toggle
               data-ng-if="!isSaving">
-        Add to Group <span class="caret"></span>
+        Add to Curated Cohort <span class="caret"></span>
       </button>
       <ul class="dropdown-menu group-all-menu"
           uib-dropdown-menu
@@ -38,13 +38,13 @@
             data-ng-class="{'group-checkbox-item': group, 'divider': !group}"
             data-ng-repeat="group in myGroups track by $index"
             data-ng-href="!isLoading">
-          <input id="student-{{student.sid}}-group-checkbox"
+          <input id="student-{{student.uid}}-curated-cohort-checkbox"
                  type="checkbox"
                  data-ng-model="group.selected"
                  data-ng-click="groupCheckboxClick(group)"
                  aria-labelledby="group-name-{{$index}}"
                  data-ng-if="group"/>
-          <span id="group-{{group.id}}-name"
+          <span id="curated-cohort-{{group.id}}-name"
                 aria-labelledby="student-{{student.sid}}-group-checkbox"
                 class="group-checkbox-name"
                 data-ng-bind="group.name"
@@ -54,9 +54,9 @@
         <li role="menuitem"
             data-ng-controller="CreateGroupController"
             data-ng-href="!isLoading">
-          <a id="group-create"
+          <a id="curated-cohort-create"
              href
-             data-ng-click="openCreateGroupModal()"><i class="fa fa-plus"></i> Create New Group</a>
+             data-ng-click="openCreateCuratedCohortModal()"><i class="fa fa-plus"></i> Create New Curated Cohort</a>
         </li>
       </ul>
     </div>

--- a/boac/static/app/group/groupsSelectorDirective.js
+++ b/boac/static/app/group/groupsSelectorDirective.js
@@ -124,12 +124,10 @@
         };
 
         /**
-         * Click on checkbox of an individual student.
-         *
-         * @param  {Student}    student      Student checkbox has been toggled.
+         * @param  {Student}    student      Add/remove student to/from curated cohort.
          * @return {void}
          */
-        $rootScope.checkboxForStudentGroupsSelector = function(student) {
+        $rootScope.curatedCohortStudentToggle = function(student) {
           if (student.selectedForStudentGroups) {
             var allStudentsSelected = true;
             _.each(scope.students, function(_student) {

--- a/boac/static/app/group/manageGroups.html
+++ b/boac/static/app/group/manageGroups.html
@@ -16,32 +16,32 @@
     </div>
     <div data-ng-if="!myGroups.length" data-ng-controller="CreateGroupController">
       You have no curated cohorts.
-      <a id="sidebar-group-create"
+      <a id="curated-cohort-create"
          href
-         data-ng-click="openCreateGroupModal()"><i class="fa fa-plus"></i> Create a new curated cohort</a>
+         data-ng-click="openCreateCuratedCohortModal()"><i class="fa fa-plus"></i> Create a new curated cohort</a>
     </div>
     <div data-ng-repeat="group in myGroups">
       <hr class="cohort-manage-row-separator"/>
       <div class="flex-container flex-space-between" data-ng-if="!group.editMode">
         <div class="cohort-manage-name wrap-hard">
           <strong>
-            <a id="group-{{group.id}}"
+            <a id="curated-cohort-{{group.id}}"
                data-ng-bind="group.name"
                data-ng-href="/group/{{group.id}}"></a>
           </strong>
-          <span class="faint-text">(<span id="group-student-count-{{$index}}" data-ng-bind="group.studentCount"></span>)</span>
+          <span class="faint-text">(<span id="curated-cohort-student-count-{{group.id}}" data-ng-bind="group.studentCount"></span>)</span>
         </div>
         <div>
           <span data-ng-controller="DeleteGroupController">
             <button type="button"
-                    id="delete-group-btn-{{$index}}"
+                    id="delete-curated-cohort-btn-{{$index}}"
                     class="btn-link cohort-manage-btn-link"
                     data-ng-click="openDeleteGroupModal(group)">
               Delete
             </button> <span class="faint-text">|</span>
           </span>
           <button type="button"
-                  id="edit-group-btn-{{$index}}"
+                  id="edit-curated-cohort-btn-{{$index}}"
                   class="btn-link cohort-manage-btn-link"
                   data-ng-click="setEditMode(group, true)">
             Rename
@@ -58,7 +58,7 @@
                  data-ng-change="group.hideError = true"
                  data-ng-model="group.name"
                  focus-on="group.editMode"
-                 id="group-label-input-{{$index}}"
+                 id="curated-cohort-label-input-{{$index}}"
                  maxlength="255"
                  name="label"
                  required
@@ -68,14 +68,14 @@
         </div>
         <div class="edit-mode-button-container">
           <button type="button"
-                  id="group-save-btn-{{$index}}"
+                  id="curated-cohort-save-btn-{{$index}}"
                   class="btn btn-sm btn-primary cohort-manage-btn"
                   data-ng-disabled="!group.name"
                   data-ng-click="changeGroupName(group, group.name)">
             Rename
           </button>
           <button type="button"
-                  id="group-cancel-btn-{{$index}}"
+                  id="curated-cohort-cancel-btn-{{$index}}"
                   class="btn btn-sm btn-default cohort-manage-btn"
                   data-ng-click="cancelEdit(group)">
             Cancel

--- a/boac/static/app/group/manageGroupsController.js
+++ b/boac/static/app/group/manageGroupsController.js
@@ -28,7 +28,6 @@
   'use strict';
 
   angular.module('boac').controller('ManageGroupsController', function(
-    authService,
     studentGroupFactory,
     studentGroupService,
     validationService,
@@ -57,7 +56,7 @@
     };
 
     $scope.changeGroupName = function(group, name) {
-      validationService.validateName({id: group.id, name: name}, authService.getMe().myGroups, function(error) {
+      validationService.validateName({id: group.id, name: name}, function(error) {
         group.error = error;
         group.hideError = false;
         if (!group.error) {

--- a/boac/static/app/home/home.html
+++ b/boac/static/app/home/home.html
@@ -10,19 +10,21 @@
       <div id="curated-cohorts-header-row" class="home-page-section-header-wrapper">
         <h1 class="page-section-header">Curated Cohorts</h1>
         <div class="home-cohort-actions" data-ng-controller="CreateGroupController">
-          <a id="home-curated-cohorts-create-link" href data-ng-click="openCreateGroupModal()">Create</a> |
+          <a id="home-curated-cohorts-create-link" href data-ng-click="openCreateCuratedCohortModal()">Create</a> |
           <a id="home-curated-cohorts-manage-link" href="/groups/manage">Manage</a>
         </div>
       </div>
       <div data-ng-if="!myGroups.length">
         You have no curated cohorts.
         <span data-ng-controller="CreateGroupController">
-          <a id="home-group-create" href data-ng-click="openCreateGroupModal()"> Create a new curated cohort.</a>
+          <a id="home-curated-cohort-create"
+             href
+             data-ng-click="openCreateCuratedCohortModal()"> Create a new curated cohort.</a>
         </span>
       </div>
       <div data-ng-repeat="group in myGroups" data-ng-if="myGroups.length">
         <h2 class="page-section-header-sub">
-          <a id="home-group-{{$index}}"
+          <a id="home-curated-cohort-{{group.id}}"
              data-ng-bind="group.name"
              data-ng-href="/group/{{group.id}}"></a> (<span data-ng-bind="group.studentCount"></span>)
         </h2>
@@ -44,7 +46,7 @@
       </div>
       <div data-ng-repeat="cohort in myCohorts" data-ng-if="myCohorts.length">
         <h2 class="page-section-header-sub">
-          <a id="home-cohort-{{$index}}"
+          <a id="home-filtered-cohort-{{$index}}"
              data-ng-bind="cohort.label"
              data-ng-href="/cohort?c={{cohort.id}}"></a> (<span data-ng-bind="cohort.totalStudentCount"></span>)
         </h2>

--- a/boac/static/app/nav/sidebar.html
+++ b/boac/static/app/nav/sidebar.html
@@ -1,8 +1,8 @@
 <div class="sidebar-section-search">
-  <form id="search-students-form" data-ng-submit="searchForStudents()">
-    <label for="search-students-input" class="sr-only">Search for students</label>
+  <form id="sidebar-search-students-form" data-ng-submit="searchForStudents()">
+    <label for="sidebar-search-students-input" class="sr-only">Search for students</label>
     <span class="search-students-icon"><i class="fa fa-search"></i></span>
-    <input id="search-students-input"
+    <input id="sidebar-search-students-input"
            type="text"
            class="search-students-input"
            data-ng-model="searchPhrase"
@@ -18,7 +18,7 @@
         data-ng-controller="CreateGroupController">
     <a id="sidebar-curated-cohorts-manage" href="/groups/manage" class="sidebar-row-link-label-text">Curated Cohorts</a>
     <a id="sidebar-curated-cohort-create" class="sidebar-create-link" href
-       data-ng-click="openCreateGroupModal()"><i class="fa fa-plus"></i></a>
+       data-ng-click="openCreateCuratedCohortModal()"><i class="fa fa-plus"></i></a>
   </span>
 </div>
 <div class="sidebar-row-link" data-ng-repeat="group in myGroups">

--- a/boac/static/app/nav/sidebarNavController.js
+++ b/boac/static/app/nav/sidebarNavController.js
@@ -72,7 +72,7 @@
       });
     });
 
-    $rootScope.$on('cohortUpdated', function(event, data) {
+    $rootScope.$on('cohortNameChanged', function(event, data) {
       _.each($scope.myCohorts, function(cohort) {
         if (cohort.id === data.cohort.id) {
           cohort.label = data.cohort.label;

--- a/boac/static/app/search/searchResults.html
+++ b/boac/static/app/search/searchResults.html
@@ -27,8 +27,8 @@
       </div>
       <div class="cohort-tabs-container-column-03">
         <div class="cohort-sort-column">
-          <label class="cohort-sort-label" for="cohort-sort-by">Sort by</label>
-          <select id="cohort-sort-by"
+          <label class="cohort-sort-label" for="search-results-sort-by">Sort by</label>
+          <select id="search-results-sort-by"
                   class="form-control"
                   data-ng-model="orderBy.selected"
                   data-ng-options="o.value as o.name for o in orderBy.options">
@@ -37,16 +37,16 @@
       </div>
     </div>
     <div data-ng-if="!isLoading && !error && search.results.totalStudentCount">
-      <ul id="cohort-students-list" class="list-group">
+      <ul id="search-results" class="list-group">
         <div class="list-group-item cohort-student-list-item"
              data-ng-class="{'list-group-item-info': anchor===student.uid}"
              data-ng-repeat="student in search.results.students">
 
           <div class="cohort-list-view-column-00">
             <div class="student-checkbox-add-to-group">
-              <input id="student-{{student.sid}}-checkbox-add-to-group"
+              <input id="{{student.uid}}-curated-cohort-checkbox"
                      type="checkbox"
-                     data-ng-click="checkboxForStudentGroupsSelector(student)"
+                     data-ng-click="curatedCohortStudentToggle(student)"
                      data-ng-model="student.selectedForStudentGroups"/>
             </div>
           </div>

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -80,11 +80,11 @@
               <div class="student-bio-status-box-groups student-groups-checkboxes">
                 <div>
                   <h4 class="student-bio-header">
-                    Curated Cohorts <span data-ng-if="myGroups.length">(<a id="groups-manage" href="/groups/manage">Manage</a>)</span>
+                    Curated Cohorts <span data-ng-if="myGroups.length">(<a id="curated-cohorts-manage" href="/groups/manage">Manage</a>)</span>
                   </h4>
                 </div>
                 <div class="student-group-checkbox" data-ng-repeat="group in myGroups track by $index">
-                  <input id="student-group-checkbox-{{$index}}"
+                  <input id="curated-cohort-checkbox-{{$index}}"
                          class="student-group-checkbox-input"
                          type="checkbox"
                          data-ng-model="group.selected"
@@ -95,9 +95,9 @@
                 </div>
                 <div class="student-group-create-new">
                   <span data-ng-controller="CreateGroupController">
-                    <a id="group-create"
+                    <a id="curated-cohort-create"
                        href
-                       data-ng-click="openCreateGroupModal()"><i class="fa fa-plus"></i> Create New Curated Cohort</a>
+                       data-ng-click="openCreateCuratedCohortModal()"><i class="fa fa-plus"></i> Create New Curated Cohort</a>
                   </span>
                 </div>
               </div>

--- a/boac/static/app/user/authService.js
+++ b/boac/static/app/user/authService.js
@@ -54,6 +54,30 @@
       });
     };
 
+    $rootScope.$on('cohortCreated', function(event, data) {
+      if (_.get($rootScope, 'me.myCohorts')) {
+        $rootScope.me.myCohorts.push(data.cohort);
+      }
+    });
+
+    $rootScope.$on('cohortDeleted', function(event, data) {
+      if (_.get($rootScope, 'me.myCohorts')) {
+        $rootScope.me.myCohorts = _.remove($rootScope.me.myCohorts, function(cohort) {
+          return data.cohort.id !== cohort.id;
+        });
+      }
+    });
+
+    $rootScope.$on('cohortNameChanged', function(event, data) {
+      if (_.get($rootScope, 'me.myCohorts')) {
+        _.each($rootScope.me.myCohorts, function(cohort) {
+          if (data.cohort.id === group.id) {
+            cohort.name = data.cohort.name;
+          }
+        });
+      }
+    });
+
     $rootScope.$on('groupCreated', function(event, data) {
       if (_.get($rootScope, 'me.myGroups')) {
         $rootScope.me.myGroups.push(data.group);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-812
https://jira.ets.berkeley.edu/jira/browse/BOAC-825
https://jira.ets.berkeley.edu/jira/browse/BOAC-830
https://jira.ets.berkeley.edu/jira/browse/BOAC-829

* sensible `ids` for Teena
* bye-bye "Groups"
* `authService` now listens for all cohort create/delete/rename events
