### PR TITLE
BOAC-1087, new SSL cert for boac.berkeley.edu

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -47,7 +47,7 @@ option_settings:
   aws:elbv2:listener:443:
     ListenerEnabled: 'true'
     Protocol: HTTPS
-    SSLCertificateArns: arn:aws:acm:us-west-2:697877139013:certificate/f03f2099-26e6-4a71-abdb-b63dfa848f7c
+    SSLCertificateArns: arn:aws:acm:us-west-2:697877139013:certificate/f81da03d-f9c9-40f2-ad99-521e051203f7
 
   # Load Balancer security group
   aws:elbv2:loadbalancer:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1087

`arn` grabbed from https://jira.ets.berkeley.edu/jira/browse/BOAC-1083
