### PR TITLE
BOAC-1671, key=route.fullPath reloads view; sidebar paths are unique per current time (ms)

### DIFF
--- a/src/components/sidebar/Cohorts.vue
+++ b/src/components/sidebar/Cohorts.vue
@@ -9,12 +9,7 @@
           <router-link id="cohort-create"
                        class="sidebar-create-link"
                        aria-label="Create cohort"
-                       :to="{
-                         path: '/create_cohort',
-                         query: {
-                           reloadRouteKey: reloadRouteKey()
-                         }
-                       }"><i class="fas fa-plus"></i></router-link>
+                       :to="forceUniquePath('/cohort/new?')"><i class="fas fa-plus"></i></router-link>
         </span>
       </div>
     </div>
@@ -25,7 +20,7 @@
         <router-link :id="`sidebar-cohort-${cohort.id}`"
                      :aria-label="`Cohort ${cohort.name} has ${cohort.totalStudentCount} students`"
                      class="sidebar-row-link-label-text"
-                     :to="`/cohort/${cohort.id}`">{{ cohort.name }}</router-link>
+                     :to="forceUniquePath(`/cohort/${cohort.id}`)">{{ cohort.name }}</router-link>
       </div>
       <div>
         <span :id="`sidebar-cohort-${cohort.id}-total-student-count`"

--- a/src/components/sidebar/CuratedGroups.vue
+++ b/src/components/sidebar/CuratedGroups.vue
@@ -12,7 +12,7 @@
         <router-link :id="'sidebar-curated-cohort-' + index"
                      :aria-label="'Curated group ' + group.name + ' has ' + group.studentCount + ' students'"
                      class="sidebar-row-link-label-text"
-                     :to="'/curated_group/' + group.id">{{ group.name }}</router-link>
+                     :to="forceUniquePath(`/curated_group/${group.id}`)">{{ group.name }}</router-link>
       </div>
       <div>
         <span :id="'sidebar-curated-cohort-' + index + '-count'"
@@ -26,9 +26,10 @@
 
 <script>
 import UserMetadata from '@/mixins/UserMetadata';
+import Util from '@/mixins/Util';
 
 export default {
   name: 'CuratedGroups',
-  mixins: [UserMetadata]
+  mixins: [UserMetadata, Util]
 };
 </script>

--- a/src/layouts/StandardLayout.vue
+++ b/src/layouts/StandardLayout.vue
@@ -16,7 +16,7 @@
       <div class="index-container-content">
         <div id="content" class="body-text">
           <!-- The ':key' attribute forces component reload when same route is requested with diff id in path. -->
-          <router-view :key="routeKey"></router-view>
+          <router-view :key="$route.fullPath"></router-view>
         </div>
         <Footer v-if="!loading"/>
       </div>
@@ -29,22 +29,14 @@ import Footer from '@/components/Footer';
 import HeaderMenu from '@/components/HeaderMenu';
 import Loading from '@/mixins/Loading';
 import Sidebar from '@/components/sidebar/Sidebar';
-import Util from '@/mixins/Util';
 
 export default {
   name: 'StandardLayout',
-  mixins: [Loading, Util],
+  mixins: [Loading],
   components: {
     Footer,
     HeaderMenu,
     Sidebar
-  },
-  computed: {
-    routeKey() {
-      const path = this.$route.path;
-      const key = this.get(this.$route.query, 'reloadRouteKey');
-      return key ? `${path}${key}` : path;
-    }
   }
 };
 </script>

--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -10,9 +10,10 @@ export default {
     extend: _.extend,
     filterList: _.filter,
     find: _.find,
+    flatten: _.flatten,
     focusModalById: id =>
       document.getElementById(id) && document.getElementById(id).focus(),
-    flatten: _.flatten,
+    forceUniquePath: routePath => `${routePath}?_=${new Date().getTime()}`,
     get: _.get,
     includes: _.includes,
     inRange: _.inRange,
@@ -35,7 +36,6 @@ export default {
         }, 500);
       });
     },
-    reloadRouteKey: () => new Date().getTime(),
     remove: _.remove,
     setPageTitle: phrase =>
       (document.title = `${phrase || 'UC Berkeley'} | BOAC`),

--- a/src/router.ts
+++ b/src/router.ts
@@ -85,13 +85,6 @@ const router = new Router({
           }
         },
         {
-          path: '/create_cohort',
-          component: Cohort,
-          meta: {
-            title: 'Create Cohort'
-          }
-        },
-        {
           path: '/course/:termId/:sectionId',
           component: Course,
           meta: {

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -31,10 +31,6 @@ const getters = {
 };
 
 const mutations = {
-  logout: (state: any) => {
-    state.isUserAuthenticated = false;
-    state.user = null;
-  },
   registerUser: (state: any, user: any) => {
     state.isUserAuthenticated = user.isAuthenticated;
     if (user.uid) {

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -291,15 +291,14 @@
            <div v-if="section.totalStudentCount > pagination.itemsPerPage">
              <span class="sr-only"><span id="total-student-count">{{ section.totalStudentCount / pagination.itemsPerPage | ceil }}</span>
                pages of search results</span>
-             <b-pagination
-               id="pagination-widget"
-               size="md"
-               :total-rows="section.totalStudentCount"
-               :limit="20"
-               v-model="pagination.currentPage"
-               :per-page="pagination.itemsPerPage"
-               :hide-goto-end-buttons="true"
-               @input="nextPage()">
+             <b-pagination id="pagination-widget"
+                           size="md"
+                           :total-rows="section.totalStudentCount"
+                           :limit="20"
+                           v-model="pagination.currentPage"
+                           :per-page="pagination.itemsPerPage"
+                           :hide-goto-end-buttons="true"
+                           @input="nextPage()">
              </b-pagination>
            </div>
          </div>

--- a/src/views/cohort/Cohort.vue
+++ b/src/views/cohort/Cohort.vue
@@ -99,9 +99,9 @@ export default {
       this.setPageTitle(this.cohortName);
       this.loaded();
     } else {
-      let id = this.get(this.$route, 'params.id');
+      let id = parseInt(this.get(this.$route, 'params.id'));
       this.init({
-        id,
+        id: Number.isInteger(id) ? id : null,
         orderBy: this.preferences.sortBy
       }).then(() => {
         this.showFilters = !this.isCompactView;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1671

Sidebar links to `/create`, `/cohort` and `/curated` will always cause `router-view` reload. I also verified pagination on course and cohort pages.