### PR TITLE
BOAC-990, cohort defined by coeAdvisorUid alone is read-only

### DIFF
--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -112,23 +112,29 @@ def translate_grading_basis(code):
     return bases.get(code) or code
 
 
+def is_read_only_cohort(cohort):
+    criteria = cohort if isinstance(cohort.filter_criteria, dict) else json.loads(cohort.filter_criteria)
+    keys_with_not_none_value = [key for key, value in criteria.items() if value not in [None, []]]
+    return keys_with_not_none_value == ['coeAdvisorUid']
+
+
 def decorate_cohort(cohort, order_by=None, offset=0, limit=50, include_students=True, include_alerts_for_uid=None):
     decorated = {
         'id': cohort.id,
         'code': cohort.id,
+        'isReadOnly': is_read_only_cohort(cohort),
         'label': cohort.label,
         'name': cohort.label,
         'owners': [user.uid for user in cohort.owners],
     }
-    c = cohort if isinstance(cohort.filter_criteria, dict) else json.loads(cohort.filter_criteria)
-    gpa_ranges = util.get(c, 'gpaRanges', [])
-    # Property name 'team_group_codes' is deprecated; we prefer the camelCased 'groupCodes'.
-    group_codes = util.get(c, 'groupCodes', []) or util.get(c, 'team_group_codes', [])
-    levels = util.get(c, 'levels', [])
-    majors = util.get(c, 'majors', [])
-    unit_ranges = util.get(c, 'unitRanges', [])
-    in_intensive_cohort = util.to_bool_or_none(util.get(c, 'inIntensiveCohort'))
-    is_inactive_asc = util.get(c, 'isInactiveAsc')
+    criteria = cohort if isinstance(cohort.filter_criteria, dict) else json.loads(cohort.filter_criteria)
+    gpa_ranges = util.get(criteria, 'gpaRanges', [])
+    group_codes = util.get(criteria, 'groupCodes', [])
+    levels = util.get(criteria, 'levels', [])
+    majors = util.get(criteria, 'majors', [])
+    unit_ranges = util.get(criteria, 'unitRanges', [])
+    in_intensive_cohort = util.to_bool_or_none(util.get(criteria, 'inIntensiveCohort'))
+    is_inactive_asc = util.get(criteria, 'isInactiveAsc')
     results = Student.get_students(
         gpa_ranges=gpa_ranges,
         group_codes=group_codes,

--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -157,7 +157,7 @@ ACADEMIC_PLAN_TO_DEGREE_PROGRAM_PAGE = {
 
 BERKELEY_DEPT_NAME_TO_CODE = {
     'Athletic Study Center': 'UWASC',
-    'Electrical Engineering and Computer Science': 'EHEEC',
+    'College of Engineering': 'COENG',
 }
 
 

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -60,7 +60,7 @@ _test_users = [
 ]
 
 _users_per_dept = {
-    'EHEEC': [
+    'COENG': [
         {
             'uid': '1022796',
             'is_advisor': False,

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -256,6 +256,31 @@ class TestCohortDetail:
         f = cohort['filterCriteria']
         assert 'majors' in f and len(f['majors']) == 2
 
+    def test_read_only_cohort(self, client, fake_auth):
+        fake_auth.login('1022796')
+        data = {
+            'label': 'Students of Jane the COE Advisor',
+            'coeAdvisorUid': '1022796',
+            'groupCodes': [],
+            'majors': [],
+        }
+        response = client.post('/api/cohort/create', data=json.dumps(data), content_type='application/json')
+        assert response.status_code == 200
+        cohort = json.loads(response.data)
+        assert cohort['isReadOnly'] is True
+        cohort_id = cohort['id']
+        response = client.delete(f'/api/cohort/delete/{cohort_id}')
+        assert response.status_code == 403
+
+    def test_forbidden_cohort_creation(self, client, fake_auth):
+        fake_auth.login('1081940')
+        data = {
+            'label': 'John the ASC Advisor',
+            'coeAdvisorUid': '1022796',
+        }
+        response = client.post('/api/cohort/create', data=json.dumps(data), content_type='application/json')
+        assert response.status_code == 403
+
     def test_invalid_create_cohort_params(self, authenticated_session, client):
         bad_range_syntax = 'numrange(2, BLARGH, \'[)\')'
         data = {

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -59,16 +59,16 @@ class TestUserProfile:
         assert not len(user['departments'])
 
     def test_department_beyond_asc(self, client, fake_auth):
-        """Returns EHEEC director."""
+        """Returns COENG director."""
         fake_auth.login('1022796')
         response = client.get('/api/profile')
         assert response.status_code == 200
         user = response.json
         assert user['isAdmin'] is False
         assert len(user['departments']) == 1
-        assert 'EHEEC' in user['departments']
-        assert user['departments']['EHEEC']['isAdvisor'] is False
-        assert user['departments']['EHEEC']['isDirector'] is True
+        assert 'COENG' in user['departments']
+        assert user['departments']['COENG']['isAdvisor'] is False
+        assert user['departments']['COENG']['isDirector'] is True
 
     def test_athletic_study_center_user(self, client, fake_auth):
         """Returns Athletic Study Center advisor."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-986

And, only COE advisors can leverage the `coeAdvisorUid` criteria.