### PR TITLE
BOAC-1185 Default value fixes for ASC criteria

### DIFF
--- a/boac/static/app/cohort/filtered/filterCriteriaFactory.js
+++ b/boac/static/app/cohort/filtered/filterCriteriaFactory.js
@@ -76,7 +76,7 @@
         },
         {
           available: authService.canViewAsc(),
-          defaultValue: false,
+          defaultValue: (authService.isAscUser() ? false : null),
           handler: utilService.lenientBoolean,
           depth: 1,
           key: 'isInactiveAsc',
@@ -85,7 +85,7 @@
         },
         {
           available: authService.canViewAsc(),
-          defaultValue: false,
+          defaultValue: null,
           depth: 1,
           handler: utilService.lenientBoolean,
           key: 'inIntensiveCohort',


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1185

Three-valued logic strikes again!

Setting ASC intensive or inactive to `false` rather than `null` introduces an ASC criterion into the mix and limits the result set to ASC students.

We want inactives to be excluded by default for ASC users but not admins.

We don't want intensives to be excluded by default for anyone.

@johncrossman should make sure this makes sense.