### PR TITLE
BOAC-1320, if user edits filter then auto-cancel other filter row edit

### DIFF
--- a/src/components/cohort/CohortPageHeader.vue
+++ b/src/components/cohort/CohortPageHeader.vue
@@ -71,11 +71,11 @@
                variant="link"
                :aria-label="`isCompactView ? 'Show cohort filters' : 'Hide cohort filters'`"
                @click="toggleShowHideDetails()"
-               v-if="cohortId">
+               v-if="cohortId && size(filters)">
           {{isCompactView ? 'Show' : 'Hide'}} Filters
         </b-btn>
       </div>
-      <div class="faint-text" v-if="cohortId && isOwnedByCurrentUser">|</div>
+      <div class="faint-text" v-if="cohortId && isOwnedByCurrentUser && size(filters)">|</div>
       <div v-if="cohortId && isOwnedByCurrentUser">
         <b-btn id="rename-button"
                class="pl-2 pr-2 pt-0"

--- a/src/store/modules/cohort-edit-session.ts
+++ b/src/store/modules/cohort-edit-session.ts
@@ -9,7 +9,7 @@ import { getCohortFilterOptions, translateToMenu } from '@/api/menu';
 import router from '@/router';
 import store from '@/store';
 
-const EDIT_MODE_TYPES = [null, 'add', 'apply', 'edit', 'rename'];
+const EDIT_MODE_TYPES = ['add', 'apply', 'edit-[0-9]+', 'rename'];
 
 const state = {
   cohortId: undefined,
@@ -57,7 +57,10 @@ const mutations = {
   isCompactView: (state: any, compactView: boolean) =>
     (state.isCompactView = compactView),
   setEditMode(state: any, editMode: string) {
-    if (_.includes(EDIT_MODE_TYPES, editMode)) {
+    if (_.isNil(editMode)) {
+      state.editMode = null;
+    } else if (_.find(EDIT_MODE_TYPES, type => editMode.match(type))) {
+      // Valid mode
       state.editMode = editMode;
     } else {
       throw new TypeError('Invalid page mode: ' + editMode);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1320

I'm tossing out the use of `this.$eventHub.$on` when it comes to state management in filter rows – each row allows add/edit/remove of filter – in favor of a more intuitive use of `EDIT_MODE_TYPES`.  (We keep `editMode` value in Vuex store.)