### PR TITLE
BOAC-903, lock down bower dependencies (angular, bootstrap)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,15 @@
 {
   "name": "boac",
   "dependencies": {
-    "angular": "^1.6.9",
-    "angular-animate": "^1.6.9",
-    "angular-base64": "^2.0.5",
-    "angular-bootstrap": "^2.5.0",
-    "angular-ui-router": "^1.0.15",
-    "bootstrap": "^3.3.7",
+    "angular": "1.6.10",
+    "angular-animate": "1.6.10",
+    "angular-base64": "2.0.5",
+    "angular-bootstrap": "2.5.0",
+    "angular-ui-router": "1.0.18",
+    "bootstrap": "3.3.7",
     "d3": "4.12.0",
-    "fontawesome": "5.0.10",
+    "fontawesome": "5.0.13",
     "highcharts-release": "6.0.7",
-    "lodash": "^4.17.5"
+    "lodash": "4.17.10"
   }
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-903

Angular seems to have a bug in 1.7.0; related to https://github.com/angular/angular/issues/9275? I'm locking us down at 1.6.10. I believe the other minor upgrades (eg, lodash) are safe.