### PR TITLE
BOAC-861, curated-cohort-selector must behave across browsers, result-sets

### DIFF
--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -92,7 +92,8 @@
          data-ng-if="!isLoading && !error && (tab === 'matrix' || cohort.totalStudentCount)">
 
       <div class="cohort-tabs-container-column-01">
-        <curated-cohort-selector data-students="cohort.students" data-ng-if="tab === 'list'"></curated-cohort-selector>
+        <curated-cohort-selector data-students="cohort.students"
+                                 data-ng-if="cohort.students.length && (tab === 'list')"></curated-cohort-selector>
       </div>
       <div class="cohort-tabs-container-column-02">
         <div data-ng-include="'/static/app/shared/tabs.html'"></div>
@@ -119,8 +120,8 @@
             <div class="student-checkbox-add-to-group">
               <input id="student-{{student.uid}}-curated-cohort-checkbox"
                      type="checkbox"
-                     data-ng-click="curatedCohortStudentToggle(student)"
-                     data-ng-model="student.selectedForStudentGroups"/>
+                     data-ng-click="student.curatedCohortToggle($event)"
+                     data-ng-model="student.selectedForCuratedCohort"/>
             </div>
           </div>
 

--- a/boac/static/app/cohort/cohortController.js
+++ b/boac/static/app/cohort/cohortController.js
@@ -484,7 +484,7 @@
       $scope.showIntensiveCheckbox = false;
       $scope.showInactiveCheckbox = false;
       $scope.search.dropdown = defaultDropdownState();
-      $rootScope.$broadcast('resetStudentGroupsSelector');
+      $rootScope.$broadcast('resetCuratedCohortSelector');
       // Refresh search results
       $scope.cohort.code = 'search';
       $rootScope.pageTitle = 'Search';

--- a/boac/static/app/course/course.html
+++ b/boac/static/app/course/course.html
@@ -63,7 +63,8 @@
 
       <div class="course-tabs-container">
         <div class="course-tabs-container-column-01">
-          <curated-cohort-selector data-students="section.students" data-ng-if="tab === 'list'"></curated-cohort-selector>
+          <curated-cohort-selector data-students="section.students"
+                                   data-ng-if="section.students.length && (tab === 'list')"></curated-cohort-selector>
         </div>
         <div class="course-tabs-container-column-02">
           <div data-ng-include="'/static/app/shared/tabs.html'"></div>
@@ -94,8 +95,8 @@
               <div class="student-checkbox-add-to-group">
                 <input id="student-{{student.uid}}-curated-cohort-checkbox"
                        type="checkbox"
-                       data-ng-click="curatedCohortStudentToggle(student)"
-                       data-ng-model="student.selectedForStudentGroups"/>
+                       data-ng-click="student.curatedCohortToggle($event)"
+                       data-ng-model="student.selectedForCuratedCohort"/>
               </div>
             </div>
 

--- a/boac/static/app/group/groupsSelector.html
+++ b/boac/static/app/group/groupsSelector.html
@@ -11,7 +11,7 @@
     <div class="group-btn-group"
          uib-dropdown
          is-open="selector.isOpen"
-         data-ng-if="selector.showGroupsMenu">
+         data-ng-if="selector.showCuratedCohortMenu">
       <button id="added-to-curated-cohort-confirmation"
               type="button"
               data-ng-disabled="true"

--- a/boac/static/app/home/sortableAlertsTable.html
+++ b/boac/static/app/home/sortableAlertsTable.html
@@ -32,8 +32,8 @@
       <div class="student-checkbox-add-to-group">
         <input id="{{student.uid}}-curated-cohort-checkbox"
                type="checkbox"
-               data-ng-click="curatedCohortStudentToggle(student)"
-               data-ng-model="student.selectedForStudentGroups"/>
+               data-ng-click="student.curatedCohortToggle($event)"
+               data-ng-model="student.selectedForCuratedCohort"/>
       </div>
     </div>
     <div class="group-summary-column group-summary-column-01">

--- a/boac/static/app/home/sortableAlertsTableDirective.js
+++ b/boac/static/app/home/sortableAlertsTableDirective.js
@@ -27,7 +27,7 @@
 
   'use strict';
 
-  angular.module('boac').directive('sortableAlertsTable', function(authService, config, $rootScope) {
+  angular.module('boac').directive('sortableAlertsTable', function(authService, config) {
 
     return {
       // @see https://docs.angularjs.org/guide/directive#template-expanding-directive
@@ -44,7 +44,6 @@
       link: function(scope) {
         scope.isCurrentUserAscAdvisor = authService.isCurrentUserAscAdvisor();
         scope.demoMode = config.demoMode;
-        scope.curatedCohortStudentToggle = $rootScope.curatedCohortStudentToggle;
         scope.sort = function(options, sortBy) {
           if (options.sortBy === sortBy) {
             options.reverse = !options.reverse;

--- a/boac/static/app/search/searchResults.html
+++ b/boac/static/app/search/searchResults.html
@@ -22,7 +22,8 @@
 
   <div class="cohort-column-results" data-ng-if="!isLoading && !error && search.totalStudentCount">
     <div class="search-header-curated-cohort">
-      <curated-cohort-selector data-students="search.students"></curated-cohort-selector>
+      <curated-cohort-selector data-students="search.students"
+                               data-ng-if="search.students.length"></curated-cohort-selector>
     </div>
     <div>
       <sortable-alerts-table data-students="search.students" data-options="displayOptions"></sortable-alerts-table>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-861

Some added insurance to this feature:
* do not render `curated-cohort-selector` until students have loaded
* `event.stopPropagation()` in case of cross-browser differences
* put the `toggle` function on each student instance, to guarantee its presence 