### PR TITLE
BOAC-842, Flask user_loader does not benefit from AuthorizedUser lazy=True

### DIFF
--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -41,18 +41,15 @@ class AuthorizedUser(Base, UserMixin):
     department_memberships = db.relationship(
         'UniversityDeptMember',
         back_populates='authorized_user',
-        lazy=True,
     )
     cohort_filters = db.relationship(
         'CohortFilter',
         secondary=cohort_filter_owners,
         back_populates='owners',
-        lazy=True,
     )
     alert_views = db.relationship(
         'AlertView',
         back_populates='viewer',
-        lazy=True,
     )
 
     def __init__(self, uid, is_admin=False):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-842

The SQLAlchemy traceback includes ref to http://sqlalche.me/e/bhk3

```
DetachedInstanceError: Instance AuthorizedUser is not bound to a Session; attribute refresh operation cannot proceed
```