### PR TITLE
BOAC-1569, router fixes (py, js and vue) to support split-brain testing

### DIFF
--- a/boac/static/app/routes.js
+++ b/boac/static/app/routes.js
@@ -118,7 +118,7 @@
         reloadOnSearch: false
       })
       .state('filteredCohortsAll', {
-        url: '/cohort/filtered/all',
+        url: '/cohorts/all',
         views: standardLayout('AllFilteredCohortsController', '/static/app/cohort/filtered/all.html'),
         resolve: resolvePrivate
       })
@@ -166,7 +166,7 @@
         reloadOnSearch: false
       });
 
-  }).run(function($rootScope, $state, $transitions, authFactory, config, status) {
+  }).run(function($location, $rootScope, $state, $transitions, authFactory, config, status) {
 
     $state.defaultErrorHandler(function(error) {
       var message = _.get(error, 'detail.message');
@@ -185,18 +185,6 @@
         $state.go('404');
       } else {
         $state.go('login', {casLoginError: message});
-      }
-    });
-
-    $transitions.onBefore({}, function($transition) {
-      if (config.vueEnabled) {
-        var url = _.toString($transition.$to().self.url);
-        for (var key in config.vuePaths) {
-          if (url.startsWith(key)) {
-            // Force page refresh. The server-side routing will redirect user to Vue-enabled index.html and proper path.
-            window.location = url;
-          }
-        }
       }
     });
 
@@ -225,6 +213,15 @@
     });
 
     $transitions.onSuccess({}, function() {
+      if (config.vueEnabled) {
+        var path = $location.url();
+        for (var pattern in config.vuePaths) {
+          if (new RegExp(pattern).exec(path)) {
+            // Force page refresh. The server-side routing will redirect user to Vue-enabled index.html and proper path.
+            window.location = $location.absUrl();
+          }
+        }
+      }
       document.body.scrollTop = document.documentElement.scrollTop = 0;
     });
   });

--- a/config/test.py
+++ b/config/test.py
@@ -41,6 +41,6 @@ INDEX_HTML_VUE = 'tests/static/test-index-vue.html'
 VUE_PATHS = {
     '/admin': '/admin',
     r'/cohort/curated/([0-9]+).*': r'/curated_group/\1',
-    '/cohort/filtered/all': '/cohorts/all',
+    '/cohorts/all': '/cohorts/all',
     r'/student/([0-9]+).*': r'/student/\1',
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -38,6 +38,6 @@ export function setDemoMode(demoMode: boolean) {
     })
     .then(response => response.data, () => null)
     .then(() => {
-      store.getters.user.inDemoMode = demoMode;
+      store.dispatch('user/setDemoMode', demoMode);
     });
 }

--- a/src/components/sidebar/Cohorts.vue
+++ b/src/components/sidebar/Cohorts.vue
@@ -9,7 +9,7 @@
           <router-link id="sidebar-filtered-cohort-create"
                        class="sidebar-create-link"
                        aria-label="Create cohort"
-                       to="/cohort/create"><i class="fas fa-plus"></i></router-link>
+                       to="/create_cohort"><i class="fas fa-plus"></i></router-link>
         </span>
       </div>
     </div>
@@ -17,10 +17,10 @@
          v-for="(cohort, index) in myCohorts"
          v-bind:key="cohort.id">
       <div class="sidebar-row-link-label">
-        <router-link :id="'sidebar-filtered-cohort-' + index"
-                     :aria-label="'Cohort ' + cohort.name + ' has ' + cohort.totalStudentCount + ' students'"
+        <router-link :id="`sidebar-filtered-cohort-${index}`"
+                     :aria-label="`Cohort ${cohort.name} has ${cohort.totalStudentCount}  students`"
                      class="sidebar-row-link-label-text"
-                     :to="'/cohort/' + cohort.id">{{ cohort.name }}</router-link>
+                     :to="`/cohort/${cohort.id}`">{{ cohort.name }}</router-link>
       </div>
       <div>
         <span :id="'sidebar-filtered-cohort-' + index + '-count'"

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -30,6 +30,9 @@ const getters = {
   },
   supportEmailAddress: (state: any): string => {
     return _.get(state.config, 'supportEmailAddress');
+  },
+  vuePaths: (state: any): string[] => {
+    return _.get(state.config, 'vuePaths');
   }
 };
 

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -29,6 +29,9 @@ const mutations = {
       state.user = user;
     }
   },
+  setDemoMode: (state: any, demoMode: boolean) => {
+    state.user.demoMode = demoMode;
+  },
   userAuthenticated: (state: any) => {
     state.isUserAuthenticated = true;
   }
@@ -37,6 +40,9 @@ const mutations = {
 const actions = {
   logout: ({ commit }) => {
     commit('logout');
+  },
+  setDemoMode: ({ commit }, demoMode) => {
+    commit('setDemoMode', demoMode);
   },
   userAuthenticated: ({ commit }) => {
     commit('userAuthenticated');

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -45,7 +45,7 @@ class TestVueRedirect:
 
     def test_path_rewrite_to_vue_enabled(self, client, asc_advisor_session):
         """Serves Vue page when the legacy route is mapped to a Vue route."""
-        response = client.get('/cohort/filtered/all')
+        response = client.get('/cohorts/all')
         assert response.status_code == 200
         assert 'I am a Vue.js page' in str(response.data)
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1569

The most delicate fix in this PR is found in `router.ts` where we must parse VUE_PATHS config and perform "legacyPathRedirect" if the URL path is not yet supported in Vue-land. This split-brain code will be removed in late Jan.