### PR TITLE
BOAC-1617 Update LDAP host in default config

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -103,7 +103,7 @@ DATA_LOCH_STUDENT_SCHEMA = 'student'
 
 DISABLE_MATRIX_VIEW_THRESHOLD = 800
 
-LDAP_HOST = 'nds-test.berkeley.edu'
+LDAP_HOST = 'ldap-test.berkeley.edu'
 LDAP_BIND = 'mybind'
 LDAP_PASSWORD = 'secret'
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1617

Purely a housekeeping PR, since local configs override this value.