### PR TITLE
BOAC-1063, logic of is_active_asc filter must rely on cohort owner, not current_user

### DIFF
--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -239,7 +239,7 @@ def is_authorized_to_use_boac(user):
 
 
 def get_dept_codes(user):
-    return [m.university_dept.dept_code for m in user.department_memberships]
+    return [m.university_dept.dept_code for m in user.department_memberships] if user else None
 
 
 def can_view_cohort(user, cohort):

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 
 from boac import db, std_commit
+from boac.api.util import create_my_students_cohort
 from boac.lib.berkeley import BERKELEY_DEPT_NAME_TO_CODE
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
@@ -164,12 +165,15 @@ def create_filtered_cohorts():
     CohortFilter.create(uid='2040', label='Football, Defense', group_codes=['MFB-DB', 'MFB-DL'])
     CohortFilter.create(uid='2040', label='Field Hockey', group_codes=['WFH'])
     # Flint's cohorts
-    CohortFilter.create(uid='1081940', label='Defense Backs, Inactive', group_codes=['MFB-DB'], is_inactive_asc=True)
-    CohortFilter.create(uid='1081940', label='Defense Backs, Active', group_codes=['MFB-DB'], is_inactive_asc=False)
-    CohortFilter.create(uid='1081940', label='Defense Backs, All', group_codes=['MFB-DB'])
-    CohortFilter.create(uid='1081940', label='Undeclared students', majors=['Undeclared'], is_inactive_asc=False)
-    CohortFilter.create(uid='1081940', label='All sports', group_codes=['MFB-DL', 'WFH'], is_inactive_asc=False)
+    asc_advisor_uid = '1081940'
+    CohortFilter.create(uid=asc_advisor_uid, label='Defense Backs, Inactive', group_codes=['MFB-DB'], is_inactive_asc=True)
+    CohortFilter.create(uid=asc_advisor_uid, label='Defense Backs, Active', group_codes=['MFB-DB'], is_inactive_asc=False)
+    CohortFilter.create(uid=asc_advisor_uid, label='Defense Backs, All', group_codes=['MFB-DB'])
+    CohortFilter.create(uid=asc_advisor_uid, label='Undeclared students', majors=['Undeclared'], is_inactive_asc=False)
+    CohortFilter.create(uid=asc_advisor_uid, label='All sports', group_codes=['MFB-DL', 'WFH'], is_inactive_asc=False)
     # Sandeep's cohorts
+    coe_advisor_uid = '1133399'
+    create_my_students_cohort(coe_advisor_uid, 'Sandeep')
     CohortFilter.create(uid='1133399', label='Radioactive Women and Men', majors=['Nuclear Engineering BS'])
     std_commit(allow_test_environment=True)
 

--- a/tests/test_api/test_api_util.py
+++ b/tests/test_api/test_api_util.py
@@ -1,0 +1,45 @@
+"""
+Copyright ©2018. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from boac.api import util as api_util
+from boac.models.authorized_user import AuthorizedUser
+
+
+coe_advisor_uid = '1133399'
+
+
+class TestUtil:
+    """Generic API utilities."""
+
+    def test_cohort_decoration_outside_request_context(self):
+        """Personalize the cohort name."""
+        cohort_filters = AuthorizedUser.find_by_uid(coe_advisor_uid).cohort_filters
+        assert len(cohort_filters)
+        canned_cohort = next((c for c in cohort_filters if api_util.is_read_only_cohort(c)), None)
+        assert canned_cohort
+        decorated_cohort = api_util.decorate_cohort(canned_cohort)
+        assert decorated_cohort['name'] == 'Sandeep\'s Students'
+        assert decorated_cohort['isReadOnly'] is True

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -175,11 +175,11 @@ class TestUserAnalytics:
     unknown = api_path.format(unknown_uid)
 
     @pytest.fixture()
-    def non_asc_advisor(self, fake_auth):
+    def coe_advisor(self, fake_auth):
         fake_auth.login('1133399')
 
     @pytest.fixture()
-    def authenticated_response(self, non_asc_advisor, client):
+    def authenticated_response(self, coe_advisor, client):
         return client.get(TestUserAnalytics.deborah)
 
     @pytest.fixture()
@@ -323,18 +323,18 @@ class TestUserAnalytics:
         assert analytics['lastActivity']['student']['percentile'] == 93
         assert analytics['lastActivity']['displayPercentile'] == '90th'
 
-    def test_student_not_found(self, non_asc_advisor, client):
+    def test_student_not_found(self, coe_advisor, client):
         """Returns 404 if no viewable student."""
         response = client.get(TestUserAnalytics.unknown)
         assert response.status_code == 404
         assert response.json['message'] == 'Unknown student'
 
-    def test_user_analytics_not_department_authorized(self, non_asc_advisor, client):
+    def test_user_analytics_not_department_authorized(self, coe_advisor, client):
         """Returns 404 if attempting to view a user outside one's own department."""
         response = client.get(TestUserAnalytics.dave)
         assert response.status_code == 404
 
-    def test_relevant_majors(self, non_asc_advisor, client):
+    def test_relevant_majors(self, coe_advisor, client):
         """Returns list of majors relevant to our student population."""
         response = client.get('/api/majors/relevant')
         assert response.status_code == 200

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -98,7 +98,8 @@ class TestBerkeleyAuthorization:
         assert berkeley.is_authorized_to_use_boac(asc_advisor)
 
     def test_zero_dept_codes(self, admin_user, unauthorized_user):
-        assert not berkeley.get_dept_codes(admin_user)
+        assert berkeley.get_dept_codes(None) is None
+        assert berkeley.get_dept_codes(admin_user) == []
         assert not berkeley.get_dept_codes(unauthorized_user)
 
     def test_asc_dept_codes(self, asc_advisor, coe_advisor):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1063

Two problems:
* `cache_utils` are invoking `api_utils`, which might very likely have a `current_user` dependency. I'll create a separate non-urgent Jira to fix. 
* How `cohort.is_active_asc` translates to SQL should depend on cohort owner and _not_ the current_user viewing the cohort 