### PR TITLE
BOAC-1299 Zero-percentiles are still legitimate data

### DIFF
--- a/boac/lib/analytics.py
+++ b/boac/lib/analytics.py
@@ -39,7 +39,7 @@ def mean_metrics_across_sites(canvas_sites, key):
             if not metric_for_key:
                 continue
             percentile = metric_for_key.get('percentile')
-            if percentile and not math.isnan(percentile):
+            if percentile is not None and not math.isnan(percentile):
                 percentiles.append(percentile)
         if len(percentiles):
             mean_percentile = mean(percentiles)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1299

To venture onto BOAC-1272's turf, most of the examples I've found have greater-than-zero rounded-up percentiles.