### PR TITLE
BOAC-917 Null last_activity_at should be falsey

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -99,8 +99,8 @@ def loch_student_analytics(canvas_user_id, canvas_course_id, term_id):
         app.logger.warn(f'Canvas user {canvas_user_id} not found in Data Loch for course site {canvas_course_id}')
         student_row = pandas.DataFrame({
             'canvas_user_id': [int(canvas_user_id)],
-            'current_score': [0],
-            'last_activity_at': [1],
+            'current_score': [None],
+            'last_activity_at': [None],
         })
         df = df.append(student_row, ignore_index=True)
         # Fetch newly appended row, mostly for the sake of its properly set-up index.

--- a/tests/test_lib/test_analytics.py
+++ b/tests/test_lib/test_analytics.py
@@ -132,7 +132,9 @@ class TestAnalyticsFromLochAnalytics:
         assert digested == {'currentScore': _error, 'lastActivity': _error}
 
     def test_when_no_data(self, app):
-        mr = MockRows(io.StringIO('canvas_user_id,course_scores'))
+        exclusive_rows = 'canvas_user_id,course_scores,last_activity_at,sis_enrollment_status\n' \
+            '1,1,1,E'
+        mr = MockRows(io.StringIO(exclusive_rows))
         with register_mock(data_loch._get_canvas_course_scores, mr):
             digested = analytics.loch_student_analytics(self.canvas_user_id, self.canvas_course_id, self.term_id)
         score = digested['currentScore']
@@ -140,6 +142,9 @@ class TestAnalyticsFromLochAnalytics:
         assert score['student']['percentile'] is None
         assert score['boxPlottable'] is False
         assert score['courseDeciles'] is None
+        last_activity = digested['lastActivity']
+        assert last_activity['student']['raw'] is 0
+        assert 'daysSinceLastActivity' not in last_activity['student']
 
 
 class TestAnalyticsFromLochLastActivity:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-917

An incomplete test gave us too much confidence in that reasonable-looking code.