### PR TITLE
BOAC-1562 Fix vue-analytics console error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,11 +32,14 @@ Vue.use(require('vue-lodash'));
 HighchartsMore(Highcharts);
 Vue.use(VueHighcharts, { Highcharts });
 
-Vue.use(VueAnalytics, {
-  id: store.dispatch('context/loadConfig').then(response => {
-    return _.get(response, 'googleAnalyticsId');
-  }),
-  checkDuplicatedScript: true
+store.dispatch('context/loadConfig').then(response => {
+  let googleAnalyticsId = _.get(response, 'googleAnalyticsId');
+  if (googleAnalyticsId) {
+    Vue.use(VueAnalytics, {
+      id: googleAnalyticsId,
+      checkDuplicatedScript: true
+    });
+  }
 });
 
 // Filters


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1562

Switching around the initialization logic quiets `vue-analytics.js:1 t.replace is not a function` errors in local testing.