### PR TITLE
NOJIRA, upgrade requests to version 2.20.0 for security reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ decorator==4.3.0
 ldap3==2.5.1
 names==0.3.0
 psycopg2==2.7.5
-requests==2.19.1
+requests==2.20.0
 simplejson==3.16.0
 xmltodict==0.11.0
 https://github.com/python-cas/python-cas/archive/master.zip

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ whitelist_externals = *
 
 [testenv:test]
 commands =
-    pytest {posargs}
+    pytest {posargs: tests}
 
 [testenv:lint-js]
 commands =


### PR DESCRIPTION
...and default target dir for `tox -e test` to avoid `pytest` scan of `node_modules` dir.