### PR TITLE
BOAC-987, coe_advisor_uid added to cohort_filter options; decorate in cf model moved to controller level

### DIFF
--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -46,6 +46,7 @@ def all_students():
 @login_required
 def get_students():
     params = request.get_json()
+    coe_advisor_uid = util.get(params, 'coeAdvisorUid')
     gpa_ranges = util.get(params, 'gpaRanges')
     group_codes = util.get(params, 'groupCodes')
     levels = util.get(params, 'levels')
@@ -60,6 +61,7 @@ def get_students():
     if not asc_authorized and (in_intensive_cohort is not None or is_inactive_asc is not None):
         raise ForbiddenRequestError('You are unauthorized to access student data managed by other departments')
     results = Student.get_students(
+        coe_advisor_uid=coe_advisor_uid,
         gpa_ranges=gpa_ranges,
         group_codes=group_codes,
         levels=levels,

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -26,6 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from boac.api import errors
 import boac.api.util as api_util
+from boac.api.util import decorate_cohort
 from boac.externals.cal1card_photo_api import get_cal1card_photo
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
@@ -60,8 +61,9 @@ def user_profile():
                     'isDirector': m.is_director,
                 },
             })
+        my_cohorts = CohortFilter.all_owned_by(uid)
         profile.update({
-            'myCohorts': CohortFilter.all_owned_by(uid, include_alerts=True),
+            'myCohorts': [decorate_cohort(c, include_alerts_for_uid=uid, include_students=False) for c in my_cohorts],
             'myGroups': groups,
             'isAdmin': current_user.is_admin,
             'departments': departments,

--- a/boac/models/student.py
+++ b/boac/models/student.py
@@ -25,7 +25,6 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 
 from boac import db, std_commit
-import boac.api.util as api_util
 from boac.lib import util
 from boac.models.base import Base
 from boac.models.db_relationships import student_athletes, student_group_members
@@ -115,17 +114,18 @@ class Student(Base):
     @classmethod
     def get_students(
             cls,
+            coe_advisor_uid=None,
             gpa_ranges=None,
             group_codes=None,
             in_intensive_cohort=None,
-            levels=None,
-            majors=None,
-            unit_ranges=None,
-            order_by=None,
-            offset=0,
-            limit=50,
-            sids_only=False,
             is_active_asc=None,
+            levels=None,
+            limit=50,
+            majors=None,
+            offset=0,
+            order_by=None,
+            sids_only=False,
+            unit_ranges=None,
     ):
         query_tables, query_filter, all_bindings = cls.get_students_query(
             group_codes=group_codes,
@@ -325,7 +325,16 @@ class Student(Base):
         return
 
     def to_api_json(self):
-        return api_util.student_to_json(self)
+        return {
+            'sid': self.sid,
+            'uid': self.uid,
+            'firstName': self.first_name,
+            'lastName': self.last_name,
+            'name': self.first_name + ' ' + self.last_name,
+            'inIntensiveCohort': self.in_intensive_cohort,
+            'isActiveAsc': self.is_active_asc,
+            'statusAsc': self.status_asc,
+        }
 
     def to_expanded_api_json(self):
         api_json = self.to_api_json()

--- a/tests/test_models/test_cohort_filter.py
+++ b/tests/test_models/test_cohort_filter.py
@@ -23,7 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
+import json
 from boac.api.errors import InternalServerError
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
@@ -42,8 +42,8 @@ class TestCohortFilter:
         group_codes = ['MSW', 'MSW-DV', 'MSW-SW']
         cohort = CohortFilter.create(uid='2040', label='Swimming, Men\'s', group_codes=group_codes)
         foosball_label = 'Foosball teams'
-        cohort = CohortFilter.update(cohort['id'], foosball_label)
-        assert cohort['label'] == foosball_label
+        cohort = CohortFilter.update(cohort.id, foosball_label)
+        assert cohort.label == foosball_label
 
     def test_filter_criteria(self):
         gpa_ranges = [
@@ -67,8 +67,9 @@ class TestCohortFilter:
             majors=majors,
             unit_ranges=unit_ranges,
         )
-        cohort = CohortFilter.find_by_id(cohort['id'])
+        cohort = CohortFilter.find_by_id(cohort.id)
         expected = {
+            'coeAdvisorUid': None,
             'gpaRanges': gpa_ranges,
             'groupCodes': group_codes,
             'inIntensiveCohort': None,
@@ -77,10 +78,10 @@ class TestCohortFilter:
             'majors': majors,
             'unitRanges': unit_ranges,
         }
-        cf = cohort['filterCriteria']
-        assert expected == cf
-        assert 2 == len(cf['gpaRanges'])
-        assert 2 == len(cf['unitRanges'])
+        filter_criteria = json.loads(cohort.filter_criteria)
+        assert expected == filter_criteria
+        assert 2 == len(filter_criteria['gpaRanges'])
+        assert 2 == len(filter_criteria['unitRanges'])
 
     def test_invalid_create(self):
         with pytest.raises(InternalServerError):
@@ -97,14 +98,14 @@ class TestCohortFilter:
         # Create and share cohort
         group_codes = ['MFB-DB', 'MFB-DL', 'MFB-MLB', 'MFB-OLB']
         cohort = CohortFilter.create(uid=owner, label='Football, Defense', group_codes=group_codes)
-        cohort = CohortFilter.share(cohort['id'], shared_with)
-        assert len(cohort['owners']) == 2
-        assert owner, shared_with in [user.uid for user in cohort['owners']]
+        cohort = CohortFilter.share(cohort.id, shared_with)
+        assert len(cohort.owners) == 2
+        assert owner, shared_with in [user.uid for user in cohort.owners]
 
         # Delete cohort and verify
         previous_owner_count = cohort_count(owner)
         previous_shared_count = cohort_count(shared_with)
-        CohortFilter.delete(cohort['id'])
+        CohortFilter.delete(cohort.id)
         assert cohort_count(owner) == previous_owner_count - 1
         assert cohort_count(shared_with) == previous_shared_count - 1
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-987

* Decoration in cohort_filter model puts undue work on simple operations (eg, delete) and tests. Ultimately, only controllers need students, alerts, etc. added to a cohort_filter instance.
* We will give COE advisors access to their students with read-only cohort_filters configured with criteria `coe_advisor_uid=12345`