### PR TITLE
BOAC-1539, 'excludeCohorts' option in /api/profile/my if front-end wants data modularity

### DIFF
--- a/boac/api/curated_cohort_controller.py
+++ b/boac/api/curated_cohort_controller.py
@@ -23,9 +23,8 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import sort_students_by_name
+from boac.api.util import get_my_curated_groups, sort_students_by_name
 from boac.lib.http import tolerant_jsonify
 from boac.merged.student import get_summary_student_profiles
 from boac.models.alert import Alert
@@ -33,6 +32,12 @@ from boac.models.curated_cohort import CuratedCohort
 from flask import current_app as app, request
 from flask_cors import cross_origin
 from flask_login import current_user, login_required
+
+
+@app.route('/api/curated_groups/my')
+@login_required
+def my_curated_cohorts():
+    return tolerant_jsonify(get_my_curated_groups())
 
 
 @app.route('/api/curated_cohort/create', methods=['POST'])

--- a/boac/api/filtered_cohort_controller.py
+++ b/boac/api/filtered_cohort_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import is_unauthorized_search, strip_analytics
+from boac.api.util import get_my_cohorts, is_unauthorized_search, strip_analytics
 from boac.lib import util
 from boac.lib.berkeley import can_view_cohort
 from boac.lib.cohort_filter_definition import get_cohort_filter_definitions
@@ -34,6 +34,12 @@ from boac.merged.student import get_student_query_scope, get_summary_student_pro
 from boac.models.cohort_filter import CohortFilter
 from flask import current_app as app, request
 from flask_login import current_user, login_required
+
+
+@app.route('/api/cohorts/my')
+@login_required
+def my_cohorts():
+    return tolerant_jsonify(get_my_cohorts())
 
 
 @app.route('/api/filter_cohort/definitions')

--- a/tests/test_api/test_filtered_cohort_controller.py
+++ b/tests/test_api/test_filtered_cohort_controller.py
@@ -64,6 +64,20 @@ def coe_owned_cohort():
 class TestCohortDetail:
     """Cohort API."""
 
+    def test_my_cohorts_not_authenticated(self, client):
+        """Rejects anonymous user."""
+        response = client.get('/api/cohorts/my')
+        assert response.status_code == 401
+
+    def test_my_cohorts(self, coe_advisor_session, client):
+        """Returns user's cohorts."""
+        response = client.get('/api/cohorts/my')
+        assert response.status_code == 200
+        cohorts = response.json
+        assert len(cohorts) == 2
+        for key in 'name', 'alertCount', 'filterCriteria', 'totalStudentCount', 'isOwnedByCurrentUser':
+            assert key in cohorts[0], f'Missing cohort element: {key}'
+
     def test_students_with_alert_counts(self, asc_advisor_session, client, create_alerts, db_session):
         # Pre-load students into cache for consistent alert data.
         client.get('/api/student/61889/analytics')

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -81,6 +81,8 @@ class TestUserProfile:
         response = client.get('/api/profile/my')
         assert response.status_code == 200
         user = response.json
+        assert 'myFilteredCohorts' in user
+        assert 'myCuratedCohorts' in user
         assert user['isAdmin'] is True
         assert user['isAsc'] is False
         assert user['isCoe'] is False
@@ -99,13 +101,15 @@ class TestUserProfile:
         assert user['departments']['COENG']['isAdvisor'] is False
         assert user['departments']['COENG']['isDirector'] is True
 
-    def test_athletic_study_center_user(self, client, fake_auth):
+    def test_asc_advisor_exclude_cohorts(self, client, fake_auth):
         """Returns Athletic Study Center advisor."""
         test_uid = '1081940'
         fake_auth.login(test_uid)
-        response = client.get('/api/profile/my')
+        response = client.get('/api/profile/my?excludeCohorts=true')
         assert response.status_code == 200
         user = response.json
+        assert 'myFilteredCohorts' not in user
+        assert 'myCuratedCohorts' not in user
         assert user['isAsc'] is True
         assert 'UWASC' in user['departments']
         assert user['departments']['UWASC']['isAdvisor'] is True
@@ -154,12 +158,12 @@ class TestMyCohorts:
         assert cohorts[0]['name'] == 'Aardvark Admirers'
         assert cohorts[-1]['name'] == 'Zebra Zealots'
 
-    def test_my_curated_cohorts(self, client, fake_auth):
-        """Returns user's student curated cohorts."""
+    def test_my_curated_groups(self, client, fake_auth):
+        """Returns user's curated groups."""
         fake_auth.login('6446')
-        response = client.get('/api/profile/my')
+        response = client.get('/api/curated_groups/my')
         assert response.status_code == 200
-        cohorts = response.json['myCuratedCohorts']
+        cohorts = response.json
         assert len(cohorts) == 2
         assert 'name' in cohorts[0]
         assert 'studentCount' in cohorts[0]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1539

The Vue front-end will load user profile and cohorts/groups separately. The key benefit is a more manageable front-end store. If we plan to add/remove/rename cohorts then I'd like to detach them from the user object. Also, a faster `/profile/my` causes certain page elements (eg, header-menu) to load more quickly.  This has no impact on Angular side of things.