### PR TITLE
BOAC-871 Falsey check for student term in course controller

### DIFF
--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -48,7 +48,10 @@ def get_section(term_id, section_id):
     student_details.merge_all(students, section['termId'])
     for student in students:
         # Cherry-pick enrollment of section requested
-        for enrollment in student.get('term', {}).get('enrollments', []):
+        student_term = student.get('term')
+        if not student_term:
+            continue
+        for enrollment in student_term.get('enrollments', []):
             if enrollment['displayName'] == section['displayName']:
                 student['enrollment'] = enrollment
     if students and util.to_bool_or_none(request.args.get('includeAverage')):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-871

Subtle and annoying gotcha: if a dict key exists but has `None` value, Python `get` will return `None` rather than using the provided fallback.