### PR TITLE
BOAC-1493 Consolidate duplicate lastActivityDays methods

### DIFF
--- a/src/components/curated/CuratedGroupStudent.vue
+++ b/src/components/curated/CuratedGroupStudent.vue
@@ -132,6 +132,7 @@
 </template>
 
 <script>
+import StudentAnalytics from '@/mixins/StudentAnalytics';
 import StudentAvatar from '@/components/student/StudentAvatar.vue';
 import StudentGpaChart from '@/components/student/StudentGpaChart.vue';
 import StudentMetadata from '@/mixins/StudentMetadata';
@@ -147,7 +148,7 @@ export default {
     StudentAvatar,
     StudentGpaChart
   },
-  mixins: [StudentMetadata, UserMetadata],
+  mixins: [StudentAnalytics, StudentMetadata, UserMetadata],
   methods: {
     removeFromCuratedCohort: function() {
       this.$eventHub.$emit('curated-group-remove-student', this.student.sid);

--- a/src/mixins/StudentMetadata.vue
+++ b/src/mixins/StudentMetadata.vue
@@ -1,5 +1,4 @@
 <script>
-import _ from 'lodash';
 import store from '@/store';
 
 export default {
@@ -17,28 +16,6 @@ export default {
     },
     isAlertGrade(grade) {
       return grade && this.$options.alertGrades.test(grade);
-    },
-    lastActivityDays(analytics) {
-      let timestamp = parseInt(
-        _.get(analytics, 'lastActivity.student.raw'),
-        10
-      );
-      if (!timestamp || isNaN(timestamp)) {
-        return 'Never';
-      }
-      // Days tick over at midnight according to the user's browser.
-      let daysSince = Math.round(
-        new Date().setHours(0, 0, 0, 0) -
-          new Date(timestamp * 1000).setHours(0, 0, 0, 0) / 86400000
-      );
-      switch (daysSince) {
-        case 0:
-          return 'Today';
-        case 1:
-          return 'Yesterday';
-        default:
-          return daysSince + ' days ago';
-      }
     },
     setSortableName: student =>
       (student.sortableName = student.lastName + ', ' + student.firstName)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1493

The trouble with mixins! We also have a `lastActivityDays` method over in https://github.com/ets-berkeley-edu/boac/blob/master/src/mixins/StudentAnalytics.vue, which is distinguished from StudentMetadata.vue by focusing specifically on our bCourses analytics (and is about to get some more methods to help with boxplots and the matrix).