### PR TITLE
BOAC-917, skip pandas.DataFrame if DataLoch has no such enrollment

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -93,6 +93,9 @@ def loch_student_analytics(canvas_user_id, canvas_course_id, term_id):
     if enrollments is None:
         _error = {'error': 'Unable to retrieve from Data Loch'}
         return {'currentScore': _error, 'lastActivity': _error}
+    if not next((e for e in enrollments if e.get('canvas_user_id') == canvas_user_id), None):
+        _error = {'error': f'According to Data Loch, Canvas user {canvas_user_id} is not enrolled in {canvas_course_id}'}
+        return {'currentScore': _error, 'lastActivity': _error}
     df = pandas.DataFrame(enrollments, columns=['canvas_user_id', 'current_score', 'last_activity_at'])
     student_row = df.loc[df['canvas_user_id'].values == int(canvas_user_id)]
     if enrollments and student_row.empty:

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -136,10 +136,10 @@ class TestAnalyticsFromLochAnalytics:
         with register_mock(data_loch._get_canvas_course_scores, mr):
             digested = analytics.loch_student_analytics(self.canvas_user_id, self.canvas_course_id, self.term_id)
         score = digested['currentScore']
-        assert score['student']['raw'] is None
-        assert score['student']['percentile'] is None
-        assert score['boxPlottable'] is False
-        assert score['courseDeciles'] is None
+        assert 'student' not in score
+        assert 'boxPlottable' not in score
+        assert 'courseDeciles' not in score
+        assert f'{self.canvas_user_id} is not enrolled' in score['error']
 
 
 class TestAnalyticsFromLochLastActivity:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-917

BOAC should not analyze bad/missing data. For the record, user described in BOAC-917 is, in fact, a member of course 1471428. Why no entry in `boac_analytics.course_enrollments` (nessie_qa)? Student was added recently, perhaps. Investigation to follow.