### PR TITLE
NS-87 Stow drops and midterms from SIS enrollments API

### DIFF
--- a/boac/externals/sis_enrollments_api.py
+++ b/boac/externals/sis_enrollments_api.py
@@ -28,9 +28,11 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from boac.lib import http
 from boac.lib.mockingbird import fixture
+from boac.models.json_cache import stow
 from flask import current_app as app
 
 
+@stow('sis_drops_and_midterms_{cs_id}', for_term=True)
 def get_drops_and_midterms(cs_id, term_id):
     """Obtain dropped classes and midterm deficient grades for the term."""
     response = get_enrollments(cs_id, term_id)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-87

Following #680, our cache load is looping through `sis_enrollments_api.drops_and_midterms` twice. First, explicitly, here:

https://github.com/ets-berkeley-edu/boac/blob/e5f0a1c2bf38b153211cf4cdfb594ce3a9ac71be/boac/api/cache_utils.py#L322

And second, as part of `merged.sis_enrollments.merge_sis_enrollments_for_term`:

https://github.com/ets-berkeley-edu/boac/blob/e5f0a1c2bf38b153211cf4cdfb594ce3a9ac71be/boac/api/cache_utils.py#L340

https://github.com/ets-berkeley-edu/boac/blob/e5f0a1c2bf38b153211cf4cdfb594ce3a9ac71be/boac/merged/sis_enrollments.py#L60

Since the merge is so complex overall and is going to get refactored anyway, probably the easiest thing for the moment is to add a `@stow` to prevent duplicate API calls.
