### PR TITLE
BOAC-1643 Add physics dept to advising groups

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -85,6 +85,10 @@ def intermediate_schema():
     return app.config['DATA_LOCH_INTERMEDIATE_SCHEMA']
 
 
+def physics_schema():
+    return app.config['DATA_LOCH_PHYSICS_SCHEMA']
+
+
 def sis_schema():
     return app.config['DATA_LOCH_SIS_SCHEMA']
 
@@ -521,6 +525,7 @@ def _student_query_tables_for_scope(scope):
         schemas_for_codes = {
             'UWASC': asc_schema(),
             'COENG': coe_schema(),
+            'PHYSI': physics_schema(),
         }
         tables = []
         # A dictionary with key 'intersection' indicates that multiple scopes should be treated as an intersection

--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -181,6 +181,7 @@ COE_ETHNICITIES_PER_CODE = {
 BERKELEY_DEPT_NAME_TO_CODE = {
     'Athletic Study Center': 'UWASC',
     'College of Engineering': 'COENG',
+    'Department of Physics': 'PHYSI',
 }
 
 

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -72,6 +72,13 @@ _users_per_dept = {
             'is_director': False,
         },
     ],
+    'PHYSI': [
+        {
+            'uid': '53791',
+            'is_advisor': False,
+            'is_director': True,
+        },
+    ],
     'UWASC': [
         {
             'uid': '1081940',

--- a/config/default.py
+++ b/config/default.py
@@ -84,6 +84,7 @@ DATA_LOCH_ASC_SCHEMA = 'boac_advising_asc'
 DATA_LOCH_BOAC_SCHEMA = 'boac_analytics'
 DATA_LOCH_COE_SCHEMA = 'boac_advising_coe'
 DATA_LOCH_INTERMEDIATE_SCHEMA = 'intermediate'
+DATA_LOCH_PHYSICS_SCHEMA = 'boac_advising_physics'
 DATA_LOCH_SIS_SCHEMA = 'sis_data'
 DATA_LOCH_STUDENT_SCHEMA = 'student'
 

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -602,12 +602,12 @@ class TestStudentAnalytics:
         for term in authenticated_response.json['enrollmentTerms']:
             assert len(term['enrollments']) > 0
             for course in term['enrollments']:
-                for canvasSite in course['canvasSites']:
-                    assert canvasSite['canvasCourseId']
-                    assert canvasSite['courseCode']
-                    assert canvasSite['courseTerm']
-                    assert canvasSite['courseCode']
-                    assert canvasSite['analytics']
+                for canvas_site in course['canvasSites']:
+                    assert canvas_site['canvasCourseId']
+                    assert canvas_site['courseCode']
+                    assert canvas_site['courseTerm']
+                    assert canvas_site['courseCode']
+                    assert canvas_site['analytics']
 
     def test_user_analytics_holds(self, asc_advisor, client):
         """Returns holds if any."""

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -204,13 +204,15 @@ class TestAuthorizedUserGroups:
         response = client.get('/api/users/authorized_groups')
         assert response.status_code == 200
         user_groups = sorted(response.json, key=lambda g: g['code'])
-        assert len(user_groups) == 3
+        assert len(user_groups) == 4
         assert user_groups[0]['name'] == 'Admins'
         assert len(user_groups[0]['users']) == 8
         assert user_groups[1]['name'] == 'College of Engineering'
         assert len(user_groups[1]['users']) == 3
-        assert user_groups[2]['name'] == 'Athletic Study Center'
-        assert len(user_groups[2]['users']) == 2
+        assert user_groups[2]['name'] == 'Department of Physics'
+        assert len(user_groups[2]['users']) == 1
+        assert user_groups[3]['name'] == 'Athletic Study Center'
+        assert len(user_groups[3]['users']) == 2
 
 
 class TestDemoMode:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1643

I thought this was going to be more complicated, but apparently we designed it right the first time. Creation of department and user records in the database will be handled via scripts under release instructions.