### PR TITLE
BOAC-1691, render view only after not loading and simplify Search view/component

### DIFF
--- a/src/components/curated/CuratedGroupHeader.vue
+++ b/src/components/curated/CuratedGroupHeader.vue
@@ -77,6 +77,7 @@
           </div>
           <div slot="modal-footer">
             <b-btn id="delete-confirm"
+                   class="btn-primary-color-override"
                    variant="primary"
                    @click="deleteGroup">
               Delete

--- a/src/components/sidebar/SearchStudents.vue
+++ b/src/components/sidebar/SearchStudents.vue
@@ -27,10 +27,11 @@
 </template>
 
 <script>
-import _ from 'lodash';
+import Util from '@/mixins/Util';
 
 export default {
   name: 'SearchStudents',
+  mixins: [Util],
   props: {
     withButton: Boolean
   },
@@ -42,11 +43,14 @@ export default {
   },
   methods: {
     search() {
-      this.searchPhrase = _.trim(this.searchPhrase);
+      this.searchPhrase = this.trim(this.searchPhrase);
       if (this.searchPhrase) {
         this.$router.push({
-          path: '/search',
-          query: { q: this.searchPhrase, includeCourses: 'true' }
+          path: this.forceUniquePath('/search'),
+          query: {
+            q: this.searchPhrase,
+            includeCourses: 'true'
+          }
         });
       }
     }

--- a/src/mixins/Loading.vue
+++ b/src/mixins/Loading.vue
@@ -1,6 +1,6 @@
 <script>
 import store from '@/store';
-import { mapGetters } from 'vuex';
+import { mapActions, mapGetters } from 'vuex';
 
 export default {
   name: 'Loading',
@@ -9,7 +9,7 @@ export default {
     ...mapGetters('context', ['loading'])
   },
   methods: {
-    startLoading: () => store.dispatch('context/loadingStart'),
+    ...mapActions('context', ['loadingStart']),
     loaded() {
       store.dispatch('context/loadingComplete');
       this.$nextTick(() => {

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -1,15 +1,10 @@
 <template>
   <div class="m-3">
     <Spinner/>
-    <div v-if="error">
-      <h1 role="alert" aria-live="passive">Error</h1>
-      <div class="faint-text">
-        <span role="alert" aria-live="passive" v-if="error.message">{{ error.message }}</span>
-        <span role="alert" aria-live="passive" v-if="!error.message">Sorry, there was an error retrieving data.</span>
-      </div>
-    </div>
-    <div v-if="!loading && !error && !results.totalStudentCount && !results.totalCourseCount">
-      <h1 role="alert" aria-live="passive">No results matching '{{ phrase }}'</h1>
+    <div v-if="!loading && !results.totalStudentCount && !results.totalCourseCount">
+      <h1 id="page-header-no-results"
+          role="alert"
+          aria-live="passive">No results matching '{{ phrase }}'</h1>
       <div>Suggestions:</div>
       <ul>
         <li>Keep your search term simple.</li>
@@ -18,16 +13,15 @@
         <li>Abbreviations of section titles may not return results; <strong>COMPSCI 161</strong> instead of <strong>CS 161</strong>.</li>
       </ul>
     </div>
-    <div tabindex="0"
-         :v-focus-if="!loading && results.totalStudentCount">
-      <div v-if="!loading && !error && results.totalStudentCount">
-        <h1>{{ 'student' | pluralize(results.totalStudentCount) }} matching '{{ phrase }}'</h1>
-        <div v-if="results.totalStudentCount > limit">
-          Showing the first {{ limit }} students.
-        </div>
+    <div id="page-header"
+         tabindex="0"
+         v-if="!loading && results.totalStudentCount">
+      <h1 ref="pageHeader">{{ 'student' | pluralize(results.totalStudentCount) }} matching '{{ phrase }}'</h1>
+      <div v-if="results.totalStudentCount > limit">
+        Showing the first {{ limit }} students.
       </div>
     </div>
-    <div class="cohort-column-results" v-if="!loading && !error && results.totalStudentCount">
+    <div class="cohort-column-results" v-if="!loading && results.totalStudentCount">
       <div class="search-header-curated-cohort">
         <CuratedGroupSelector :students="results.students"/>
       </div>
@@ -35,36 +29,28 @@
         <SortableStudents :students="results.students" :options="studentListOptions"/>
       </div>
     </div>
-    <SortableCourseList :searchPhrase="phrase"
-                        :courses="results.courses"
-                        :totalCourseCount="results.totalCourseCount"
-                        :renderPrimaryHeader="!results.totalStudentCount && !!results.totalCourseCount"
-                        v-if="!loading"/>
+    <div v-if="!loading && results.totalCourseCount">
+      <SortableCourseList :searchPhrase="phrase"
+                          :courses="results.courses"
+                          :totalCourseCount="results.totalCourseCount"
+                          :renderPrimaryHeader="!results.totalStudentCount && !!results.totalCourseCount"/>
+    </div>
   </div>
 </template>
 
 <script>
-import _ from 'lodash';
 import CuratedGroupSelector from '@/components/curated/CuratedGroupSelector';
 import Loading from '@/mixins/Loading';
 import SortableCourseList from '@/components/course/SortableCourseList';
 import SortableStudents from '@/components/search/SortableStudents';
 import Spinner from '@/components/util/Spinner';
 import UserMetadata from '@/mixins/UserMetadata';
+import Util from '@/mixins/Util';
 import { search } from '@/api/student';
 
 export default {
   name: 'Search',
-  beforeRouteUpdate(to, from, next) {
-    let phrase = _.trim(to.query.q);
-    let includeCourses = _.trim(to.query.includeCourses);
-    if (phrase) {
-      this.startLoading();
-      this.performSearch(phrase, includeCourses);
-    }
-    next();
-  },
-  mixins: [Loading, UserMetadata],
+  mixins: [Loading, UserMetadata, Util],
   components: {
     SortableCourseList,
     CuratedGroupSelector,
@@ -72,10 +58,6 @@ export default {
     Spinner
   },
   data: () => ({
-    error: null,
-    inactiveAsc: undefined,
-    includeCourses: undefined,
-    isInactiveCoe: undefined,
     limit: 50,
     phrase: null,
     results: {
@@ -92,39 +74,33 @@ export default {
   }),
   created() {
     this.phrase = this.$route.query.q;
-    this.includeCourses = this.$route.query.includeCourses;
-    this.performSearch();
-  },
-  methods: {
-    performSearch(phrase, includeCourses) {
-      this.phrase = phrase || this.phrase;
-      this.includeCourses = _.isNil(includeCourses)
-        ? this.includeCourses
-        : includeCourses;
-      if (this.phrase) {
-        // In arrow function below, 'this' does NOT reference Search component. Using 'self' as an alias is sufficient.
-        const self = this;
-        search(
-          this.phrase,
-          this.includeCourses,
-          this.isAscUser ? false : null,
-          this.isCoeUser ? false : null
-        )
-          .then(data => {
-            self.results.courses = data.courses;
-            self.results.students = data.students;
-            _.each(self.results.students, student => {
-              student.alertCount = student.alertCount || 0;
-              student.term = student.term || {};
-              student.term.enrolledUnits = student.term.enrolledUnits || 0;
-            });
-            self.results.totalCourseCount = data.totalCourseCount;
-            self.results.totalStudentCount = data.totalStudentCount;
-          })
-          .then(() => {
-            self.loaded();
+    const includeCourses = this.$route.query.includeCourses;
+    if (this.phrase) {
+      search(
+        this.phrase,
+        this.isNil(includeCourses) ? false : includeCourses,
+        this.isAscUser ? false : null,
+        this.isCoeUser ? false : null
+      )
+        .then(data => {
+          this.results.courses = data.courses;
+          this.results.students = data.students;
+          this.each(this.results.students, student => {
+            student.alertCount = student.alertCount || 0;
+            student.term = student.term || {};
+            student.term.enrolledUnits = student.term.enrolledUnits || 0;
           });
-      }
+          this.results.totalCourseCount = data.totalCourseCount;
+          this.results.totalStudentCount = data.totalStudentCount;
+        })
+        .then(() => {
+          this.loaded();
+          const focusId =
+            this.results.totalCourseCount || this.results.totalStudentCount
+              ? 'page-header'
+              : 'page-header-no-results';
+          this.putFocusNextTick(focusId);
+        });
     }
   }
 };


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1691

`Search.vue` was one of the first views cut to Vue and it shows.  Use of `beforeRouteUpdate()` is not necessary if we force unique path from the sidebar. 

Use `?w=1` to get simpler diff.