### PR TITLE
[release] BOAC-1065, 00_ami.config gets new security-group setting for custom VPC

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -51,8 +51,8 @@ option_settings:
 
   # Load Balancer security group
   aws:elbv2:loadbalancer:
-    SecurityGroups: [sg-62a3211d]
-    ManagedSecurityGroup: sg-62a3211d
+    SecurityGroups: [sg-d298dcac]
+    ManagedSecurityGroup: sg-d298dcac
 
   aws:elasticbeanstalk:command:
     DeploymentPolicy: Immutable


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1065

Expect it to match what is on `master` and `qa`: (https://github.com/ets-berkeley-edu/boac/blob/qa/.ebextensions/00_ami.config)