### PR TITLE
BOAC-1014, default student sort order is last_name, first_name

### DIFF
--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -194,7 +194,7 @@ def sis_enrollment_section_feed(enrollment):
 
 
 def sort_students_by_name(students):
-    return sorted(students, key=lambda s: (s['firstName'], s['lastName']))
+    return sorted(students, key=lambda s: (s['lastName'], s['firstName']))
 
 
 def strip_analytics(student_term_data):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1014

This impacts student lists on both class and group pages.