### PR TITLE
NS-223 Call no logger by multiple names

### DIFF
--- a/boac/logger.py
+++ b/boac/logger.py
@@ -34,9 +34,8 @@ def initialize_logger(app):
     level = app.config['LOGGING_LEVEL']
     location = app.config['LOGGING_LOCATION']
 
-    # Configure the app logger, root logger, and library loggers as desired.
+    # Configure the root logger and library loggers as desired.
     loggers = [
-        app.logger,
         logging.getLogger(),
         logging.getLogger('ldap3'),
     ]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-223

I think what's going on here is that under Flask 0.x, the app logger and root Python logger kept a respectful distance, but under Flask 1.x they're confederates in the same hierarchy and may be functionally the same thing. We'll see if this helps out boac-dev.

<s>For some reason, this change requires reverting the test changes that were, for some reason, required in #873.</s>