### PR TITLE
NOJIRA Remove unused "participations" metric

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -61,7 +61,7 @@ def mean_course_analytics_for_user(user_courses, uid, sid, canvas_user_id, term_
     merge_analytics_for_user(user_courses, uid, sid, canvas_user_id, term_id)
     mean_values = {}
     # TODO Remove misleading assignmentsOnTime metric.
-    for metric in ['assignmentsOnTime', 'pageViews', 'participations', 'courseCurrentScore']:
+    for metric in ['assignmentsOnTime', 'pageViews', 'courseCurrentScore']:
         percentiles = []
         for course in user_courses:
             percentile = course['analytics'].get(metric, {}).get('student', {}).get('percentile')
@@ -83,7 +83,6 @@ def get_student_averages(term_id, canvas_course_id):
         average_student = {
             'id': 0,
             'max_page_views': summary_feed[0]['max_page_views'],
-            'max_participations': summary_feed[0]['max_participations'],
             'tardiness_breakdown': {},
         }
 
@@ -92,7 +91,6 @@ def get_student_averages(term_id, canvas_course_id):
         for student in summary_feed:
             # Get sum totals
             _add(student, 'page_views', average_student)
-            _add(student, 'participations', average_student)
             tardiness_breakdown = student.get('tardiness_breakdown')
             if tardiness_breakdown:
                 target = average_student['tardiness_breakdown']
@@ -109,8 +107,6 @@ def get_student_averages(term_id, canvas_course_id):
                 _average_student[_key] = round(_average_student[_key] / count)
         _average(average_student, 'page_views')
         _average(average_student, 'page_views_level')
-        _average(average_student, 'participations')
-        _average(average_student, 'participations_level')
         tb = average_student['tardiness_breakdown']
         _average(tb, 'floating')
         _average(tb, 'missing')
@@ -124,7 +120,7 @@ def get_student_averages(term_id, canvas_course_id):
 def analytics_from_summary_feed(summary_feed, canvas_user_id, canvas_course_id):
     """Given a student summary feed for a Canvas course, return analytics for a given user."""
     # TODO Remove misleading tardiness_breakdown stats.
-    df = pandas.DataFrame(summary_feed, columns=['id', 'page_views', 'participations', 'tardiness_breakdown'])
+    df = pandas.DataFrame(summary_feed, columns=['id', 'page_views', 'tardiness_breakdown'])
     df['on_time'] = [row['on_time'] for row in df['tardiness_breakdown']]
     student_row = df.loc[df['id'].values == canvas_user_id]
     if not len(student_row):
@@ -133,7 +129,6 @@ def analytics_from_summary_feed(summary_feed, canvas_user_id, canvas_course_id):
     return {
         'assignmentsOnTime': analytics_for_column(df, student_row, 'on_time'),
         'pageViews': analytics_for_column(df, student_row, 'page_views'),
-        'participations': analytics_for_column(df, student_row, 'participations'),
     }
 
 

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -179,7 +179,7 @@ class TestCohortDetail:
         assert term['enrollments'][0]['displayName'] == 'BURMESE 1A'
         assert len(term['enrollments'][0]['canvasSites']) == 1
         analytics = athlete['analytics']
-        for metric in ['assignmentsOnTime', 'pageViews', 'participations', 'courseCurrentScore']:
+        for metric in ['assignmentsOnTime', 'pageViews', 'courseCurrentScore']:
             assert analytics[metric]['percentile'] > 0
             assert analytics[metric]['displayPercentile'].endswith(('rd', 'st', 'th'))
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -260,12 +260,6 @@ class TestUserAnalytics:
         assert analytics['pageViews']['courseDeciles'][9] == 917
         assert analytics['pageViews']['courseDeciles'][10] == 31983
 
-        assert analytics['participations']['student']['raw'] == 5
-        assert analytics['participations']['student']['percentile'] == 83
-        assert analytics['participations']['courseDeciles'][0] == 0
-        assert analytics['participations']['courseDeciles'][9] == 6
-        assert analytics['participations']['courseDeciles'][10] == 12
-
         assert analytics['loch']['assignmentsOnTime']['student']['raw'] == 7
         assert analytics['loch']['assignmentsSubmitted']['student']['raw'] == 8
         assert analytics['loch']['pageViews']['student']['raw'] == 766

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -119,7 +119,7 @@ class TestAnalyticsFromSummaryFeed:
         best = analytics.analytics_from_summary_feed(summary_feed, self.canvas_user_id, self.canvas_course_id)
         median = analytics.analytics_from_summary_feed(summary_feed, '101', self.canvas_course_id)
         for digested in [worst, best, median]:
-            for column in ['assignmentsOnTime', 'pageViews', 'participations']:
+            for column in ['assignmentsOnTime', 'pageViews']:
                 assert digested[column]['boxPlottable'] is False
                 assert digested[column]['student']['percentile'] is not None
 
@@ -158,7 +158,7 @@ class TestAnalyticsFromSummaryFeed:
             },
         ]
         digested = analytics.analytics_from_summary_feed(summary_feed, self.canvas_user_id, self.canvas_course_id)
-        for column in ['assignmentsOnTime', 'pageViews', 'participations']:
+        for column in ['assignmentsOnTime', 'pageViews']:
             assert digested[column]['boxPlottable'] is False
             assert digested[column]['displayPercentile'] is None
             assert digested[column]['student']['percentile'] is None
@@ -189,7 +189,7 @@ class TestAnalyticsFromSummaryFeed:
             },
         ]
         digested = analytics.analytics_from_summary_feed(summary_feed, self.canvas_user_id, self.canvas_course_id)
-        for column in ['assignmentsOnTime', 'participations']:
+        for column in ['assignmentsOnTime']:
             assert digested[column]['boxPlottable'] is False
             assert digested[column]['displayPercentile'] is None
             assert digested[column]['student']['percentile'] is None
@@ -223,15 +223,12 @@ class TestAnalyticsFromSummaryFeed:
 
         digested = analytics.analytics_from_summary_feed(summary_feed, self.canvas_user_id, self.canvas_course_id)
         print('zeroth = {}'.format(repr(digested)))
-        for column in ['assignmentsOnTime', 'participations']:
+        for column in ['assignmentsOnTime']:
             assert digested[column]['boxPlottable'] is False
             assert digested[column]['student']['percentile'] is not None
         assert digested['assignmentsOnTime']['displayPercentile'] == '0th'
         assert digested['assignmentsOnTime']['student']['raw'] == 0
         assert digested['assignmentsOnTime']['courseDeciles'][10] == 16
-        assert digested['participations']['displayPercentile'] == '0th'
-        assert digested['participations']['student']['raw'] == 0
-        assert digested['participations']['courseDeciles'][10] == 11
         assert digested['pageViews']['displayPercentile'] == '0th'
         assert digested['pageViews']['boxPlottable'] is True
 


### PR DESCRIPTION
We hope to eliminate our dependency on the expensive Canvas `analytics/student_summaries` API:

https://jira.ets.berkeley.edu/jira/browse/BOAC-873
https://jira.ets.berkeley.edu/jira/browse/BOAC-793

This PR just clears a little noise out of the way.