### PR TITLE
BOAC-1525, separate 'curated' and 'cohort' in front-end /api structure

### DIFF
--- a/src/api/cohort.ts
+++ b/src/api/cohort.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+import store from '@/store';
+
+export function getUsersWithCohorts() {
+  return axios
+    .get(`${store.state.apiBaseUrl}/api/filtered_cohorts/all`)
+    .then(response => response.data, () => null);
+}

--- a/src/api/curated.ts
+++ b/src/api/curated.ts
@@ -1,12 +1,6 @@
 import axios from 'axios';
 import store from '@/store';
 
-export function getUsersWithCohorts() {
-  return axios
-    .get(`${store.state.apiBaseUrl}/api/filtered_cohorts/all`)
-    .then(response => response.data, () => null);
-}
-
 export function getCuratedGroup(id) {
   return axios
     .get(`${store.state.apiBaseUrl}/api/curated_cohort/${id}`)

--- a/src/components/curated/CuratedGroupHeader.vue
+++ b/src/components/curated/CuratedGroupHeader.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script>
-import { deleteCuratedGroup, renameCuratedGroup } from '@/api/cohorts';
+import { deleteCuratedGroup, renameCuratedGroup } from '@/api/curated';
 import Validator from '@/mixins/Validator.vue';
 import store from '@/store';
 

--- a/src/components/curated/CuratedGroupList.vue
+++ b/src/components/curated/CuratedGroupList.vue
@@ -36,7 +36,7 @@
 
 <script>
 import _ from 'lodash';
-import { removeFromCuratedGroup } from '@/api/cohorts';
+import { removeFromCuratedGroup } from '@/api/curated';
 import store from '@/store';
 import CuratedGroupStudent from '@/components/curated/CuratedGroupStudent.vue';
 import SearchStudents from '@/components/sidebar/SearchStudents.vue';

--- a/src/components/curated/CuratedGroupSelector.vue
+++ b/src/components/curated/CuratedGroupSelector.vue
@@ -74,7 +74,7 @@
 import _ from 'lodash';
 import CreateCuratedGroupModal from '@/components/curated/CreateCuratedGroupModal.vue';
 import UserMetadata from '@/mixins/UserMetadata';
-import { addStudents, createCuratedGroup } from '@/api/cohorts';
+import { addStudents, createCuratedGroup } from '@/api/curated';
 
 export default {
   name: 'CuratedGroupSelector',

--- a/src/views/cohort/AllCohorts.vue
+++ b/src/views/cohort/AllCohorts.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { getUsersWithCohorts } from '@/api/cohorts';
+import { getUsersWithCohorts } from '@/api/cohort';
 import Spinner from '@/components/Spinner.vue';
 import Loading from '@/mixins/Loading.vue';
 

--- a/src/views/group/CuratedGroup.vue
+++ b/src/views/group/CuratedGroup.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import { getCuratedGroup } from '@/api/cohorts';
+import { getCuratedGroup } from '@/api/curated';
 import Spinner from '@/components/Spinner.vue';
 import Loading from '@/mixins/Loading.vue';
 import CuratedGroupHeader from '@/components/curated/CuratedGroupHeader.vue';


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1525

The `/cohort` view is coming soon and we'll need a dedicate client-side file for cohort api calls.