### PR TITLE
BOAC-1771, client-side notes.ts to match /api/notes; was_read() added

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -40,3 +40,12 @@ def notes_per_student(sid):
 @login_required
 def get_note(note_id):
     return tolerant_jsonify(get_advising_note(note_id))
+
+
+@app.route('/api/notes/was_read/<note_id>', methods=['POST'])
+@login_required
+def was_read(note_id):
+    # TODO
+    return tolerant_jsonify({
+        'noteId': note_id,
+    })

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import store from '@/store';
+
+export function getNotes(sid) {
+  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+  return axios
+    .get(`${apiBaseUrl}/api/notes/student/${sid}`)
+    .then(response => response.data, () => null);
+}
+
+export function getNote(noteId) {
+  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+  return axios
+    .get(`${apiBaseUrl}/api/notes/${noteId}`)
+    .then(response => response.data, () => null);
+}
+
+export function wasRead(noteId) {
+  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+  return axios
+    .post(`${apiBaseUrl}/api/notes/was_read/${noteId}`)
+    .then(response => response.data, () => null);
+}

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 coe_advisor = '1133399'
 
 
-class TestNotesController:
+class TestGetNotes:
 
     def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
@@ -43,3 +43,17 @@ class TestNotesController:
         fake_auth.login(coe_advisor)
         response = client.get('/api/notes/123')
         assert response.status_code == 200
+
+
+class TestUpdateNotes:
+
+    def test_not_authenticated(self, client):
+        """Returns 401 if not authenticated."""
+        assert client.post('/api/notes/was_read/123').status_code == 401
+
+    def test_note_was_read(self, fake_auth, client):
+        """Returns advising notes per SID."""
+        fake_auth.login(coe_advisor)
+        response = client.post('/api/notes/was_read/123')
+        assert response.status_code == 200
+        assert int(response.json['noteId']) == 123


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1771
