### PR TITLE
BOAC-1201, simplify redrawButtons in filterCriteriaComponent

### DIFF
--- a/boac/static/app/cohort/cohort.css
+++ b/boac/static/app/cohort/cohort.css
@@ -116,7 +116,7 @@
 }
 
 .cohort-filter-draft-column-02 {
-  flex: 1;
+  flex: 0;
 }
 
 .cohort-filter-draft-column-03 {
@@ -211,13 +211,13 @@
 
 .cohort-filter-item-filter {
   -webkit-flex: 0 0 200px;
-  flex: 0 0 200px;
+  flex: 0 0 100px;
   font-weight: 600;
 }
 
 .cohort-filter-item-name {
   -webkit-flex: 0 0 200px;
-  flex: 0 0 200px;
+  flex: 0 0 400px;
 }
 
 .cohort-filter-item-button {

--- a/boac/static/app/cohort/filtered/filterCriteria.html
+++ b/boac/static/app/cohort/filtered/filterCriteria.html
@@ -14,13 +14,14 @@
                 data-ng-if="filter.subcategory"></span>
         </div>
         <div class="cohort-filter-item-button">
-          <button type="button"
-                  id="remove-added-filter-{{$index}}"
-                  class="btn-link cohort-manage-btn-link"
-                  data-ng-click="buttons.removeButton.onClick($index)"
-                  data-ng-if="buttons.removeButton.show">
-            Remove
-          </button>
+          <div data-ng-if="buttons.removeButton.show">
+            <button type="button"
+                    id="remove-added-filter-{{$index}}"
+                    class="btn-link cohort-manage-btn-link"
+                    data-ng-click="buttons.removeButton.onClick($index)">
+              Remove
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -94,23 +95,25 @@
         </div>
       </div>
       <div class="cohort-filter-draft-column-03">
-        <button type="button"
-                id="unsaved-filter-add"
-                class="btn btn-primary"
-                focus-on="buttons.addButton.show"
-                data-ng-click="buttons.addButton.onClick()"
-                data-ng-if="buttons.addButton.show">
-          Add
-        </button>
+        <div data-ng-if="buttons.addButton.show">
+          <button type="button"
+                  id="unsaved-filter-add"
+                  class="btn btn-primary"
+                  focus-on="buttons.addButton.show"
+                  data-ng-click="buttons.addButton.onClick()">
+            Add
+          </button>
+        </div>
       </div>
       <div class="cohort-filter-draft-column-04">
-        <button type="button"
-                id="unsaved-filter-reset"
-                class="btn-link cohort-manage-btn-link"
-                data-ng-click="buttons.cancelButton.onClick()"
-                data-ng-if="buttons.cancelButton.show">
-          Cancel
-        </button>
+        <div data-ng-if="buttons.cancelButton.show">
+          <button type="button"
+                  id="unsaved-filter-reset"
+                  class="btn-link cohort-manage-btn-link"
+                  data-ng-click="buttons.cancelButton.onClick()">
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/boac/static/app/home/home.html
+++ b/boac/static/app/home/home.html
@@ -42,10 +42,7 @@
         <div class="home-cohort-actions">
           <a id="home-filtered-cohorts-create-link"
              data-ui-sref="filteredCohort({c: 'new'})"
-             data-ui-sref-opts="{reload: true}">Create<span class="sr-only"> a filtered cohort</span></a> |
-          <a id="home-filtered-cohorts-manage-link"
-             data-ui-sref="filteredCohortsManage()"
-             data-ui-sref-opts="{reload: true}">Manage<span class="sr-only"> your filtered cohorts</span></a>
+             data-ui-sref-opts="{reload: true}">Create<span class="sr-only"> a filtered cohort</span></a>
         </div>
       </div>
       <div data-ng-if="!myFilteredCohorts.length">

--- a/boac/static/app/routes.js
+++ b/boac/static/app/routes.js
@@ -216,9 +216,6 @@
           case 'filteredCohort':
             $rootScope.pageTitle = 'Filtered Cohort';
             break;
-          case 'filteredCohortsManage':
-            $rootScope.pageTitle = 'Manage Filtered Cohorts';
-            break;
           case 'curatedCohort':
             $rootScope.pageTitle = 'Curated Cohort';
             break;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1201
https://jira.ets.berkeley.edu/jira/browse/BOAC-1188

Relying on listeners to redraw all buttons risks strange and unwanted show/hide behavior.

This includes removal of 'Manage Cohorts' from home and flex-width tweak in added-filter rows.