### PR TITLE
BOAC-1723, structural change to /api/alerts json: 'dismissed' prop on all alert objects

### DIFF
--- a/boac/api/alerts_controller.py
+++ b/boac/api/alerts_controller.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from boac.lib.http import tolerant_jsonify
 from boac.models.alert import Alert
 from flask import current_app as app

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -180,18 +180,17 @@ class Alert(Base):
             ORDER BY alerts.created_at
         """)
         results = db.session.execute(query, {'viewer_id': viewer_id, 'key': current_term_id() + '_%', 'sid': sid})
+        feed = []
 
         def result_to_dict(result):
             return {camelize(key): result[key] for key in ['id', 'alert_type', 'key', 'message']}
-        feed = {
-            'dismissed': [],
-            'shown': [],
-        }
         for result in results:
-            if result['dismissed_at']:
-                feed['dismissed'].append(result_to_dict(result))
-            else:
-                feed['shown'].append(result_to_dict(result))
+            dismissed_at = result['dismissed_at']
+            alert = {
+                **result_to_dict(result),
+                **{'dismissed': dismissed_at and dismissed_at.strftime('%Y-%m-%d %H:%M:%S')},
+            }
+            feed.append(alert)
         return feed
 
     def activate(self):

--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -43,6 +43,7 @@ export default {
     setPageTitle: phrase =>
       (document.title = `${phrase || 'UC Berkeley'} | BOAC`),
     size: _.size,
+    slice: _.slice,
     trim: _.trim
   }
 };

--- a/tests/test_api/test_alerts_controller.py
+++ b/tests/test_api/test_alerts_controller.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from boac.models.alert import Alert
 
 admin_uid = '2040'
@@ -31,6 +30,10 @@ coe_advisor = '1133399'
 
 
 class TestAlertsController:
+
+    @classmethod
+    def _get_dismissed(cls, alerts):
+        return list(filter(lambda a: a['dismissed'], alerts))
 
     def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
@@ -41,43 +44,47 @@ class TestAlertsController:
         fake_auth.login(admin_uid)
         response = client.get('/api/alerts/current/11667051')
         assert response.status_code == 200
-        assert len(response.json['shown']) == 3
-        assert len(response.json['dismissed']) == 0
-        assert response.json['shown'][0]['alertType'] == 'late_assignment'
-        assert response.json['shown'][0]['key'] == '2178_800900300'
-        assert response.json['shown'][0]['message'] == 'Week 5 homework in RUSSIAN 13 is late.'
-        assert response.json['shown'][1]['alertType'] == 'missing_assignment'
-        assert response.json['shown'][1]['key'] == '2178_500600700'
-        assert response.json['shown'][1]['message'] == 'Week 6 homework in PORTUGUESE 12 is missing.'
-        assert response.json['shown'][2]['alertType'] == 'midterm'
-        assert response.json['shown'][2]['key'] == '2178_90100'
-        assert response.json['shown'][2]['message'] == 'BURMESE 1A midterm grade of D+.'
+        alerts = response.json
+        assert len(alerts) == 3
+        assert alerts[0]['alertType'] == 'late_assignment'
+        assert alerts[0]['key'] == '2178_800900300'
+        assert alerts[0]['message'] == 'Week 5 homework in RUSSIAN 13 is late.'
+        assert not alerts[0]['dismissed']
+        assert alerts[1]['alertType'] == 'missing_assignment'
+        assert alerts[1]['key'] == '2178_500600700'
+        assert alerts[1]['message'] == 'Week 6 homework in PORTUGUESE 12 is missing.'
+        assert not alerts[1]['dismissed']
+        assert alerts[2]['alertType'] == 'midterm'
+        assert alerts[2]['key'] == '2178_90100'
+        assert alerts[2]['message'] == 'BURMESE 1A midterm grade of D+.'
+        assert not alerts[2]['dismissed']
 
     def test_dismiss_alerts(self, create_alerts, fake_auth, client):
         """Can dismiss alerts for one user without affecting visibility for other users."""
         fake_auth.login(admin_uid)
         advisor_1_deborah_alerts = client.get('/api/alerts/current/11667051').json
-        assert len(advisor_1_deborah_alerts['shown']) == 3
-        assert len(advisor_1_deborah_alerts['dismissed']) == 0
-        alert_id = advisor_1_deborah_alerts['shown'][0]['id']
+        assert len(advisor_1_deborah_alerts) == 3
+        for alert in advisor_1_deborah_alerts:
+            assert not alert['dismissed']
+        alert_id = advisor_1_deborah_alerts[0]['id']
         response = client.get('/api/alerts/' + str(alert_id) + '/dismiss')
         assert response.status_code == 200
         assert response.json['message'] == 'Alert ' + str(alert_id) + ' dismissed by UID 2040'
 
         advisor_1_deborah_alerts = client.get('/api/alerts/current/11667051').json
-        assert len(advisor_1_deborah_alerts['shown']) == 2
-        assert len(advisor_1_deborah_alerts['dismissed']) == 1
+        assert len(advisor_1_deborah_alerts) == 3
+        assert len(self._get_dismissed(advisor_1_deborah_alerts)) == 1
 
         fake_auth.login(coe_advisor)
         advisor_2_deborah_alerts = client.get('/api/alerts/current/11667051').json
-        assert len(advisor_2_deborah_alerts['shown']) == 3
-        assert len(advisor_2_deborah_alerts['dismissed']) == 0
+        assert len(advisor_2_deborah_alerts) == 3
+        assert len(self._get_dismissed(advisor_2_deborah_alerts)) == 0
 
     def test_duplicate_dismiss_alerts(self, create_alerts, fake_auth, client):
         """Shrugs off duplicate dismissals."""
         fake_auth.login(admin_uid)
         advisor_1_deborah_alerts = client.get('/api/alerts/current/11667051').json
-        alert_id = advisor_1_deborah_alerts['shown'][0]['id']
+        alert_id = advisor_1_deborah_alerts[0]['id']
         response = client.get('/api/alerts/' + str(alert_id) + '/dismiss')
         assert response.status_code == 200
         response = client.get('/api/alerts/' + str(alert_id) + '/dismiss')
@@ -96,12 +103,12 @@ class TestAlertsController:
 
         fake_auth.login(admin_uid)
         advisor_1_deborah_alerts = client.get('/api/alerts/current/11667051').json
-        assert len(advisor_1_deborah_alerts['shown']) == 2
-        assert advisor_1_deborah_alerts['shown'][0]['key'] == '2178_500600700'
-        assert len(advisor_1_deborah_alerts['dismissed']) == 0
+        assert len(advisor_1_deborah_alerts) == 2
+        assert advisor_1_deborah_alerts[0]['key'] == '2178_500600700'
+        assert len(self._get_dismissed(advisor_1_deborah_alerts)) == 0
 
         fake_auth.login(coe_advisor)
         advisor_2_deborah_alerts = client.get('/api/alerts/current/11667051').json
-        assert len(advisor_2_deborah_alerts['shown']) == 2
-        assert advisor_2_deborah_alerts['shown'][0]['key'] == '2178_500600700'
-        assert len(advisor_2_deborah_alerts['dismissed']) == 0
+        assert len(advisor_2_deborah_alerts) == 2
+        assert advisor_2_deborah_alerts[0]['key'] == '2178_500600700'
+        assert len(self._get_dismissed(advisor_1_deborah_alerts)) == 0

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from boac import std_commit
 from boac.models.alert import Alert
 from boac.models.cohort_filter import CohortFilter
@@ -38,7 +37,7 @@ class TestCacheUtils:
     def test_creates_alert_for_midterm_grade(self, app):
         from boac.api.cache_utils import refresh_alerts
         refresh_alerts(2178)
-        alerts = Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')['shown']
+        alerts = Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')
         assert 1 == len(alerts)
         assert 0 < alerts[0]['id']
         assert 'midterm' == alerts[0]['alertType']

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -110,9 +110,9 @@ class TestCohortDetail:
         assert dave_doolittle['lastName']
         assert dave_doolittle['alertCount'] == 1
 
-        alert_to_dismiss = client.get('/api/alerts/current/11667051').json['shown'][0]['id']
+        alert_to_dismiss = client.get('/api/alerts/current/11667051').json[0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
-        alert_to_dismiss = client.get('/api/alerts/current/2345678901').json['shown'][0]['id']
+        alert_to_dismiss = client.get('/api/alerts/current/2345678901').json[0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
 
         students_with_alerts = client.get(f'/api/cohort/{cohort_id}/students_with_alerts').json

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -117,7 +117,7 @@ class TestMyCuratedCohorts:
         assert len(students_with_alerts) == 2
         assert students_with_alerts[0]['alertCount'] == 3
 
-        alert_to_dismiss = client.get('/api/alerts/current/11667051').json['shown'][0]['id']
+        alert_to_dismiss = client.get('/api/alerts/current/11667051').json[0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
         students_with_alerts = client.get(f'/api/curated_group/{cohort_id}/students_with_alerts').json
         assert students_with_alerts[0]['alertCount'] == 2

--- a/tests/test_models/test_alert.py
+++ b/tests/test_models/test_alert.py
@@ -23,14 +23,14 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from boac.models.alert import Alert
 import pytest
 from tests.util import override_config
 
 
 def get_current_alerts(sid):
-    return Alert.current_alerts_for_sid(sid=sid, viewer_id='2040')['shown']
+    alerts = Alert.current_alerts_for_sid(sid=sid, viewer_id='2040')
+    return list(filter(lambda a: not a['dismissed'], alerts))
 
 
 alert_props = {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1723

Suitable to new UX paradigm.