### PR TITLE
BOAC-1149, legacy select-majors-filter belongs in legacy controller

### DIFF
--- a/boac/static/app/cohort/_filtered/filterCriteriaService.js
+++ b/boac/static/app/cohort/_filtered/filterCriteriaService.js
@@ -63,45 +63,7 @@
       });
     };
 
-    /**
-     * @param  {Array}     allOptions     All options of dropdown
-     * @param  {Function}  isSelected     Determines value of 'selected' property
-     * @return {void}
-     */
-    var setSelected = function(allOptions, isSelected) {
-      _.each(allOptions, function(option) {
-        if (option) {
-          option.selected = isSelected(option);
-        }
-      });
-    };
-
-    /**
-     * @param  {String}    menuName      For example, 'majors'
-     * @param  {Object}    optionGroup   Menu represents a group of options (see option-group definition)
-     * @return {void}
-     */
-    var onClickMajorOptionGroup = function(menuName, optionGroup) {
-      if (menuName === 'majors') {
-        if (optionGroup.selected) {
-          if (optionGroup.name === 'Declared') {
-            // If user selects "Declared" then all other checkboxes are deselected
-            $scope.search.count.majors = 1;
-            setSelected($scope.search.options.majors, function(major) {
-              return major.name === optionGroup.name;
-            });
-          } else if (optionGroup.name === 'Undeclared') {
-            // If user selects "Undeclared" then "Declared" is deselected
-            manualSetSelected(menuName, 'Declared', false);
-            onClickOption(menuName, optionGroup);
-          }
-        } else {
-          onClickOption(menuName, optionGroup);
-        }
-      }
-    };
-
-    var getMajors = function(callback) {
+    var getMajors = function(onClickDeclaredUndeclared, callback) {
       studentFactory.getRelevantMajors().then(function(response) {
         // Remove '*-undeclared' options in favor of generic 'Undeclared'
         var majors = _.filter(response.data, function(major) {
@@ -117,12 +79,12 @@
           {
             name: 'Declared',
             value: 'Declared',
-            onClick: onClickMajorOptionGroup
+            onClick: onClickDeclaredUndeclared
           },
           {
             name: 'Undeclared',
             value: 'Undeclared',
-            onClick: onClickMajorOptionGroup
+            onClick: onClickDeclaredUndeclared
           },
           null
         );
@@ -142,7 +104,7 @@
     var getAvailableFilters = function(definitions, callback) {
       async.series([
         function(done) {
-          getMajors(function(majors) {
+          getMajors(_.noop, function(majors) {
             setMenuOptions(definitions, 'majors', majors);
             setMenuOptions(definitions, 'gpaRanges', studentFactory.getGpaRanges());
             setMenuOptions(definitions, 'levels', studentFactory.getStudentLevels());

--- a/boac/static/app/cohort/filtered/cohortController.js
+++ b/boac/static/app/cohort/filtered/cohortController.js
@@ -290,6 +290,44 @@
     };
 
     /**
+     * @param  {Array}     allOptions     All options of dropdown
+     * @param  {Function}  isSelected     Determines value of 'selected' property
+     * @return {void}
+     */
+    var setSelected = function(allOptions, isSelected) {
+      _.each(allOptions, function(option) {
+        if (option) {
+          option.selected = isSelected(option);
+        }
+      });
+    };
+
+    /**
+     * @param  {String}    menuName      For example, 'majors'
+     * @param  {Object}    optionGroup   Menu represents a group of options (see option-group definition)
+     * @return {void}
+     */
+    var onClickDeclaredUndeclared = function(menuName, optionGroup) {
+      if (menuName === 'majors') {
+        if (optionGroup.selected) {
+          if (optionGroup.name === 'Declared') {
+            // If user selects "Declared" then all other checkboxes are deselected
+            $scope.search.count.majors = 1;
+            setSelected($scope.search.options.majors, function(major) {
+              return major.name === optionGroup.name;
+            });
+          } else if (optionGroup.name === 'Undeclared') {
+            // If user selects "Undeclared" then "Declared" is deselected
+            manualSetSelected(menuName, 'Declared', false);
+            onClickOption(menuName, optionGroup);
+          }
+        } else {
+          onClickOption(menuName, optionGroup);
+        }
+      }
+    };
+
+    /**
      * The search form must reflect the team codes of the saved cohort.
      *
      * @param  {Function}    callback    Follow up activity per caller
@@ -558,7 +596,7 @@
       athleticsFactory.getAllTeamGroups().then(function(teamsResponse) {
         var groupCodes = teamsResponse.data;
 
-        filterCriteriaService.getMajors(function(majors) {
+        filterCriteriaService.getMajors(onClickDeclaredUndeclared, function(majors) {
           var decorate = utilService.decorateOptions;
           $scope.search.options = {
             gpaRanges: decorate(studentFactory.getGpaRanges(), 'name'),


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1149

The BOAC-1149 fix was in PR #795 and yet while verifying I discovered `$scope` usage in `filterCriteriaService`. This puts that bit of legacy code back in legacy controller.