### PR TITLE
BOAC-943 Disentangle external cache load from application-specific table updates

### DIFF
--- a/boac/merged/sis_profile.py
+++ b/boac/merged/sis_profile.py
@@ -30,8 +30,6 @@ from boac.externals import sis_student_api
 from boac.lib.berkeley import degree_program_url_for_major, term_name_for_sis_id
 from boac.lib.util import vacuum_whitespace
 from boac.models.json_cache import stow
-from boac.models.normalized_cache_student import NormalizedCacheStudent
-from boac.models.normalized_cache_student_major import NormalizedCacheStudentMajor
 from flask import current_app as app
 
 
@@ -57,8 +55,6 @@ def merge_sis_profile(csid):
     merge_sis_profile_phones(sis_response, sis_profile)
     if sis_profile['academicCareer'] == 'UGRD':
         sis_profile['degreeProgress'] = sis_degree_progress_api.parsed_degree_progress(csid)
-
-    store_normalized_profile(csid, sis_profile)
 
     return sis_profile
 
@@ -149,13 +145,3 @@ def merge_sis_profile_plans(academic_status, sis_profile):
             program = student_plan.get('academicPlan', {}).get('academicProgram', {}).get('program', {})
             plan_feed['program'] = program.get('description')
         sis_profile['plans'].append(plan_feed)
-
-
-def store_normalized_profile(csid, sis_profile):
-    gpa = sis_profile.get('cumulativeGPA')
-    level = sis_profile.get('level', {}).get('description')
-    units = sis_profile.get('cumulativeUnits')
-    NormalizedCacheStudent.update_profile(csid, gpa=gpa, level=level, units=units)
-
-    majors = [plan['description'] for plan in sis_profile.get('plans', [])]
-    NormalizedCacheStudentMajor.update_majors(csid, majors)

--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -122,6 +122,16 @@ def stow(key_pattern, for_term=False):
     return _stow
 
 
+def fetch(key, term_id=None):
+    """Query the cache for a given key with optional term specification."""
+    if term_id:
+        term_name = term_name_for_sis_id(term_id)
+        key = f'term_{term_name}-{key}'
+    stowed = working_cache().query.filter_by(key=key).first()
+    if stowed is not None:
+        return stowed.json
+
+
 def insert_row(key, json):
     """Insert new cache row with conflict checks."""
     row = working_cache()(key=key, json=json)

--- a/boac/models/normalized_cache_student.py
+++ b/boac/models/normalized_cache_student.py
@@ -24,6 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 
+from decimal import Decimal
 from boac import db, std_commit
 from boac.models.base import Base
 
@@ -46,6 +47,9 @@ class NormalizedCacheStudent(Base):
 
     @classmethod
     def update_profile(cls, sid, gpa=None, level=None, units=None):
+        # Converting to string, then Decimal forces fixed-point rather than floating.
+        gpa = gpa and Decimal(str(gpa))
+        units = units and Decimal(str(units))
         row = cls.query.filter_by(sid=sid).first()
         if row:
             row.gpa = gpa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,8 +117,9 @@ def fake_auth(app, db, client):
 
 
 @pytest.fixture()
-def create_alerts(db_session):
-    """Create three canned alerts for the current term and one for the previous term."""
+def create_alerts(client, db_session):
+    """Create assignment and midterm grade alerts."""
+    # Create three canned alerts for the current term and one for the previous term.
     Alert.create(
         sid='11667051',
         alert_type='late_assignment',
@@ -143,6 +144,10 @@ def create_alerts(db_session):
         key='2178_100200300',
         message='Week 5 homework in BOSCRSR 27B is late.',
     )
+    # Load our usual student of interest into the cache and generate midterm alerts from fixture data.
+    client.get('/api/user/61889/analytics')
+    from boac.api.cache_utils import load_alerts
+    load_alerts(2178)
 
 
 def pytest_itemcollected(item):

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -1,0 +1,92 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from decimal import Decimal
+from boac.externals import sis_student_api
+from boac.lib.berkeley import current_term_id
+from boac.lib.mockingbird import MockResponse, register_mock
+from boac.merged.sis_enrollments import merge_sis_enrollments_for_term
+from boac.models import json_cache
+from boac.models.alert import Alert
+from boac.models.normalized_cache_student import NormalizedCacheStudent
+from boac.models.normalized_cache_student_major import NormalizedCacheStudentMajor
+import pytest
+
+
+@pytest.mark.usefixtures('db_session')
+class TestCacheUtils:
+    """Test cache utils."""
+
+    def test_populates_normalized_cache(self, app, db):
+        from boac.api.cache_utils import load_normalized_cache
+        load_normalized_cache(current_term_id())
+
+        brigitte = NormalizedCacheStudent.query.filter_by(sid='11667051').first()
+        assert brigitte.level == 'Junior'
+        assert brigitte.units == Decimal('101.3')
+        assert brigitte.gpa == Decimal('3.8')
+
+        student_major_rows = NormalizedCacheStudentMajor.query.filter_by(sid='11667051').all()
+        assert len(student_major_rows) == 2
+        majors = [row.major for row in student_major_rows]
+        assert 'English BA' in majors
+        assert 'Astrophysics BS' in majors
+
+    def test_updates_normalized_cache(self, app):
+        # Load default fixture data, clear the JSON cache.
+        from boac.api.cache_utils import load_normalized_cache
+        load_normalized_cache(current_term_id())
+        json_cache.clear('sis_student_api_11667051')
+        json_cache.clear('merged_sis_profile_11667051')
+
+        # Our student levels up and changes a major.
+        with open(app.config['BASE_DIR'] + '/fixtures/sis_student_api_11667051.json') as file:
+            modified_response_body = file.read().replace('Junior', 'Senior').replace('Astrophysics BS', 'Hungarian BA')
+            modified_response = MockResponse(200, {}, modified_response_body)
+            with register_mock(sis_student_api._get_student, modified_response):
+                # Without re-merging the SIS profile, reload the normalized cache.
+                load_normalized_cache(current_term_id())
+
+                # Updated fixture data is loaded.
+                brigitte = NormalizedCacheStudent.query.filter_by(sid='11667051').first()
+                assert brigitte.level == 'Senior'
+
+                student_major_rows = NormalizedCacheStudentMajor.query.filter_by(sid='11667051').all()
+                majors = [row.major for row in student_major_rows]
+                assert len(student_major_rows) == 2
+                assert 'English BA' in majors
+                assert 'Hungarian BA' in majors
+
+    def test_creates_alert_for_midterm_grade(self, app):
+        merge_sis_enrollments_for_term([], '61889', '11667051', app.config['CANVAS_CURRENT_ENROLLMENT_TERM'])
+        from boac.api.cache_utils import load_alerts
+        load_alerts(2178)
+        alerts = Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')['shown']
+        assert 1 == len(alerts)
+        assert 0 < alerts[0]['id']
+        assert 'midterm' == alerts[0]['alertType']
+        assert '2178_90100' == alerts[0]['key']
+        assert 'BURMESE 1A midterm grade of D+.' == alerts[0]['message']

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -64,10 +64,13 @@ class TestCohortDetail:
         assert defense_backs_all['totalStudentCount'] == 3
         assert defense_backs_inactive['totalStudentCount'] == 1
 
-    def test_my_cohorts_includes_students_with_alert_counts(self, create_alerts, authenticated_session, client):
+    def test_my_cohorts_includes_students_with_alert_counts(self, create_alerts, authenticated_session, client, db_session):
         # Pre-load students into cache for consistent alert data.
         client.get('/api/user/61889/analytics')
         client.get('/api/user/98765/analytics')
+        from boac.api.cache_utils import load_alerts
+        load_alerts(2178)
+
         cohorts = client.get('/api/cohorts/my').json
         assert len(cohorts[0]['alerts']) == 2
 

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from boac.externals.data_loch import get_sis_enrollments
 from boac.models.normalized_cache_enrollment import NormalizedCacheEnrollment
 import pytest
 
@@ -41,9 +40,8 @@ def authenticated_session(fake_auth):
 
 @pytest.fixture()
 def course_data_load(fake_auth):
-    sis_enrollments = get_sis_enrollments(student_uid, term_id)
     # Cache course data
-    NormalizedCacheEnrollment.update_enrollments(term_id=term_id, sid=student_sid, enrollments=sis_enrollments)
+    NormalizedCacheEnrollment.update_enrollments(term_id=term_id, uid=student_uid, sid=student_sid)
 
 
 class TestCourseController:

--- a/tests/test_api/test_student_groups_controller.py
+++ b/tests/test_api/test_student_groups_controller.py
@@ -75,7 +75,7 @@ class TestStudentGroupsController:
         assert response.status_code == 200
         assert response.json['students'] == []
 
-    def test_group_summary_excludes_students_without_alerts(self, create_alerts, authenticated_session, client):
+    def test_group_summary_excludes_students_without_alerts(self, authenticated_session, create_alerts, client, db_session):
         """When all groups are requested, returns only students with alerts."""
         groups = client.get('/api/groups/my').json
         assert groups[0]['studentCount'] == 4
@@ -87,7 +87,7 @@ class TestStudentGroupsController:
         groups = client.get('/api/groups/my').json
         assert groups[0]['students'][0]['alertCount'] == 2
 
-    def test_group_detail_includes_students_without_alerts(self, create_alerts, authenticated_session, client):
+    def test_group_detail_includes_students_without_alerts(self, authenticated_session, create_alerts, client):
         """When group detail is requested, returns all students."""
         groups = client.get('/api/groups/my').json
         group = client.get(f'/api/group/{groups[0]["id"]}').json
@@ -96,7 +96,7 @@ class TestStudentGroupsController:
         assert 'alertCount' not in group['students'][2]
         assert 'alertCount' not in group['students'][3]
 
-    def test_group_index_includes_summary(self, authenticated_session, client):
+    def test_group_index_includes_summary(self, authenticated_session, create_alerts, client):
         """Returns summary details but not full term and analytics data for group index."""
         groups = client.get('/api/groups/my').json
         students = groups[0]['students']

--- a/tests/test_merged/test_sis_enrollments.py
+++ b/tests/test_merged/test_sis_enrollments.py
@@ -27,14 +27,13 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from boac.api.util import canvas_courses_api_feed
 from boac.externals import data_loch
 from boac.merged.sis_enrollments import merge_sis_enrollments_for_term
-from boac.models.alert import Alert
 import pytest
 
 
 @pytest.mark.usefixtures('db_session')
 class TestMergedSisEnrollments:
 
-    def test_creates_alert_for_midterm_grade(self, app):
+    def test_merges_midterm_grades(self, app):
         feed = merge_sis_enrollments_for_term([], '61889', '11667051', app.config['CANVAS_CURRENT_ENROLLMENT_TERM'])
         assert '2178' == feed['termId']
         enrollments = feed['enrollments']
@@ -42,12 +41,6 @@ class TestMergedSisEnrollments:
         assert 'D+' == enrollments[0]['midtermGrade']
         assert 'BURMESE 1A' == enrollments[0]['displayName']
         assert 90100 == enrollments[0]['sections'][0]['ccn']
-        alerts = Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')['shown']
-        assert 1 == len(alerts)
-        assert 0 < alerts[0]['id']
-        assert 'midterm' == alerts[0]['alertType']
-        assert '2178_90100' == alerts[0]['key']
-        assert 'BURMESE 1A midterm grade of D+.' == alerts[0]['message']
 
     def test_includes_course_site_section_mappings(self, app):
         """Maps Canvas sites to SIS courses and sections."""

--- a/tests/test_merged/test_sis_profile.py
+++ b/tests/test_merged/test_sis_profile.py
@@ -24,59 +24,13 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 
-from decimal import Decimal
-from boac.externals import sis_student_api
-from boac.lib.mockingbird import MockResponse, register_mock
 from boac.merged.sis_profile import merge_sis_profile
-from boac.models import json_cache
-from boac.models.normalized_cache_student import NormalizedCacheStudent
-from boac.models.normalized_cache_student_major import NormalizedCacheStudentMajor
 import pytest
 
 
 @pytest.mark.usefixtures('db_session')
 class TestSisProfile:
     """Test SIS profile."""
-
-    def test_populates_normalized_cache(self, app):
-        """Populates the normalized cache."""
-        merge_sis_profile('11667051')
-
-        student_rows = NormalizedCacheStudent.query.all()
-        assert student_rows[-1].sid == '11667051'
-        assert student_rows[-1].level == 'Junior'
-        assert student_rows[-1].units == Decimal('101.3')
-        assert student_rows[-1].gpa == Decimal('3.8')
-
-        student_major_rows = NormalizedCacheStudentMajor.query.all()
-        majors = [row.major for row in student_major_rows]
-        assert 'English BA' in majors
-        assert 'Astrophysics BS' in majors
-
-    def test_updates_normalized_cache(self, app):
-        """Updates the normalized cache."""
-        # Load default fixture data, clear the JSON cache.
-        merge_sis_profile('11667051')
-        json_cache.clear('merged_sis_profile_11667051')
-        json_cache.clear('sis_student_api_11667051')
-
-        # Our student levels up and changes a major.
-        with open(app.config['BASE_DIR'] + '/fixtures/sis_student_api_11667051.json') as file:
-            modified_response_body = file.read().replace('Junior', 'Senior').replace('Astrophysics BS', 'Hungarian BA')
-            modified_response = MockResponse(200, {}, modified_response_body)
-            with register_mock(sis_student_api._get_student, modified_response):
-
-                # The normalized cache keeps pace.
-                merge_sis_profile('11667051')
-
-                student_rows = NormalizedCacheStudent.query.all()
-                assert student_rows[-1].sid == '11667051'
-                assert student_rows[-1].level == 'Senior'
-
-                student_major_rows = NormalizedCacheStudentMajor.query.all()
-                majors = [row.major for row in student_major_rows]
-                assert 'English BA' in majors
-                assert 'Hungarian BA' in majors
 
     def test_skips_concurrent_academic_status(self, app):
         """Skips concurrent academic status."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-943

A lot of files are touched here, but I hope the principle is clear enough: normalized cache load and alert load move up into `boac.api.cache_utils`, and tests come along for the ride.