### PR TITLE
BOAC-1190, fix Teams page and remove its inaccurate totalStudentCount

### DIFF
--- a/boac/static/app/athletics/teams.html
+++ b/boac/static/app/athletics/teams.html
@@ -19,8 +19,6 @@
       <ul data-ng-if="!isLoading" class="home-list">
         <li data-ng-repeat="team in teams">
           <a data-ng-bind="team.name" data-ng-href="{{team.url}}"></a>
-          (<span data-ng-bind="team.totalStudentCount"></span>)
-          <br>
         </li>
       </ul>
     </div>

--- a/boac/static/app/athletics/teamsController.js
+++ b/boac/static/app/athletics/teamsController.js
@@ -42,12 +42,11 @@
             teams[teamCode] = {
               code: t.teamCode,
               name: teamName,
-              totalStudentCount: t.totalStudentCount,
-              url: '/cohort/filtered?name=' + encodeURI(teamName) + '&',
+              url: '/cohort/filtered?cohortName=' + encodeURI(teamName) + '&',
               teamGroups: []
             };
           }
-          teams[teamCode].url += 't=' + encodeURI(t.groupCode) + '&';
+          teams[teamCode].url += 'team=' + encodeURI(t.groupCode) + '&';
         });
         $scope.teams = _.values(teams);
         page.loading(false);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1190

`totalStudentCount` will be inaccurate for Football because a SID might be double counted if student is on two squads. IMO, fixing this is not worth the effort.  