### PR TITLE
BOAC-1245 No duplicate activity alerts for multiple course sites under same enrollment

### DIFF
--- a/fixtures/loch_student_enrollment_term_3456789012_2178.json
+++ b/fixtures/loch_student_enrollment_term_3456789012_2178.json
@@ -110,6 +110,43 @@
           "courseCode": "MED ST 205",
           "courseName": "Medieval Manuscripts as Primary Sources",
           "courseTerm": "Fall 2017"
+        },
+        {
+          "analytics": {
+            "assignmentsSubmitted": null,
+            "courseEnrollmentCount": 25,
+            "currentScore": null,
+            "lastActivity": {
+              "boxPlottable": true,
+              "courseDeciles": [
+                0,
+                0,
+                1533975180,
+                1534134360,
+                1534296120,
+                1534404540,
+                1534566180,
+                1534724580,
+                1534993320,
+                1535264940,
+                1535533860
+              ],
+              "courseMean": {
+                "percentile": 45,
+                "raw": 1534360153.3705
+              },
+              "displayPercentile": "19th",
+              "student": {
+                "percentile": 10,
+                "raw": 0,
+                "roundedUpPercentile": 19
+              }
+            }
+          },
+          "canvasCourseId": 7654329,
+          "courseCode": "MED ST 205",
+          "courseName": "Tuesday Night Paleography Roundtable",
+          "courseTerm": "Fall 2017"
         }
       ],
       "displayName": "MED ST 205",

--- a/fixtures/loch_student_enrollment_term_5678901234_2178.json
+++ b/fixtures/loch_student_enrollment_term_5678901234_2178.json
@@ -113,6 +113,43 @@
         },
         {
           "analytics": {
+            "assignmentsSubmitted": null,
+            "courseEnrollmentCount": 25,
+            "currentScore": null,
+            "lastActivity": {
+              "boxPlottable": true,
+              "courseDeciles": [
+                0,
+                0,
+                1533975180,
+                1534134360,
+                1534296120,
+                1534404540,
+                1534566180,
+                1534724580,
+                1534993320,
+                1535264940,
+                1535533860
+              ],
+              "courseMean": {
+                "percentile": 45,
+                "raw": 1534360153.3705
+              },
+              "displayPercentile": "20th",
+              "student": {
+                "percentile": 20,
+                "raw": 1533985180,
+                "roundedUpPercentile": 20
+              }
+            }
+          },
+          "canvasCourseId": 7654329,
+          "courseCode": "MED ST 205",
+          "courseName": "Tuesday Night Paleography Roundtable",
+          "courseTerm": "Fall 2017"
+        },
+        {
+          "analytics": {
             "assignmentsSubmitted": {
               "boxPlottable": false,
               "courseDeciles": null,

--- a/tests/test_models/test_alert.py
+++ b/tests/test_models/test_alert.py
@@ -116,13 +116,13 @@ class TestNoActivityAlert:
     """Alerts for no bCourses activity."""
 
     def test_update_no_activity_alerts(self):
-        """Can be created from bCourses analytics feeds."""
+        """Can be created from bCourses analytics feeds, at most one per enrollment."""
         Alert.update_all_for_term(2178)
         alerts = get_current_alerts('3456789012')
         assert len(alerts) == 1
         assert alerts[0]['id'] > 0
         assert alerts[0]['alertType'] == 'no_activity'
-        assert alerts[0]['key'] == '2178_7654321'
+        assert alerts[0]['key'] == '2178_MED ST 205'
         assert alerts[0]['message'] == 'No activity! Student has yet to use the MED ST 205 bCourses site for Fall 2017.'
 
     def test_no_activity_percentile_cutoff(self, app):
@@ -139,14 +139,14 @@ class TestInfrequentActivityAlert:
     """Alerts for infrequent bCourses activity."""
 
     def test_update_infrequent_activity_alerts(self, app):
-        """Can be created from bCourses analytics feeds."""
+        """Can be created from bCourses analytics feeds, at most one per enrollment."""
         with override_config(app, 'ALERT_INFREQUENT_ACTIVITY_ENABLED', True):
             Alert.update_all_for_term(2178)
             alerts = get_current_alerts('5678901234')
             assert len(alerts) == 1
             assert alerts[0]['id'] > 0
             assert alerts[0]['alertType'] == 'infrequent_activity'
-            assert alerts[0]['key'] == '2178_7654321'
+            assert alerts[0]['key'] == '2178_MED ST 205'
             assert alerts[0]['message'].startswith('Infrequent activity! Last MED ST 205 bCourses activity')
 
     def test_infrequent_activity_percentile_cutoff(self, app):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1245

Activity alerts are now keyed by term id + course display name rather than Canvas site id.