### PR TITLE
BOAC-1440, vue-cli-service requires Node >=8; update buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 eb_codebuild_settings:
   CodeBuildServiceRole: arn:aws:iam::697877139013:role/service-role/code-build-BOAC-service-role
   ComputeType: BUILD_GENERAL1_MEDIUM
-  Image: aws/codebuild/nodejs:6.3.1
+  Image: aws/codebuild/nodejs:8.11.0
   Timeout: 60
 
 phases:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1440

See available CodeBuild docker images:
https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html