### PR TITLE
BOAC-1333, no student avatars on homepage listings

### DIFF
--- a/boac/static/app/home/home.html
+++ b/boac/static/app/home/home.html
@@ -74,6 +74,7 @@
             </a>
           </uib-accordion-heading>
           <sortable-alerts-table data-students="cohort.students"
+                                 data-include-avatar=false
                                  data-options="cohort"
                                  data-ng-if="cohort.students.length"></sortable-alerts-table>
           <div>

--- a/boac/static/app/home/sortableAlertsTable.html
+++ b/boac/static/app/home/sortableAlertsTable.html
@@ -81,7 +81,8 @@
            tabindex="0"
            data-ng-class="{'img-blur': demoMode.blur}"
            data-ng-src="/api/student/{{student.uid}}/photo"
-           data-avatar-fallback>
+           data-avatar-fallback
+           data-ng-if="includeAvatar">
     </div>
     <div class="group-summary-column group-summary-column-02">
       <a aria-label="Go to profile page of {{student.firstName}} {{student.lastName}}"

--- a/boac/static/app/home/sortableAlertsTableDirective.js
+++ b/boac/static/app/home/sortableAlertsTableDirective.js
@@ -35,6 +35,7 @@
 
       // @see https://docs.angularjs.org/guide/directive#isolating-the-scope-of-a-directive
       scope: {
+        includeAvatar: '=',
         options: '=',
         students: '='
       },

--- a/boac/static/app/search/searchResults.html
+++ b/boac/static/app/search/searchResults.html
@@ -30,7 +30,9 @@
                                data-ng-if="search.students.length"></curated-cohort-selector>
     </div>
     <div>
-      <sortable-alerts-table data-students="search.students" data-options="displayOptions"></sortable-alerts-table>
+      <sortable-alerts-table data-students="search.students"
+                             data-include-avatar=true
+                             data-options="displayOptions"></sortable-alerts-table>
     </div>
   </div>
 </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1333

This should help homepage perf a bit; lazy-loading students on-cohort-click would be a real winner, methinks.