### PR TITLE
BOAC-1058, /api/team_groups/all returns empty list for unauthorized users

### DIFF
--- a/boac/api/athletics_controller.py
+++ b/boac/api/athletics_controller.py
@@ -55,9 +55,9 @@ def get_team(code):
 @app.route('/api/team_groups/all')
 @login_required
 def get_all_team_groups():
-    if not authorized():
-        raise ResourceNotFoundError('Unknown path')
-    return tolerant_jsonify(athletics.all_team_groups())
+    # TODO: Give unauthorized user a 404 without disrupting COE advisors on the filtered-cohort view.
+    data = athletics.all_team_groups() if authorized() else []
+    return tolerant_jsonify(data)
 
 
 @app.route('/api/teams/all')

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -64,6 +64,12 @@ class TestAthletics:
         response = client.get('/api/teams/all')
         assert response.status_code == 404
 
+    def test_team_groups_not_authorized(self, client, coe_advisor):
+        """Returns 404 if not authorized."""
+        response = client.get('/api/team_groups/all')
+        assert response.status_code == 200
+        assert not response.json
+
     def test_get_all_team_groups(self, asc_advisor, client):
         """Returns all team-groups if authenticated."""
         response = client.get('/api/team_groups/all')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1058

The one and only call to the `/api/team_groups/all` feed is baked into the `cohortController.js` logic. Although team data does not surface to COE advisors, they are being impacted by the 404. The safest fix, given our release schedule, is to return an empty list to unauthorized users and keep the response.status at 200.