### PR TITLE
BOAC-1442, order of build commands (buildspec) matters; gulp dist comes first

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,9 +21,9 @@ phases:
   build:
     commands:
       - sudo npm install -g @vue/cli
-      - sudo npm run build-vue
       - sudo ./node_modules/.bin/bower install --allow-root
       - sudo ./node_modules/.bin/gulp dist --allow-root
+      - sudo npm run build-vue
 
   post_build:
     commands:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1442

As you might assume, `gulp dist` was blowing away the dist dir. I look forward to ditching gulp. 