### PR TITLE
BOAC-906 Fixes for cache management

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -230,7 +230,7 @@ def load_term(term_id=berkeley.current_term_id()):
         s, f = load_canvas_externals(uid, term_id)
         success_count += s
         failures += f
-        s, f = load_sis_externals(term_id, csid)
+        s, f = load_sis_externals(uid, csid, term_id)
         success_count += s
         failures += f
         nbr_finished += 1
@@ -283,8 +283,8 @@ def load_canvas_externals(uid, term_id):
     return success_count, failures
 
 
-def load_sis_externals(term_id, csid):
-    from boac.externals import sis_degree_progress_api, sis_enrollments_api, sis_student_api
+def load_sis_externals(uid, csid, term_id):
+    from boac.externals import sis_degree_progress_api, sis_student_api
     from boac.merged.sis_enrollments import merge_enrollment
 
     term_name = berkeley.term_name_for_sis_id(term_id)
@@ -305,13 +305,13 @@ def load_sis_externals(term_id, csid):
     else:
         failures.append(f'SIS get_student failed for CSID {csid}')
 
-    enrollments = sis_enrollments_api.get_enrollments(csid, term_id)
+    enrollments = data_loch.get_sis_enrollments(uid, term_id) or []
     if enrollments:
         # Perform higher-level enrollments feed processing; update NormalizedCacheEnrollment.
         merge_enrollment(csid, enrollments, term_id, term_name)
         success_count += 1
     elif enrollments is None:
-        failures.append(f'SIS get_enrollments failed for CSID {csid}, term_id {term_id}')
+        failures.append(f'get_sis_enrollments failed for CSID {csid}, term_id {term_id}')
     return success_count, failures
 
 

--- a/boac/merged/sis_enrollments.py
+++ b/boac/merged/sis_enrollments.py
@@ -95,6 +95,7 @@ def merge_drops_and_midterms(cs_id, term_name, term_feed):
 @stow('merged_enrollment_{cs_id}', for_term=True)
 def merge_enrollment(cs_id, enrollments, term_id, term_name):
     enrollments_by_class = {}
+    enrollments_for_normalized_cache = []
     term_section_ids = {}
     enrolled_units = 0
     for enrollment in enrollments:
@@ -104,6 +105,8 @@ def merge_enrollment(cs_id, enrollments, term_id, term_name):
             continue
 
         term_section_ids[section_id] = True
+        if enrollment['sis_enrollment_status'] in ['E', 'W']:
+            enrollments_for_normalized_cache.append(enrollment)
         section_feed = {
             'ccn': enrollment['sis_section_id'],
             'component': enrollment['sis_instruction_format'],
@@ -139,7 +142,7 @@ def merge_enrollment(cs_id, enrollments, term_id, term_name):
     enrollments_feed = sorted(enrollments_by_class.values(), key=lambda x: x['displayName'])
     sort_sections(enrollments_feed)
     # Cache course and enrollment info
-    NormalizedCacheEnrollment.update_enrollments(term_id=term_id, sid=cs_id, enrollments=enrollments)
+    NormalizedCacheEnrollment.update_enrollments(term_id=term_id, sid=cs_id, enrollments=enrollments_for_normalized_cache)
     term_feed = {
         'termId': term_id,
         'termName': term_name,

--- a/boac/models/normalized_cache_enrollment.py
+++ b/boac/models/normalized_cache_enrollment.py
@@ -58,9 +58,8 @@ class NormalizedCacheEnrollment(Base):
         std_commit()
         # Add fresh enrollment data
         for enrollment in enrollments:
-            if enrollment['sis_enrollment_status'] in ['E', 'W']:
-                normalized = cls(term_id=term_id, section_id=int(enrollment['sis_section_id']), sid=sid)
-                db.session.add(normalized)
+            normalized = cls(term_id=term_id, section_id=int(enrollment['sis_section_id']), sid=sid)
+            db.session.add(normalized)
         std_commit()
 
     @classmethod


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-906

Clean up some garbage from https://github.com/ets-berkeley-edu/boac/pull/655 .

* Obsolete call from cache_utils.
* Missed section de-duplication on the way to NormalizedCacheEnrollment.