### PR TITLE
BOAC-1053, inactive checkbox must use data-ng-checked pattern (missed in previous PR)

### DIFF
--- a/boac/static/app/cohort/cohort.html
+++ b/boac/static/app/cohort/cohort.html
@@ -48,7 +48,7 @@
         <input id="intensive-checkbox"
                type="checkbox"
                data-ng-click="search.checkboxes.intensive.checked = !search.checkboxes.intensive.checked"
-               data-ng-model="search.checkboxes.intensive.checked"/>
+               data-ng-checked="search.checkboxes.intensive.checked"/>
         <label class="cohort-checkbox-label"
                for="intensive-checkbox"
                data-ng-bind="search.checkboxes.intensive.label"></label>
@@ -59,7 +59,7 @@
                type="checkbox"
                data-ng-disabled="!search.checkboxes.inactive.show"
                data-ng-click="search.checkboxes.inactive.checked = !search.checkboxes.inactive.checked"
-               data-ng-model="search.checkboxes.inactive.checked"/>
+               data-ng-checked="search.checkboxes.inactive.checked"/>
         <label class="cohort-checkbox-label"
                for="inactive-checkbox"
                data-ng-if="search.checkboxes.inactive.show"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1053

`data-ng-checked` replaces `data-ng-model` in this new checkbox pattern.