### PR TITLE
BOAC-1703: enables pagination arrows and scopes styles

### DIFF
--- a/src/components/curated/CuratedStudentCheckbox.vue
+++ b/src/components/curated/CuratedStudentCheckbox.vue
@@ -42,9 +42,3 @@ export default {
   }
 };
 </script>
-
-<style>
-.form-check-inline {
-  margin: 0;
-}
-</style>

--- a/src/components/home/HomeCohort.vue
+++ b/src/components/home/HomeCohort.vue
@@ -101,10 +101,7 @@ export default {
 };
 </script>
 
-<style>
-.panel-group {
-  margin-bottom: 20px;
-}
+<style scoped>
 .panel-group .panel + .panel {
   margin-top: 5px;
 }

--- a/src/components/student/StudentAlerts.vue
+++ b/src/components/student/StudentAlerts.vue
@@ -90,7 +90,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .student-alert {
   margin: 10px 0;
   padding: 5px 15px;

--- a/src/components/student/StudentUnitsChart.vue
+++ b/src/components/student/StudentUnitsChart.vue
@@ -159,10 +159,10 @@ export default {
   transform: rotate(135deg);
   width: 10px;
 }
-.swatch-blue-medium {
+.student-chart-units-container .swatch-blue-medium {
   background-color: #aec9eb;
 }
-.swatch-blue-light {
+.student-chart-units-container .swatch-blue-light {
   background-color: #d6e4f9;
 }
 </style>

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -297,7 +297,6 @@
                            :limit="20"
                            v-model="pagination.currentPage"
                            :per-page="pagination.itemsPerPage"
-                           :hide-goto-end-buttons="true"
                            @input="nextPage()">
              </b-pagination>
            </div>
@@ -658,11 +657,5 @@ export default {
 #content .page-item.active .page-link {
   background-color: #337ab7;
   border-color: #337ab7;
-}
-
-/* Hide default first/last buttons in bootstrap-vue pagination widget. */
-#content ul.pagination li:first-child,
-#content ul.pagination li:last-child {
-  display: none;
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -69,7 +69,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .panel-group {
   margin-bottom: 20px;
 }

--- a/src/views/cohort/Cohort.vue
+++ b/src/views/cohort/Cohort.vue
@@ -47,7 +47,6 @@
                             :limit="10"
                             v-model="pageNumber"
                             :per-page="pagination.itemsPerPage"
-                            :hide-goto-end-buttons="true"
                             @input="nextPage()">
               </b-pagination>
             </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1703

The Bootstrap-Vue pagination widget works differently than Angular's - the ellipsis is not meant to be clickable.  Instead, pages 11-_n_ can be accessed via the arrow buttons (first, previous, next, and last).

I also realized that unless `scoped` is specified, anything in the `<style>...</style>` section of a component applies to the entire app.