### PR TITLE
[QA] BOAC-1147, shell script wraps create_my_students_cohort_per_uid.py script

### DIFF
--- a/scripts/db/migrate/20180809-BOAC-1147/create_my_students_cohort_per_uid.sh
+++ b/scripts/db/migrate/20180809-BOAC-1147/create_my_students_cohort_per_uid.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# -------------------------------------------------------------------
+#
+# Script must be run with sudo
+#
+# -------------------------------------------------------------------
+
+# Abort immediately if a command fails
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Sorry, you must use 'sudo' to run this script."; echo
+  exit 1
+fi
+
+# Load env variables
+[ -e /opt/python/current/env ] && source /opt/python/current/env && env
+
+# Run Python script
+advisor_uid=${1}
+advisor_first_name="${2}"
+
+cd /opt/python/current/app
+python3 scripts/db/migrate/20180809-BOAC-1147/create_my_students_cohort_per_uid.py "${advisor_uid}" "${advisor_first_name}"
+
+echo 'Done.'
+
+exit 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1147

Shell script invokes the mandatory `source /opt/python/current/env && env`