### PR TITLE
BOAC-1145, do not omit ASC team-groups with zero active students

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -235,8 +235,7 @@ def get_team_groups(group_codes=None, team_code=None):
     params = {}
     sql = f"""SELECT group_code, group_name, team_code, team_name, COUNT(DISTINCT sid)
         FROM {asc_schema()}.students
-        WHERE active = TRUE
-        AND team_code IS NOT NULL"""
+        WHERE team_code IS NOT NULL"""
     if group_codes:
         sql += ' AND group_code = ANY(:group_codes)'
         params.update({'group_codes': group_codes})

--- a/boac/merged/athletics.py
+++ b/boac/merged/athletics.py
@@ -34,10 +34,12 @@ def all_team_groups():
         return []
 
     def translate_row(row):
+        group_code = row['group_code']
+        group_name = row['group_name'] + ' (AA)' if group_code.endswith('-AA') else row['group_name']
         return {
-            'groupCode': row['group_code'],
-            'groupName': row['group_name'],
-            'name': row['group_name'],
+            'groupCode': group_code,
+            'groupName': group_name,
+            'name': group_name,
             'teamCode': row['team_code'],
             'teamName': row['team_name'],
             'totalStudentCount': row['count'],

--- a/fixtures/loch.sql
+++ b/fixtures/loch.sql
@@ -79,6 +79,7 @@ VALUES
 ('5678901234', FALSE, TRUE, 'Compete', 'MFB-DL', 'Football, Defensive Line', 'FBM', 'Football'),
 ('5678901234', FALSE, TRUE, 'Compete', 'MTE', 'Men''s Tennis', 'TNM', 'Men''s Tennis'),
 ('7890123456', TRUE, TRUE, 'Compete', 'MBB', 'Men''s Baseball', 'BAM', 'Men''s Baseball'),
+('3456789012', TRUE, TRUE, 'Compete', 'MBB-AA', 'Men''s Baseball', 'BAM', 'Men''s Baseball'),
 -- 'A mug is a mug in everything.' - Colonel Harrington
 ('890127492', TRUE, FALSE, 'Trouble', 'MFB-DB', 'Football, Defensive Backs', 'FBM', 'Football'),
 ('890127492', TRUE, FALSE, 'Trouble', 'MFB-DL', 'Football, Defensive Line', 'FBM', 'Football'),

--- a/tests/test_api/test_athletics_controller.py
+++ b/tests/test_api/test_athletics_controller.py
@@ -77,17 +77,18 @@ class TestAthletics:
         team_groups = response.json
         group_codes = [team_group['groupCode'] for team_group in team_groups]
         group_names = [team_group['groupName'] for team_group in team_groups]
-        total_student_counts = [team_group['totalStudentCount'] for team_group in team_groups]
-        assert ['MFB-DB', 'MFB-DL', 'MBB', 'MTE', 'WFH', 'WTE'] == group_codes
+        assert ['MFB-DB', 'MFB-DL', 'MBB', 'MBB-AA', 'MTE', 'WFH', 'WTE'] == group_codes
         assert [
             'Football, Defensive Backs',
             'Football, Defensive Line',
             'Men\'s Baseball',
+            'Men\'s Baseball (AA)',
             'Men\'s Tennis',
             'Women\'s Field Hockey',
             'Women\'s Tennis',
         ] == group_names
-        assert [2, 3, 1, 1, 1, 1] == total_student_counts
+        total_student_counts = [team_group['totalStudentCount'] for team_group in team_groups]
+        assert [3, 4, 1, 1, 2, 2, 2] == total_student_counts
 
     def test_get_all_teams(self, asc_advisor, client):
         """Returns all teams if authenticated."""
@@ -100,7 +101,7 @@ class TestAthletics:
         total_student_counts = [team['totalStudentCount'] for team in teams]
         assert ['FBM', 'BAM', 'TNM', 'FHW', 'TNW'] == team_codes
         assert ['Football', 'Men\'s Baseball', 'Men\'s Tennis', 'Women\'s Field Hockey', 'Women\'s Tennis'] == team_names
-        assert [3, 1, 1, 1, 1] == total_student_counts
+        assert [3, 2, 1, 1, 1] == total_student_counts
         football = teams[0]
         assert football['code'] == 'FBM'
         assert football['name'] == 'Football'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1145
https://jira.ets.berkeley.edu/jira/browse/BOAC-1158

No impact on ASC's exclude-inactives-in-search requirement but it does bring Big (Junk) Data to the "Teams" dropdown.