### PR TITLE
BOAC-1247, Flask 1.0.2 for BOAC

### DIFF
--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -42,7 +42,7 @@ def admin_required(func):
         if login_ok or api_key_ok:
             return func(*args, **kw)
         else:
-            app.logger.warn(f'Unauthorized request to {request.path}')
+            app.logger.warning(f'Unauthorized request to {request.path}')
             return app.login_manager.unauthorized()
     return _admin_required
 

--- a/boac/factory.py
+++ b/boac/factory.py
@@ -29,7 +29,7 @@ from boac.configs import load_configs
 from boac.logger import initialize_logger
 from boac.routes import register_routes
 from flask import Flask
-from werkzeug.contrib.cache import SimpleCache
+from flask_caching import Cache
 
 
 def create_app():
@@ -50,8 +50,5 @@ def create_app():
 def initialize_cache(app):
     """Baby's First Cache."""
     default = app.config['CACHE_DEFAULT']
-    if default:
-        app.cache = SimpleCache(default_timeout=default)
-    else:
-        app.cache = None
-    return app.cache
+    # 'app' is auto-configured in init_app() of this Cache instance
+    return Cache(app, config={'CACHE_TYPE': 'simple', 'CACHE_DEFAULT_TIMEOUT': default}) if default else None

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -25,15 +25,15 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 
 from boac.models.authorized_user import AuthorizedUser
-from flask import make_response, request
-import flask_login
+from flask import jsonify, make_response, request
+from flask_login import LoginManager
 
 
 def register_routes(app):
     """Register app routes."""
     # Register authentication modules. This should be done before
     # any authentication-protected routes are registered.
-    login_manager = flask_login.LoginManager()
+    login_manager = LoginManager()
     login_manager.user_loader(AuthorizedUser.find_by_uid)
     login_manager.init_app(app)
 
@@ -51,6 +51,10 @@ def register_routes(app):
 
     # Register error handlers.
     import boac.api.error_handlers
+
+    @app.login_manager.unauthorized_handler
+    def unauthorized_handler():
+        return jsonify(success=False, data={'login_required': True}, message='Unauthorized'), 401
 
     # Unmatched API routes return a 404.
     @app.route('/api/<path:path>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-Flask==0.12.2
+Flask==1.0.2
+Flask-Caching==1.3.3
 Flask-Login==0.4.1
 Flask-SQLAlchemy==2.3.2
 SQLAlchemy==1.2.10
 Werkzeug==0.14
-cx_Oracle==6.0.3
+cx_Oracle==6.4.1
 decorator==4.3.0
 ldap3==2.5
 names==0.3.0
@@ -16,13 +17,13 @@ https://github.com/python-cas/python-cas/archive/master.zip
 # Dependencies for pandas 0.23.3. Note that pandas is not included in this requirements.txt file because
 # of potential conflicts during installation; it must be separately installed once its dependencies are
 # in place.
-numpy==1.15.0
+numpy==1.15.1
 python-dateutil==2.7.3
 pytz==2018.5
 
 # For testing
 
 https://github.com/gabrielfalcao/HTTPretty/archive/master.zip
-pytest==3.6.3
-pytest-flask==0.10.0
-tox==3.1.2
+pytest==3.8.0
+pytest-flask==0.12.0
+tox==3.3.0

--- a/tests/test_externals/test_cal1card_photo_api.py
+++ b/tests/test_externals/test_cal1card_photo_api.py
@@ -40,7 +40,7 @@ class TestCal1CardPhotoApi:
     def test_user_not_found(self, app, caplog):
         """Logs error and returns False when user not found."""
         response = cal1card_photo_api.get_cal1card_photo(9999999)
-        assert 'HTTP/1.1" 404' in caplog.text
+        assert '404 Client Error' in caplog.text
         assert response is False
 
     def test_server_error(self, app, caplog):
@@ -48,7 +48,7 @@ class TestCal1CardPhotoApi:
         api_error = MockResponse(500, {}, '{"message": "Internal server error."}')
         with register_mock(cal1card_photo_api._get_cal1card_photo, api_error):
             response = cal1card_photo_api._get_cal1card_photo(61889)
-            assert 'HTTP/1.1" 500' in caplog.text
+            assert '500 Server Error' in caplog.text
             assert not response
             assert response.raw_response.status_code == 500
             assert response.raw_response.json()['message']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1247

BOAC runs w/o problem on localhost. Let's see what `boac-dev` says. Includes recommend `flask_caching` setup: https://flask-caching.readthedocs.io/en/latest/   Can we ditch `werkzeug`?