### PR TITLE
BOAC-1788, refactor to put alerts/holds/etc. under student['notifications']

### DIFF
--- a/boac/api/alerts_controller.py
+++ b/boac/api/alerts_controller.py
@@ -29,13 +29,6 @@ from flask import current_app as app
 from flask_login import current_user, login_required
 
 
-@app.route('/api/alerts/current/<sid>')
-@login_required
-def get_current_alerts_for_sid(sid):
-    alerts = Alert.current_alerts_for_sid(viewer_id=current_user.id, sid=sid)
-    return tolerant_jsonify(alerts)
-
-
 @app.route('/api/alerts/<alert_id>/dismiss')
 @login_required
 def dismiss_alert(alert_id):

--- a/boac/api/student_controller.py
+++ b/boac/api/student_controller.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from itertools import islice
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import add_alert_counts, is_asc_authorized, is_unauthorized_search
+from boac.api.util import add_alert_counts, is_asc_authorized, is_unauthorized_search, put_notifications
 from boac.externals.cal1card_photo_api import get_cal1card_photo
 from boac.externals.data_loch import get_enrolled_primary_sections
 from boac.lib import util
@@ -39,15 +39,16 @@ from flask import current_app as app, request, Response
 from flask_login import current_user, login_required
 
 
-@app.route('/api/student/<uid>/analytics')
+@app.route('/api/student/<uid>')
 @login_required
-def user_analytics(uid):
-    feed = get_student_and_terms(uid)
-    if not feed:
+def get_student(uid):
+    student = get_student_and_terms(uid)
+    if not student:
         raise ResourceNotFoundError('Unknown student')
+    put_notifications(student)
     # CalCentral's Student Overview page is advisors' official information source for the student.
-    feed['studentProfileLink'] = f'https://calcentral.berkeley.edu/user/overview/{uid}'
-    return tolerant_jsonify(feed)
+    student['studentProfileLink'] = f'https://calcentral.berkeley.edu/user/overview/{uid}'
+    return tolerant_jsonify(student)
 
 
 @app.route('/api/student/<uid>/photo')

--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -220,15 +220,6 @@ def get_student_and_terms(uid):
         else:
             # Omit dropped sections for past terms.
             term.pop('droppedSections', None)
-    holds_for_sid = data_loch.get_sis_holds(student['sid'])
-    profile['holds'] = []
-    for hold in holds_for_sid:
-        hold_feed = json.loads(hold['feed'])
-        profile['holds'].append({
-            'type': hold_feed.get('type'),
-            'reason': hold_feed.get('reason'),
-            'date': hold_feed.get('fromDate'),
-        })
     return profile
 
 

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -186,12 +186,12 @@ class Alert(Base):
             return {camelize(key): result[key] for key in ['id', 'alert_type', 'key', 'message']}
         for result in results:
             dismissed_at = result['dismissed_at']
-            updated_at = result['updated_at']
             alert = {
                 **result_to_dict(result),
                 **{
                     'dismissed': dismissed_at and dismissed_at.strftime('%Y-%m-%d %H:%M:%S'),
-                    'updatedAt': updated_at.strftime('%Y-%m-%d %H:%M:%S'),
+                    'createdAt': result['created_at'].strftime('%Y-%m-%d %H:%M:%S'),
+                    'updatedAt': result['updated_at'].strftime('%Y-%m-%d %H:%M:%S'),
                 },
             }
             feed.append(alert)

--- a/src/api/student.ts
+++ b/src/api/student.ts
@@ -9,17 +9,10 @@ export function dismissStudentAlert(alertId: string) {
     .then(response => response.data, () => null);
 }
 
-export function getStudentAlerts(sid: string) {
+export function getStudent(uid: string) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
-    .get(`${apiBaseUrl}/api/alerts/current/${sid}`)
-    .then(response => response.data, () => null);
-}
-
-export function getStudentDetails(uid: string) {
-  let apiBaseUrl = store.getters['context/apiBaseUrl'];
-  return axios
-    .get(`${apiBaseUrl}/api/student/${uid}/analytics`)
+    .get(`${apiBaseUrl}/api/student/${uid}`)
     .then(response => response.data, () => null);
 }
 

--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -21,6 +21,7 @@ export default {
     inRange: _.inRange,
     isEmpty: _.isEmpty,
     isNil: _.isNil,
+    keys: _.keys,
     map: _.map,
     mapValues: _.mapValues,
     merge: _.merge,

--- a/src/views/Student.vue
+++ b/src/views/Student.vue
@@ -18,6 +18,13 @@
       </div>
       <div class="m-3">
         <AcademicTimeline :student="student"/>
+        <div v-if="student.sisProfile.withdrawalCancel">
+          <span class="red-flag-small">
+            {{ student.sisProfile.withdrawalCancel.description }}
+            ({{ student.sisProfile.withdrawalCancel.reason }})
+            {{ student.sisProfile.withdrawalCancel.date | date }}
+          </span>
+        </div>
       </div>
       <div>
         <StudentClasses :student="student"/>
@@ -35,7 +42,7 @@ import StudentProfileGPA from '@/components/student/profile/StudentProfileGPA';
 import StudentProfileHeader from '@/components/student/profile/StudentProfileHeader';
 import StudentProfileUnits from '@/components/student/profile/StudentProfileUnits';
 import Util from '@/mixins/Util';
-import { getStudentDetails } from '@/api/student';
+import { getStudent } from '@/api/student';
 
 export default {
   name: 'Student',
@@ -56,7 +63,7 @@ export default {
   }),
   created() {
     const uid = this.get(this.$route, 'params.uid');
-    getStudentDetails(uid).then(data => {
+    getStudent(uid).then(data => {
       if (data) {
         this.setPageTitle(data.name);
         this.assign(this.student, data);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ def create_alerts(client, db_session):
         message='Week 5 homework in BOSCRSR 27B is late.',
     )
     # Load our usual student of interest into the cache and generate midterm alerts from fixture data.
-    client.get('/api/student/61889/analytics')
+    client.get('/api/student/61889')
     Alert.update_all_for_term(2178)
 
 

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -79,8 +79,8 @@ class TestCohortDetail:
 
     def test_students_with_alert_counts(self, asc_advisor_session, client, create_alerts, db_session):
         # Pre-load students into cache for consistent alert data.
-        client.get('/api/student/61889/analytics')
-        client.get('/api/student/98765/analytics')
+        client.get('/api/student/61889')
+        client.get('/api/student/98765')
         from boac.models.alert import Alert
         Alert.update_all_for_term(2178)
         cohorts = CohortFilter.all_owned_by(asc_advisor_uid)
@@ -110,9 +110,14 @@ class TestCohortDetail:
         assert dave_doolittle['lastName']
         assert dave_doolittle['alertCount'] == 1
 
-        alert_to_dismiss = client.get('/api/alerts/current/11667051').json[0]['id']
+        def _get_alerts(uid):
+            response = client.get(f'/api/student/{uid}')
+            assert response.status_code == 200
+            return response.json['notifications']['alert']
+
+        alert_to_dismiss = _get_alerts(61889)[0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
-        alert_to_dismiss = client.get('/api/alerts/current/2345678901').json[0]['id']
+        alert_to_dismiss = _get_alerts(98765)[0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
 
         students_with_alerts = client.get(f'/api/cohort/{cohort_id}/students_with_alerts').json

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -117,7 +117,8 @@ class TestMyCuratedCohorts:
         assert len(students_with_alerts) == 2
         assert students_with_alerts[0]['alertCount'] == 3
 
-        alert_to_dismiss = client.get('/api/alerts/current/11667051').json[0]['id']
+        student = client.get('/api/student/61889').json
+        alert_to_dismiss = student['notifications']['alert'][0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
         students_with_alerts = client.get(f'/api/curated_group/{cohort_id}/students_with_alerts').json
         assert students_with_alerts[0]['alertCount'] == 2


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1788

A substantial refactor allowed for a lot of code removal and faster page load. Plus, having alerts/holds/etc. bundled in one spot is more intuitive.