### PR TITLE
BOAC-1664/ BOAC-1661, reloadRouteKey force route reload; history.pushState in /cohort; btn colors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,6 +27,16 @@ export default {
   background-color: #286090;
   border-color: #204d74;
 }
+.btn-primary-color-override {
+  background-color: #337ab7 !important;
+  border-color: #2e6da4 !important;
+}
+.btn-primary-color-override:hover,
+.btn-primary-color-override:focus,
+.btn-primary-color-override:active {
+  background-color: #286090 !important;
+  border-color: #204d74 !important;
+}
 .btn-link:active,
 .btn-link:focus,
 .btn-link:focus-within,

--- a/src/components/admin/DevAuth.vue
+++ b/src/components/admin/DevAuth.vue
@@ -36,9 +36,9 @@
       </div>
       <div class="ml-1">
         <b-btn id="dev-auth-submit"
-               class="splash-btn-dev-auth"
-               aria-label="Log in to BOAC with dev-auth"
+               class="splash-btn-dev-auth btn-primary-color-override"
                variant="primary"
+               aria-label="Log in to BOAC with dev-auth"
                type="submit">DevAuth!</b-btn>
       </div>
     </div>

--- a/src/components/cohort/ApplyAndSaveButtons.vue
+++ b/src/components/cohort/ApplyAndSaveButtons.vue
@@ -76,6 +76,7 @@ export default {
       this.createCohort(name).then(() => {
         this.savedCohortCallback(`Cohort ${name} created`);
         this.setPageTitle(this.cohortName);
+        history.pushState({}, null, `/cohort/${this.cohortId}`);
         this.isPerforming = null;
       });
     },

--- a/src/components/cohort/ApplyAndSaveButtons.vue
+++ b/src/components/cohort/ApplyAndSaveButtons.vue
@@ -2,9 +2,9 @@
   <div>
       <div class="sr-only" aria-live="polite">{{ cohortUpdateStatus }}</div>
       <b-btn id="unsaved-filter-apply"
-             class="btn-filter-draft-apply"
-             aria-label="Search for students"
+             class="btn-filter-draft-apply btn-primary-color-override"
              variant="primary"
+             aria-label="Search for students"
              @click="apply()"
              :disabled="!!editMode"
              v-if="showApplyButton">
@@ -13,8 +13,11 @@
       <div v-if="showSaveButton && isPerforming !== 'search'">
         <b-btn id="save-button"
                class="save-button-width mt-3"
-               :aria-label="`cohortId ? 'Save cohort' : 'Create cohort'`"
+               :class="{
+                 'btn-primary-color-override': this.isPerforming !== 'acknowledgeSave'
+               }"
                :variant="saveButtonVariant"
+               :aria-label="`cohortId ? 'Save cohort' : 'Create cohort'`"
                :disabled="!!editMode || showCreateModal || !!isPerforming"
                @click="save()">
           <span v-if="isPerforming === 'acknowledgeSave'">Saved</span>

--- a/src/components/cohort/CohortPageHeader.vue
+++ b/src/components/cohort/CohortPageHeader.vue
@@ -49,9 +49,9 @@
     </div>
     <div class="d-flex align-self-baseline m-1 mr-4" v-if="renameMode">
       <b-btn id="rename-confirm"
-             class="cohort-manage-btn"
-             aria-label="Save changes to cohort name"
+             class="cohort-manage-btn btn-primary-color-override"
              variant="primary"
+             aria-label="Save changes to cohort name"
              size="sm"
              @click.prevent="submitRename()"
              :disabled="!name">
@@ -59,8 +59,8 @@
       </b-btn>
       <b-btn id="rename-cancel"
              class="cohort-manage-btn"
-             aria-label="Cancel rename cohort"
              variant="link"
+             aria-label="Cancel rename cohort"
              size="sm"
              @click="cancelRename()">
         Cancel
@@ -69,9 +69,9 @@
     <div class="d-flex align-self-baseline m-1 mr-4" v-if="!renameMode">
       <div>
         <b-btn id="show-hide-details-button"
-               :aria-label="`isCompactView ? 'Show cohort filters' : 'Hide cohort filters'`"
                class="no-wrap pr-2 pt-0"
                variant="link"
+               :aria-label="`isCompactView ? 'Show cohort filters' : 'Hide cohort filters'`"
                @click="toggleShowHideDetails()"
                v-if="cohortId">
           {{isCompactView ? 'Show' : 'Hide'}} Filters
@@ -81,8 +81,8 @@
       <div v-if="cohortId && isOwnedByCurrentUser">
         <b-btn id="rename-button"
                class="pl-2 pr-2 pt-0"
-               aria-label="Rename this cohort"
                variant="link"
+               aria-label="Rename this cohort"
                @click="beginRename()">
           Rename
         </b-btn>

--- a/src/components/cohort/CreateCohortModal.vue
+++ b/src/components/cohort/CreateCohortModal.vue
@@ -20,6 +20,7 @@
       </div>
       <div class="modal-footer pl-0 mr-2">
         <b-btn id="create-confirm"
+               class="btn-primary-color-override"
                variant="primary"
                :disabled="!name.length"
                @click.prevent="createCohort()">

--- a/src/components/cohort/DeleteCohortModal.vue
+++ b/src/components/cohort/DeleteCohortModal.vue
@@ -9,6 +9,7 @@
     <div class="modal-footer">
       <form @submit.prevent="deleteCohort()">
         <b-btn id="delete-confirm"
+               class="btn-primary-color-override"
                variant="primary"
                @click.prevent="deleteCohort()">Delete</b-btn>
         <b-btn id="delete-cancel"

--- a/src/components/cohort/FilterRow.vue
+++ b/src/components/cohort/FilterRow.vue
@@ -111,7 +111,7 @@
     </div>
     <div class="cohort-filter-draft-column-03 pl-0" v-if="!isExistingFilter">
       <b-btn id="unsaved-filter-add"
-             class="ml-2"
+             class="btn-primary-color-override ml-2"
              variant="primary"
              aria-label="Add this new filter to the search criteria"
              @click="addNewFilter()"
@@ -124,8 +124,8 @@
          v-if="isModifyingFilter && filter.type && !isExistingFilter">
       <b-btn id="unsaved-filter-reset"
              class="cohort-manage-btn-link p-0"
-             aria-label="Cancel this filter selection"
              variant="link"
+             aria-label="Cancel this filter selection"
              @click="reset()">
         Cancel
       </b-btn>
@@ -135,8 +135,8 @@
         <span v-if="filter.type !== 'boolean'">
           <b-btn :id="`edit-added-filter-${index}`"
                  class="btn-cohort-added-filter pr-1"
-                 :aria-label="`Edit this ${filter.name} filter`"
                  variant="link"
+                 :aria-label="`Edit this ${filter.name} filter`"
                  size="sm"
                  @click="editExistingFilter()">
             Edit
@@ -144,8 +144,8 @@
         </span>
         <b-btn :id="`remove-added-filter-${index}`"
                class="btn-cohort-added-filter pl-2 pr-0"
-               :aria-label="`Remove this ${filter.name} filter`"
                variant="link"
+               :aria-label="`Remove this ${filter.name} filter`"
                size="sm"
                @click="removeFilter(index)">
           Remove
@@ -153,16 +153,17 @@
       </div>
       <div class="d-flex flex-row" v-if="isModifyingFilter">
         <b-btn :id="`update-added-filter-${index}`"
-               :aria-label="`Update this ${filter.name} filter`"
+               class="btn-primary-color-override"
                variant="primary"
+               :aria-label="`Update this ${filter.name} filter`"
                size="sm"
                @click="updateExisting()">
           Update
         </b-btn>
         <b-btn :id="`cancel-edit-added-filter-${index}`"
                class="btn-cohort-added-filter"
-               aria-label="Cancel update"
                variant="link"
+               aria-label="Cancel update"
                size="sm"
                @click="cancelEditExisting()">
           Cancel

--- a/src/components/curated/CreateCuratedGroupModal.vue
+++ b/src/components/curated/CreateCuratedGroupModal.vue
@@ -20,6 +20,7 @@
       </div>
       <div class="modal-footer pl-0 mr-2">
         <b-btn id="create-confirm"
+               class="btn-primary-color-override"
                variant="primary"
                :disabled="!name.length"
                @click.prevent="createCuratedGroup()">

--- a/src/components/curated/CuratedGroupHeader.vue
+++ b/src/components/curated/CuratedGroupHeader.vue
@@ -31,6 +31,7 @@
     </div>
     <div class="d-flex align-self-baseline mr-4" v-if="renameMode.on">
       <b-btn id="rename-confirm"
+             class="btn-primary-color-override"
              variant="primary"
              size="sm"
              aria-label="Save changes to curated group name"
@@ -40,8 +41,8 @@
       </b-btn>
       <b-btn id="rename-cancel"
              class="cohort-manage-btn"
-             aria-label="Cancel rename curated group"
              variant="link"
+             aria-label="Cancel rename curated group"
              size="sm"
              @click="exitRenameMode">
         Cancel

--- a/src/components/sidebar/Cohorts.vue
+++ b/src/components/sidebar/Cohorts.vue
@@ -9,7 +9,12 @@
           <router-link id="cohort-create"
                        class="sidebar-create-link"
                        aria-label="Create cohort"
-                       :to="{path: '/create_cohort', query: { reload: 'true' }}"><i class="fas fa-plus"></i></router-link>
+                       :to="{
+                         path: '/create_cohort',
+                         query: {
+                           reloadRouteKey: reloadRouteKey()
+                         }
+                       }"><i class="fas fa-plus"></i></router-link>
         </span>
       </div>
     </div>
@@ -33,10 +38,11 @@
 
 <script>
 import UserMetadata from '@/mixins/UserMetadata';
+import Util from '@/mixins/Util';
 
 export default {
   name: 'Cohorts',
-  mixins: [UserMetadata]
+  mixins: [UserMetadata, Util]
 };
 </script>
 

--- a/src/layouts/Login.vue
+++ b/src/layouts/Login.vue
@@ -9,10 +9,10 @@
       <div class="splash-cell-sign-in">
         <form @submit.prevent="logIn()">
           <b-btn id="splash-sign-in"
-                 class="btn-sign-in"
+                 class="btn-sign-in btn-primary-color-override"
+                 variant="primary"
                  aria-label="Log in to BOAC"
                  @click.stop="logIn()"
-                 variant="primary"
                  tabindex="0"
                  placement="top-left">Sign In</b-btn>
         </form>

--- a/src/layouts/StandardLayout.vue
+++ b/src/layouts/StandardLayout.vue
@@ -41,7 +41,9 @@ export default {
   },
   computed: {
     routeKey() {
-      return `${this.$route.path}${this.get(this.$route.query, 'reload')}`;
+      const path = this.$route.path;
+      const key = this.get(this.$route.query, 'reloadRouteKey');
+      return key ? `${path}${key}` : path;
     }
   }
 };

--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -35,6 +35,7 @@ export default {
         }, 500);
       });
     },
+    reloadRouteKey: () => new Date().getTime(),
     remove: _.remove,
     setPageTitle: phrase =>
       (document.title = `${phrase || 'UC Berkeley'} | BOAC`),


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1664
https://jira.ets.berkeley.edu/jira/browse/BOAC-1661

W.r.t `reloadRouteKey`, a better approach than https://github.com/ets-berkeley-edu/boac/pull/1182, methinks. Includes fix to NOT reload route when user creates new cohort.

This PR also has commit for bootstrap button color override.