### PR TITLE
BOAC-1500 Autofocus page headers audibly but not visibly

### DIFF
--- a/boac/static/app/main.css
+++ b/boac/static/app/main.css
@@ -381,6 +381,10 @@ body {
   text-shadow: 0 1px 0 #fff;
 }
 
+#content h1:focus {
+  outline: none;
+}
+
 #content .list-group-item-info {
   color: #31708f;
   background-color: #d9edf7;

--- a/src/components/curated/CuratedGroupHeader.vue
+++ b/src/components/curated/CuratedGroupHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="cohort-header-container">
     <div v-if="!renameMode.on">
-      <h1 class="page-section-header">
+      <h1 tabindex="0" ref="pageHeader" class="page-section-header">
         <span>{{ curatedGroup.name || 'Curated Group' }}</span>
         <span class="faint-text"> (<span>{{ 'student' | pluralize(curatedGroup.studentCount, {1: 'One'})}}</span>)</span>
       </h1>
@@ -91,12 +91,13 @@
 
 <script>
 import { deleteCuratedGroup, renameCuratedGroup } from '@/api/curated';
+import Loading from '@/mixins/Loading.vue';
 import Validator from '@/mixins/Validator.vue';
 import router from '@/router';
 
 export default {
   name: 'CuratedGroupHeader',
-  mixins: [Validator],
+  mixins: [Loading, Validator],
   props: ['curatedGroup'],
   data: () => ({
     isModalOpen: false,
@@ -115,6 +116,9 @@ export default {
         });
       }
     }
+  },
+  mounted() {
+    this.loaded();
   },
   methods: {
     enterRenameMode: function() {

--- a/src/mixins/Loading.vue
+++ b/src/mixins/Loading.vue
@@ -10,7 +10,14 @@ export default {
   },
   methods: {
     startLoading: () => store.dispatch('context/loadingStart'),
-    loaded: () => store.dispatch('context/loadingComplete')
+    loaded() {
+      store.dispatch('context/loadingComplete');
+      this.$nextTick(() => {
+        if (this.$refs.pageHeader) {
+          this.$refs.pageHeader.focus();
+        }
+      });
+    }
   }
 };
 </script>

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -18,9 +18,10 @@
       <div>
         <div class="course-container-summary">
           <div class="course-column-description">
-            <h1 focus-on="!isLoading"
-                tabindex="0"
-                class="course-header">
+            <h1 id="course-header"
+                ref="pageHeader"
+                class="course-header"
+                tabindex="0">
               {{ section.displayName }}
             </h1>
             <div class="course-details-section">

--- a/src/views/Student.vue
+++ b/src/views/Student.vue
@@ -10,6 +10,8 @@
           <div class="student-bio-contact">
             <h1 class="student-section-header"
                 id="student-name-header"
+                ref="pageHeader"
+                tabindex="0"
                 :class="{'demo-mode-blur': user.inDemoMode}">
               {{student.name}}
             </h1>

--- a/src/views/cohort/AllCohorts.vue
+++ b/src/views/cohort/AllCohorts.vue
@@ -2,7 +2,7 @@
   <div class="m-3">
     <Spinner/>
     <div v-if="!loading">
-      <h1>Everyone's Cohorts</h1>
+      <h1 ref="pageHeader" tabindex="0">Everyone's Cohorts</h1>
 
       <div v-if="!usersWithCohorts.length">
         <div>There are no saved cohorts</div>

--- a/src/views/group/CuratedGroups.vue
+++ b/src/views/group/CuratedGroups.vue
@@ -2,7 +2,7 @@
   <div class="container-manage-cohorts">
     <Spinner/>
     <div v-if="!loading">
-      <h1 class="page-section-header">Manage Curated Groups</h1>
+      <h1 ref="pageHeader" tabindex="0" class="page-section-header">Manage Curated Groups</h1>
       <div v-if="!curatedGroups.length" data-ng-controller="CreateCuratedCohortController">
         You have no curated groups.
         <a id="curated-cohort-create"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1500

Page headers should acquire focus on load, which requires them to be included in the tab order; but the visual outline is distracting and, unlike such outlines on links or buttons, provides no context for the user's next action.