### PR TITLE
BOAC-1324, no alerts for DeCal courses (directed/group study)

### DIFF
--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -271,3 +271,12 @@ def can_view_cohort(user, cohort):
     if cohort.owners:
         cohort_dept_codes = np.concatenate([get_dept_codes(o) for o in cohort.owners])
     return np.in1d(my_dept_codes, cohort_dept_codes)
+
+
+def section_is_eligible_for_alerts(enrollment, section):
+    if section.get('component') == 'LEC':
+        return True
+    else:
+        display_name = enrollment.get('displayName')
+        decal_catalog_id_pattern = re.compile(' 1?9[89][A-Z]?[A-Z]?$')
+        return not decal_catalog_id_pattern.search(display_name)

--- a/fixtures/loch_student_enrollment_term_11667051_2178.json
+++ b/fixtures/loch_student_enrollment_term_11667051_2178.json
@@ -340,6 +340,48 @@
       ],
       "title": "Physical Education Activities",
       "units": 0.5
+    },
+    {
+      "canvasSites": [
+        {
+          "analytics": {
+            "assignmentsSubmitted": {
+              "error": "Redshift query returned no results"
+            },
+            "currentScore": {
+              "error": "Redshift query returned no results"
+            },
+            "lastActivity": {
+              "error": "Redshift query returned no results"
+            }
+          },
+          "canvasCourseId": 1476237,
+          "courseName": "Kanye West Decal",
+          "courseCode": "SOCIOL 198 - GRP 006",
+          "courseTerm": "Fall 2017"
+        }
+      ],
+      "displayName": "SOCIOL 198",
+      "title": "Directed Group Study for Undergraduates",
+      "grade": null,
+      "gradingBasis": "Letter",
+      "sections": [
+        {
+          "ccn": 23707,
+          "component": "GRP",
+          "sectionNumber": "009",
+          "enrollmentStatus": "E",
+          "units": 2.0,
+          "gradingBasis": "Letter",
+          "midtermGrade": "D-",
+          "grade": null,
+          "primary": true,
+          "canvasCourseIds": [
+            1476237
+          ]
+        }
+      ],
+      "units": 2.0
     }
   ],
   "termId": "2178",

--- a/tests/test_api/test_filtered_cohort_controller.py
+++ b/tests/test_api/test_filtered_cohort_controller.py
@@ -202,7 +202,7 @@ class TestCohortDetail:
         term = athlete['term']
         assert term['termName'] == 'Fall 2017'
         assert term['enrolledUnits'] == 12.5
-        assert len(term['enrollments']) == 4
+        assert len(term['enrollments']) == 5
         assert term['enrollments'][0]['displayName'] == 'BURMESE 1A'
         assert len(term['enrollments'][0]['canvasSites']) == 1
         analytics = athlete['analytics']

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -554,7 +554,7 @@ class TestStudentAnalytics:
         assert len(authenticated_response.json['enrollmentTerms']) == 2
         assert authenticated_response.json['enrollmentTerms'][0]['termName'] == 'Fall 2017'
         assert authenticated_response.json['enrollmentTerms'][0]['enrolledUnits'] == 12.5
-        assert len(authenticated_response.json['enrollmentTerms'][0]['enrollments']) == 4
+        assert len(authenticated_response.json['enrollmentTerms'][0]['enrollments']) == 5
         assert authenticated_response.json['enrollmentTerms'][1]['termName'] == 'Spring 2017'
         assert authenticated_response.json['enrollmentTerms'][1]['enrolledUnits'] == 10
         assert len(authenticated_response.json['enrollmentTerms'][1]['enrollments']) == 3

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -112,3 +112,16 @@ class TestBerkeleyAuthorization:
         assert berkeley.can_view_cohort(admin_user, coe_cohorts[0])
         assert not berkeley.can_view_cohort(asc_advisor, coe_cohorts[0])
         assert berkeley.can_view_cohort(coe_advisor, coe_cohorts[0])
+
+
+class TestAlertRules:
+    """Rules related to alert creation."""
+
+    def test_section_is_eligible_for_alerts(self):
+        assert berkeley.section_is_eligible_for_alerts({'displayName': 'SOCIOL 198'}, {'component': 'LEC'})
+        dis_section = {'component': 'DIS'}
+        for catalog_id in ('98', '199', '98A', '98BC', '199BC'):
+            assert not berkeley.section_is_eligible_for_alerts({'displayName': f'SOCIOL {catalog_id}'}, dis_section)
+        for display_name in ('PSYCH 19A', 'MATH 9A', 'SOCIOL 198, Special Edition', 'Pop Music in 1988'):
+            eligible_for_alert = {'displayName': display_name}
+            assert berkeley.section_is_eligible_for_alerts(eligible_for_alert, dis_section), f'Failed on {display_name}'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1324

A query of `intermediate.course_sections` (Redshift) view for 'GRP' sections and catalog_id pattern (below) returns only 'group study' and 'directed study' sections. I believe this fits with the requirement. A second pair of eyes is welcome.

Use `?w=1` for an easier diff read.