### PR TITLE
BOAC-1310, no googleAnalytics without 'ga'

### DIFF
--- a/boac/static/app/shared/googleAnalyticsService.js
+++ b/boac/static/app/shared/googleAnalyticsService.js
@@ -42,7 +42,7 @@
      * @return {void}
      */
     var track = function(category, action, label, value) {
-      if (id) {
+      if (id && ga) {
         ga('send', 'event', category, action, label, value, {
           userId: _.get($rootScope.me, 'uid')
         });
@@ -50,7 +50,7 @@
     };
 
     $transitions.onSuccess({}, function() {
-      if (id) {
+      if (id && ga) {
         var uid = _.get($rootScope.me, 'uid');
         ga('create', id, 'auto');
         if (uid) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1310

Notice the `asycn` in `index.html`:
```
<script async src='https://www.google-analytics.com/analytics.js'></script>
```
Do not use 'ga' until the async is done.