### PR TITLE
NS-100 Move CalNet load up into cache_utils for easier relocation

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -31,6 +31,7 @@ from boac.api.util import canvas_courses_api_feed
 from boac.externals import data_loch
 from boac.lib import berkeley
 from boac.merged import import_asc_athletes
+from boac.merged.calnet import merge_student_calnet_data
 from boac.merged.sis_enrollments import merge_sis_enrollments_for_term
 from boac.merged.sis_profile import merge_sis_profile
 from boac.models import json_cache
@@ -229,6 +230,9 @@ def load_term(term_id=berkeley.current_term_id()):
 
     success_count = 0
     failures = []
+
+    # Load CalNet attributes from LDAP, including any missing UIDs.
+    merge_student_calnet_data()
 
     ids = get_all_student_ids()
     nbr_students = len(ids)

--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -23,9 +23,11 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
+from boac import db, std_commit
 from boac.externals import calnet
 from boac.models.json_cache import stow
+from boac.models.student import Student
+from flask import current_app as app
 
 
 @stow('calnet_user_for_uid_{uid}')
@@ -37,3 +39,41 @@ def get_calnet_user_for_uid(app, uid):
         'firstName': p and p['first_name'],
         'lastName': p and p['last_name'],
     }
+
+
+def update_student_attributes(students=None):
+    sid_map = {}
+    for student in students:
+        sid_map.setdefault(student.sid, []).append(student)
+    sids = list(sid_map.keys())
+
+    # Search LDAP.
+    all_attributes = calnet.client(app).search_csids(sids)
+    if len(sids) != len(all_attributes):
+        app.logger.warning(f'Looked for {len(sids)} SIDs but only found {len(all_attributes)}')
+
+    # Update db
+    for a in all_attributes:
+        # Since we searched LDAP by SID, we can be fairly sure that the results have SIDs.
+        sid = a['csid']
+        name_split = a['sortable_name'].split(',') if 'sortable_name' in a else ''
+        full_name = [name.strip() for name in reversed(name_split)]
+        for m in sid_map[sid]:
+            new_uid = a['uid']
+            if m.uid != new_uid:
+                app.logger.info(f'For SID {sid}, changing UID {m.uid} to {new_uid}')
+                m.uid = new_uid
+            new_first_name = full_name[0] if len(full_name) else ''
+            new_last_name = full_name[1] if len(full_name) > 1 else ''
+            if (m.first_name != new_first_name) or (m.last_name != new_last_name):
+                app.logger.info(f'For SID {sid}, changing name "{m.first_name} {m.last_name}" to "{new_first_name} {new_last_name}"')
+                m.first_name = new_first_name
+                m.last_name = new_last_name
+    return students
+
+
+def merge_student_calnet_data():
+    students = Student.query.all()
+    update_student_attributes(students)
+    app.logger.info(f'Modified {len(db.session.dirty)} student records from calnet')
+    std_commit()

--- a/boac/merged/import_asc_athletes.py
+++ b/boac/merged/import_asc_athletes.py
@@ -28,7 +28,7 @@ import csv
 
 from boac import db, std_commit
 from boac.externals import asc_athletes_api
-from boac.externals import calnet
+from boac.merged.calnet import merge_student_calnet_data
 from boac.models.athletics import Athletics
 from boac.models.student import Student
 from flask import current_app as app
@@ -158,7 +158,7 @@ def compare_tsvs(old_tsv='tmp/AscStudentsOrig.tsv', new_tsv='tmp/AscStudents.tsv
 def update_from_asc(asc_rows):
     status = merge_student_athletes(asc_rows)
     app.logger.info(f'{status}')
-    merge_in_calnet_data()
+    merge_student_calnet_data()
     return status
 
 
@@ -382,41 +382,3 @@ def unambiguous_group_name(asc_group_name, group_code):
         return f'{asc_group_name} - Other'
     else:
         return asc_group_name
-
-
-def merge_in_calnet_data():
-    students = Student.query.all()
-    update_student_attributes(students)
-    app.logger.info(f'Modified {len(db.session.dirty)} student records from calnet')
-    std_commit()
-
-
-def update_student_attributes(students=None):
-    sid_map = {}
-    for student in students:
-        sid_map.setdefault(student.sid, []).append(student)
-    sids = list(sid_map.keys())
-
-    # Search LDAP.
-    all_attributes = calnet.client(app).search_csids(sids)
-    if len(sids) != len(all_attributes):
-        app.logger.warning(f'Looked for {len(sids)} SIDs but only found {len(all_attributes)}')
-
-    # Update db
-    for a in all_attributes:
-        # Since we searched LDAP by SID, we can be fairly sure that the results have SIDs.
-        sid = a['csid']
-        name_split = a['sortable_name'].split(',') if 'sortable_name' in a else ''
-        full_name = [name.strip() for name in reversed(name_split)]
-        for m in sid_map[sid]:
-            new_uid = a['uid']
-            if m.uid != new_uid:
-                app.logger.info(f'For SID {sid}, changing UID {m.uid} to {new_uid}')
-                m.uid = new_uid
-            new_first_name = full_name[0] if len(full_name) else ''
-            new_last_name = full_name[1] if len(full_name) > 1 else ''
-            if (m.first_name != new_first_name) or (m.last_name != new_last_name):
-                app.logger.info(f'For SID {sid}, changing name "{m.first_name} {m.last_name}" to "{new_first_name} {new_last_name}"')
-                m.first_name = new_first_name
-                m.last_name = new_last_name
-    return students


### PR DESCRIPTION
Step one of https://jira.ets.berkeley.edu/jira/browse/NS-100

When the code first deploys, the CalNet merge will usually be redundant effort since it's also done in the Import ASC Students task. But because the entire long chain of student updates and refreshes will be refactored in this sprint, I don't expect it to stay redundant for long. If you prefer that I eliminate the duplication now, just let me know.