### PR TITLE
BOAC-793, swap out page-views on the front-end; prep for days-since-course-site-visited metric

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -61,7 +61,7 @@ def mean_course_analytics_for_user(user_courses, uid, sid, canvas_user_id, term_
     merge_analytics_for_user(user_courses, uid, sid, canvas_user_id, term_id)
     mean_values = {}
     # TODO Remove misleading assignmentsOnTime metric.
-    for metric in ['assignmentsOnTime', 'pageViews', 'courseCurrentScore']:
+    for metric in ['assignmentsOnTime', 'daysSinceCourseSiteVisited', 'courseCurrentScore']:
         percentiles = []
         for course in user_courses:
             percentile = course['analytics'].get(metric, {}).get('student', {}).get('percentile')
@@ -128,7 +128,7 @@ def analytics_from_summary_feed(summary_feed, canvas_user_id, canvas_course_id):
         return {'error': 'Unable to retrieve analytics'}
     return {
         'assignmentsOnTime': analytics_for_column(df, student_row, 'on_time'),
-        'pageViews': analytics_for_column(df, student_row, 'page_views'),
+        'daysSinceCourseSiteVisited': analytics_for_column(df, student_row, 'page_views'),
     }
 
 
@@ -192,7 +192,7 @@ def analytics_from_loch(uid, canvas_user_id, canvas_course_id, term_id):
     return {
         'assignmentsOnTime': loch_assignments_on_time(canvas_user_id, canvas_course_id, term_id),
         'assignmentsSubmitted': loch_assignments_submitted(canvas_user_id, canvas_course_id, term_id),
-        'pageViews': loch_page_views(uid, canvas_course_id, term_id),
+        'daysSinceCourseSiteVisited': loch_page_views(uid, canvas_course_id, term_id),
     }
 
 

--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -177,7 +177,7 @@
           <div class="student-course-activity-wrapper">
             <div class="student-course-activity-row">
               <div class="student-column student-text">CLASS</div>
-              <div class="student-column student-text">PAGE VIEWS</div>
+              <div class="student-column student-text">ACTIVITY</div>
               <div class="cohort-list-view-column-grade student-text">MID</div>
               <div class="cohort-list-view-column-grade student-text">FINAL</div>
             </div>
@@ -187,10 +187,7 @@
               </div>
               <div class="student-column">
                 <div class="cohort-boxplot-container" data-ng-repeat="canvasSite in enrollment.canvasSites">
-                  <boxplot-draw class="cohort-boxplot"
-                                data-compact-tooltip="true"
-                                data-dataset="canvasSite.analytics.pageViews"
-                                data-ng-if="tab === 'list'"></boxplot-draw>
+                  17 days ago
                 </div>
               </div>
               <div class="cohort-list-view-column-grade">

--- a/boac/static/app/course/course.html
+++ b/boac/static/app/course/course.html
@@ -86,7 +86,7 @@
             <div class="course-list-view-column-03 course-list-view-column-header course-list-view-column-03-header" data-ng-if="$first">COURSE<div>SITE(S)</div></div>
             <div class="course-list-view-column-04 course-list-view-column-header" data-ng-if="$first">ASSIGNMENTS <div class="no-wrap">ON TIME</div></div>
             <div class="course-list-view-column-05 course-list-view-column-header" data-ng-if="$first">ASSIGNMENT<div>GRADES</div></div>
-            <div class="course-list-view-column-06 course-list-view-column-header" data-ng-if="$first">PAGE VIEWS</div>
+            <div class="course-list-view-column-06 course-list-view-column-header" data-ng-if="$first">ACTIVITY</div>
             <div class="course-list-view-column-07 course-list-view-column-header" data-ng-if="$first">MID</div>
             <div class="course-list-view-column-08 course-list-view-column-header" data-ng-if="$first">FINAL</div>
 
@@ -186,9 +186,7 @@
               <div class="course-list-view-column-canvas-sites">
                 <div class="profile-boxplot-container"
                      data-ng-repeat="canvasSite in student.enrollment.canvasSites">
-                  <boxplot-draw class="profile-boxplot"
-                                data-dataset="canvasSite.analytics.pageViews"
-                                data-ng-if="canvasSite.analytics.pageViews"></boxplot-draw>
+                  17 days
                 </div>
               </div>
             </div>

--- a/boac/static/app/group/group.html
+++ b/boac/static/app/group/group.html
@@ -100,7 +100,7 @@
           <div class="student-course-activity-wrapper">
             <div class="student-course-activity-row">
               <div class="student-column student-text">CLASS</div>
-              <div class="student-column student-text">PAGE VIEWS</div>
+              <div class="student-column student-text">ACTIVITY</div>
               <div class="cohort-list-view-column-grade student-text">MID</div>
               <div class="cohort-list-view-column-grade student-text">FINAL</div>
             </div>
@@ -110,10 +110,7 @@
               </div>
               <div class="student-column">
                 <div class="cohort-boxplot-container" data-ng-repeat="canvasSite in enrollment.canvasSites">
-                  <boxplot-draw class="cohort-boxplot"
-                                data-compact-tooltip="true"
-                                data-dataset="canvasSite.analytics.pageViews"
-                                data-ng-if="tab === 'list'"></boxplot-draw>
+                  17 days
                 </div>
               </div>
               <div class="cohort-list-view-column-grade">

--- a/boac/static/app/main.css
+++ b/boac/static/app/main.css
@@ -244,15 +244,18 @@
 
 .visualize-metrics {
   margin-bottom: 20px;
+  width: 80%;
 }
 
 .visualize-metrics td {
   font-size: 14px;
   padding: 0 25px 5px 0;
+  vertical-align: top;
 }
 
 .visualize-metrics-legend {
   color: #999;
+  white-space: nowrap;
 }
 
 .visualize-metrics-maximum {

--- a/boac/static/app/shared/boxplotService.js
+++ b/boac/static/app/shared/boxplotService.js
@@ -161,7 +161,7 @@
           borderColor: 'transparent',
           headerFormat: '',
           hideDelay: 0,
-          pointFormat: dataset.student.raw + ' Page Views (Class median is ' + dataset.courseDeciles[5] + ')',
+          pointFormat: 'Last visited course site 17 days ago. 75 out of 78 have connected more recently.',
           positioner: function(labelWidth, labelHeight) {
             return {
               x: -50,

--- a/boac/static/app/shared/matrix.css
+++ b/boac/static/app/shared/matrix.css
@@ -55,7 +55,7 @@
 .matrix-axis-label {
   font-size: 16px;
   font-weight: 200;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.075em;
   text-transform: uppercase;
   stroke: #999;
 }

--- a/boac/static/app/shared/matrix.html
+++ b/boac/static/app/shared/matrix.html
@@ -1,6 +1,6 @@
 <div id="matrix-header" class="matrix-header">
   <h4>Student Performance</h4>
-  <div>Current student achievements, comparing assignment grades and page views to the average in each bCourses class site.</div>
+  <div>Assignment grades plotted against number of days since the student last visited the bCourses course site.</div>
 </div>
 <div id="matrix-container" class="matrix-container">
   <!-- IMPORTANT: We use data-ng-show because d3 must populate the div before we reveal it to the user. -->
@@ -11,7 +11,7 @@
     <div class="cohort-missing-student-data-header">
       <div class="student-avatar-container"></div>
       <div class="cohort-student-bio-container"></div>
-      <div class="student-column">bCourses Page Views</div>
+      <div class="student-column">Days since student last visited bCourses course site</div>
       <div class="student-column"
            data-ng-bind="yAxisMeasure==='analytics.courseCurrentScore' ? 'Assignment Grades' : 'Online Assignments on Time'"></div>
     </div>
@@ -44,7 +44,7 @@
           </div>
         </div>
         <div class="student-column">
-          <span data-ng-bind-template="{{student.analytics.pageViews.displayPercentile}} percentile" data-ng-if="student.analytics.pageViews"></span>
+          <span data-ng-bind-template="{{student.analytics.daysSinceCourseSiteVisited.displayPercentile}} percentile" data-ng-if="student.analytics.daysSinceCourseSiteVisited"></span>
         </div>
         <div class="student-column" data-ng-if="yAxisMeasure==='analytics.courseCurrentScore'">
           <span data-ng-bind-template="{{student.analytics.courseCurrentScore.displayPercentile}} percentile" data-ng-if="student.analytics.courseCurrentScore"></span>

--- a/boac/static/app/student/student.html
+++ b/boac/static/app/student/student.html
@@ -312,19 +312,11 @@
                     </tr>
                     <tr>
                       <td class="visualize-metrics-legend">
-                        Page Views
+                        Last bCourses Activity
                       </td>
-                      <td>
-                        <span data-ng-if="canvasSite.analytics.pageViews.displayPercentile">
-                          <strong data-ng-bind="canvasSite.analytics.pageViews.displayPercentile"></strong> percentile
-                        </span>
-                        <span data-ng-if="!canvasSite.analytics.pageViews.displayPercentile">
-                          No Page Views
-                        </span>
-                      </td>
-                      <td class="profile-boxplot-container">
-                        <boxplot-draw class="profile-boxplot"
-                                      data-dataset="canvasSite.analytics.pageViews"></boxplot-draw>
+                      <td colspan="2">
+                        <span data-ng-bind="student.sisProfile.preferredName"></span> last visited the course site 17 days ago.
+                        75 out of 78 enrolled students have done so more recently.
                       </td>
                     </tr>
                   </table>

--- a/boac/static/app/visual/visualizationService.js
+++ b/boac/static/app/visual/visualizationService.js
@@ -146,7 +146,7 @@
     var drawScatterplot = function(students, yAxisMeasure, goToUserPage) {
       var svg;
 
-      function x(d) { return d.analytics.pageViews.percentile; }
+      function x(d) { return d.analytics.daysSinceCourseSiteVisited.percentile; }
       function y(d) { return _.get(d, yAxisMeasure).percentile; }
       function key(d) { return d.uid; }
 
@@ -312,7 +312,7 @@
         .attr('text-anchor', 'start')
         .attr('x', 0)
         .attr('y', height + 30)
-        .text('bCourses page views');
+        .text('Days since bCourses course site viewed');
 
       // Add a y-axis label.
       svg.append('text')
@@ -358,9 +358,9 @@
           .attr('class', config.demoMode ? 'demo-mode-blur' : 'matrix-tooltip-header')
           .text(fullName);
         var table = tooltip.append('table').attr('class', 'matrix-tooltip-table');
-        var pageViewsRow = table.append('tr');
-        pageViewsRow.append('td').attr('class', 'matrix-tooltip-label').text('bCourses page views');
-        pageViewsRow.append('td').attr('class', 'matrix-tooltip-value').text(displayValue(d, 'analytics.pageViews'));
+        var daysSinceRow = table.append('tr');
+        daysSinceRow.append('td').attr('class', 'matrix-tooltip-label').text('Days since bCourses course site viewed');
+        daysSinceRow.append('td').attr('class', 'matrix-tooltip-value').text(displayValue(d, 'analytics.daysSinceCourseSiteVisited'));
         var yAxisRow = table.append('tr');
         yAxisRow.append('td').text(yAxisName);
         yAxisRow.append('td').attr('class', 'matrix-tooltip-value').text(displayValue(d, yAxisMeasure));
@@ -401,7 +401,7 @@
       // Plot the cohort
       var yAxisMeasure = $location.search().yAxis || 'analytics.courseCurrentScore';
       var partitions = _.partition(students, function(student) {
-        return _.isFinite(_.get(student, 'analytics.pageViews.percentile')) && _.isFinite(_.get(student, yAxisMeasure + '.percentile'));
+        return _.isFinite(_.get(student, 'analytics.daysSinceCourseSiteVisited.percentile')) && _.isFinite(_.get(student, yAxisMeasure + '.percentile'));
       });
       // Pass along a subset of students that have useful data.
       drawScatterplot(partitions[0], yAxisMeasure, goToUserPage);

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -179,7 +179,7 @@ class TestCohortDetail:
         assert term['enrollments'][0]['displayName'] == 'BURMESE 1A'
         assert len(term['enrollments'][0]['canvasSites']) == 1
         analytics = athlete['analytics']
-        for metric in ['assignmentsOnTime', 'pageViews', 'courseCurrentScore']:
+        for metric in ['assignmentsOnTime', 'daysSinceCourseSiteVisited', 'courseCurrentScore']:
             assert analytics[metric]['percentile'] > 0
             assert analytics[metric]['displayPercentile'].endswith(('rd', 'st', 'th'))
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -254,15 +254,15 @@ class TestUserAnalytics:
 
         assert analytics['courseCurrentScore']['student']['raw'] == 84
 
-        assert analytics['pageViews']['student']['raw'] == 768
-        assert analytics['pageViews']['student']['percentile'] == 54
-        assert analytics['pageViews']['courseDeciles'][0] == 9
-        assert analytics['pageViews']['courseDeciles'][9] == 917
-        assert analytics['pageViews']['courseDeciles'][10] == 31983
+        assert analytics['daysSinceCourseSiteVisited']['student']['raw'] == 768
+        assert analytics['daysSinceCourseSiteVisited']['student']['percentile'] == 54
+        assert analytics['daysSinceCourseSiteVisited']['courseDeciles'][0] == 9
+        assert analytics['daysSinceCourseSiteVisited']['courseDeciles'][9] == 917
+        assert analytics['daysSinceCourseSiteVisited']['courseDeciles'][10] == 31983
 
         assert analytics['loch']['assignmentsOnTime']['student']['raw'] == 7
         assert analytics['loch']['assignmentsSubmitted']['student']['raw'] == 8
-        assert analytics['loch']['pageViews']['student']['raw'] == 766
+        assert analytics['loch']['daysSinceCourseSiteVisited']['student']['raw'] == 766
 
     def test_empty_canvas_course_feed(self, client, fake_auth):
         """Returns 200 if user is found and Canvas course feed is empty."""

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -119,7 +119,7 @@ class TestAnalyticsFromSummaryFeed:
         best = analytics.analytics_from_summary_feed(summary_feed, self.canvas_user_id, self.canvas_course_id)
         median = analytics.analytics_from_summary_feed(summary_feed, '101', self.canvas_course_id)
         for digested in [worst, best, median]:
-            for column in ['assignmentsOnTime', 'pageViews']:
+            for column in ['assignmentsOnTime', 'daysSinceCourseSiteVisited']:
                 assert digested[column]['boxPlottable'] is False
                 assert digested[column]['student']['percentile'] is not None
 
@@ -158,7 +158,7 @@ class TestAnalyticsFromSummaryFeed:
             },
         ]
         digested = analytics.analytics_from_summary_feed(summary_feed, self.canvas_user_id, self.canvas_course_id)
-        for column in ['assignmentsOnTime', 'pageViews']:
+        for column in ['assignmentsOnTime', 'daysSinceCourseSiteVisited']:
             assert digested[column]['boxPlottable'] is False
             assert digested[column]['displayPercentile'] is None
             assert digested[column]['student']['percentile'] is None
@@ -229,8 +229,8 @@ class TestAnalyticsFromSummaryFeed:
         assert digested['assignmentsOnTime']['displayPercentile'] == '0th'
         assert digested['assignmentsOnTime']['student']['raw'] == 0
         assert digested['assignmentsOnTime']['courseDeciles'][10] == 16
-        assert digested['pageViews']['displayPercentile'] == '0th'
-        assert digested['pageViews']['boxPlottable'] is True
+        assert digested['daysSinceCourseSiteVisited']['displayPercentile'] == '0th'
+        assert digested['daysSinceCourseSiteVisited']['boxPlottable'] is True
 
 
 class TestAnalyticsFromLochAssignmentsOnTime:
@@ -320,7 +320,7 @@ class TestAnalyticsFromLochCurrentScores:
         assert digested['courseDeciles'] is None
 
 
-class TestAnalyticsFromLochPageViews:
+class TestAnalyticsFromLochDaysSinceCourseSiteVisited:
     uid = '61889'
     canvas_course_id = 7654321
     term_id = '2178'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-793

I expect we'll revisit the matrix view design. Next step: plug in real "days since" data. 