### PR TITLE
BOAC-1577 Vue: add carets for student search result sorts

### DIFF
--- a/src/components/course/SortableCourseList.vue
+++ b/src/components/course/SortableCourseList.vue
@@ -17,14 +17,14 @@
     </div>
     <table class="table-full-width" v-if="totalCourseCount">
       <tr role="row">
-        <th :class="{ dropup: !sort.reverse.section }">
+        <th>
           <button id="column-sort-button-section"
                   class="btn btn-link table-header-text group-summary-column-header group-summary-header-sortable search-results-cell"
                   :aria-label="`Sort by section ${ sort.by === 'section' ? describeReverse(sort.reverse.section) : ''}`"
                   tabindex="0"
                   @click="courseSort('section')">
             Section
-            <span class="caret" v-if="sort.by === 'section'">
+            <span v-if="sort.by === 'section'">
               <i :class="{
                 'fas fa-caret-down': sort.reverse.section,
                 'fas fa-caret-up': !sort.reverse.section
@@ -32,14 +32,14 @@
             </span>
           </button>
         </th>
-        <th :class="{ dropup: !sort.reverse.title }">
+        <th>
           <button id="column-sort-button-title"
                   class="btn btn-link table-header-text group-summary-column-header group-summary-header-sortable search-results-cell"
                   :aria-label="`Sort by course name ${ sort.by === 'title' ? describeReverse(sort.reverse.title) : ''}`"
                   tabindex="0"
                   @click="courseSort('title')">
             Course Name
-            <span class="caret" v-if="sort.by === 'title'">
+            <span v-if="sort.by === 'title'">
               <i :class="{
                 'fas fa-caret-down': sort.reverse.title,
                 'fas fa-caret-up': !sort.reverse.title

--- a/src/components/search/SortableStudents.vue
+++ b/src/components/search/SortableStudents.vue
@@ -11,67 +11,99 @@
           <th class="group-summary-column group-summary-column-photo group-summary-column-header"></th>
           <th class="group-summary-column group-summary-column-name group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'sortableName')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions.sortableName">
             Name
-            <span class="caret" v-if="options.sortBy === 'sortableName'"></span>
+            <span v-if="options.sortBy === 'sortableName'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
           <th class="group-summary-column group-summary-column-sid group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'sid')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions.sid">
             SID
-            <span class="caret" v-if="options.sortBy === 'sid'"></span>
+            <span v-if="options.sortBy === 'sid'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
           <th class="group-summary-column group-summary-column-major group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'majors[0]')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions['majors[0]']">
             Major
-            <span class="caret" v-if="options.sortBy === 'majors[0]'"></span>
+            <span v-if="options.sortBy === 'majors[0]'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
           <th class="group-summary-column group-summary-column-grad group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'expectedGraduationTerm.id')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions['expectedGraduationTerm.id']">
             Grad
-            <span class="caret" v-if="options.sortBy === 'expectedGraduationTerm.id'"></span>
+            <span v-if="options.sortBy === 'expectedGraduationTerm.id'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
           <th class="group-summary-column group-summary-column-units-term group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'term.enrolledUnits')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions['term.enrolledUnits']">
             Term Units
-            <span class="caret" v-if="options.sortBy === 'term.enrolledUnits'"></span>
+            <span v-if="options.sortBy === 'term.enrolledUnits'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
           <th class="group-summary-column group-summary-column-units-completed group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'cumulativeUnits')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions.cumulativeUnits">
             Units Completed
-            <span class="caret" v-if="options.sortBy === 'cumulativeUnits'"></span>
+            <span v-if="options.sortBy === 'cumulativeUnits'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
           <th class="group-summary-column group-summary-column-gpa group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'cumulativeGPA')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions.cumulativeGPA">
             GPA
-            <span class="caret" v-if="options.sortBy === 'cumulativeGPA'"></span>
+            <span class="caret" v-if="options.sortBy === 'cumulativeGPA'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
           <th class="group-summary-column group-summary-column-issues group-summary-column-header group-summary-header-sortable"
               v-on:click="sort(options, 'alertCount')"
-              v-bind:class="{dropup: !options.reverse}"
               role="button"
               :aria-label="sortOptions.alertCount">
             Issues
-            <span class="caret" v-if="options.sortBy === 'alertCount'"></span>
+            <span v-if="options.sortBy === 'alertCount'">
+              <i :class="{
+               'fas fa-caret-down': options.reverse,
+               'fas fa-caret-up': !options.reverse
+              }"></i>
+            </span>
           </th>
         </tr>
       </thead>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1577

Also removes the no-op `dropup`/`caret` classes which were copied from the AngularJS implementation.

While testing this, I noticed a couple of more minor visual glitches relating to caret spacing:
* The first sort on "GPA" bounces the column header text to the left (because it's currently right-aligned).
* The first sort on a wrapped column header (e.g., "Term Units" in my testing) bounces all rows down (because the caret appears under the header text).

This is bug-for-bug compatible with the Angular page, though, so I'll leave it as is for the nonce.