### PR TITLE
BOAC-1737, proper error messages on /login

### DIFF
--- a/src/components/admin/DemoModeToggle.vue
+++ b/src/components/admin/DemoModeToggle.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="user.isAdmin && devAuthEnabled && inDemoMode !== null">
+  <div v-if="inDemoMode !== null">
     <h2 class="page-section-header-sub">Demo Mode</h2>
     <div class="p-2">
       <span
@@ -24,13 +24,12 @@
 </template>
 
 <script>
-import Context from '@/mixins/Context';
 import UserMetadata from '@/mixins/UserMetadata';
 import { setDemoMode } from '@/api/user';
 
 export default {
   name: 'DemoModeToggle',
-  mixins: [Context, UserMetadata],
+  mixins: [UserMetadata],
   data: () => ({
     inDemoMode: null,
     isToggling: false

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -105,10 +105,11 @@
                     sr-prefix="Last updated on" />
                 </div>
                 <div v-if="message.updatedAt && (message.updatedAt !== message.createdAt)">
-                  <div class="text-muted">Updated:</div>
+                  <div class="mt-2 text-muted">Updated:</div>
                   <TimelineDate
                     :date="message.updatedAt"
                     :include-time-of-day="true"
+                    class="mb-2"
                     sr-prefix="Last updated on" />
                 </div>
               </div>

--- a/src/layouts/Login.vue
+++ b/src/layouts/Login.vue
@@ -13,10 +13,23 @@
             variant="primary"
             aria-label="Log in to BOAC"
             tabindex="0"
-            placement="top-left"
+            placement="top"
             @click.stop="logIn()">
             Sign In
           </b-btn>
+          <b-popover
+            placement="top"
+            target="splash-sign-in"
+            title=""
+            triggers="focus"
+            @hidden="onHidden">
+            <span
+              v-for="message in errorMessages"
+              :key="message"
+              class="has-error"
+              aria-live="polite"
+              v-html="message"></span>
+          </b-popover>
         </form>
         <div class="splash-contact-us">
           Questions or feedback? Contact us at
@@ -42,6 +55,7 @@
 <script>
 import Context from '@/mixins/Context';
 import DevAuth from '@/components/admin/DevAuth';
+import Util from '@/mixins/Util';
 import { getCasLoginURL } from '@/api/auth';
 
 export default {
@@ -49,10 +63,27 @@ export default {
   components: {
     DevAuth
   },
-  mixins: [Context],
+  mixins: [Context, Util],
+  data: () => ({
+    errorMessages: undefined
+  }),
+  created() {
+    this.errorCheck();
+    this.$eventHub.$on('error-reported', () => this.errorCheck());
+  },
   methods: {
+    errorCheck() {
+      if (this.size(this.errors)) {
+        this.errorMessages = this.map(this.errors, 'message');
+        this.putFocusNextTick('splash-sign-in');
+        this.clearErrorsInStore();
+      }
+    },
     logIn() {
       getCasLoginURL().then(data => (window.location.href = data.casLoginUrl));
+    },
+    onHidden() {
+      this.errorMessages = null;
     }
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,14 +18,12 @@ import { routerHistory, writeHistory } from 'vue-router-back-button';
 axios.defaults.withCredentials = true;
 axios.interceptors.response.use(response => response, function(error) {
   let status = error.response.status;
-  if (_.includes([401, 403, 404], status)) {
+  if (_.includes([404], status)) {
     router.push({ path: '/404' });
   } else {
     store.dispatch('context/reportError', {
-      message: error.message,
-      text: error.response.text,
-      status: status,
-      stack: error.stack
+      message: _.get(error.response, 'data.message') || error.message || `Request failed with status ${status}`,
+      status: status
     });
   }
   return Promise.reject(error);

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -13,7 +13,11 @@ export default {
     ])
   },
   methods: {
-    ...mapActions('context', ['clearErrors', 'dismissError'])
+    ...mapActions('context', [
+      'clearErrorsInStore',
+      'dismissError',
+      'reportError'
+    ])
   }
 };
 </script>

--- a/src/mixins/UserMetadata.vue
+++ b/src/mixins/UserMetadata.vue
@@ -18,7 +18,8 @@ export default {
   methods: {
     ...mapActions('user', [
       'setUserPreference',
-      'loadCalnetUserByCsid'
+      'loadCalnetUserByCsid',
+      'userAuthenticated'
     ])
   }
 };

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { getConfig } from '@/api/config';
+import Vue from 'vue';
 
 const state = {
   config: undefined,
@@ -24,7 +25,7 @@ const getters = {
 };
 
 const mutations = {
-  clearErrors: (state: any) => (state.errors = []),
+  clearErrorsInStore: (state: any) => (state.errors = []),
   dismissError: (state: any, id: number) => {
     const indexOf = state.errors.findIndex((e: any) => e.id === id);
     if (indexOf > -1) {
@@ -36,12 +37,13 @@ const mutations = {
   reportError: (state: any, error: any) => {
     error.id = new Date().getTime();
     state.errors.push(error);
+    Vue.prototype.$eventHub.$emit('error-reported', error);
   },
   storeConfig: (state: any, config: any) => (state.config = config)
 };
 
 const actions = {
-  clearErrors: ({ commit }) => commit('clearErrors'),
+  clearErrorsInStore: ({ commit }) => commit('clearErrorsInStore'),
   dismissError: ({ commit }, id) => commit('dismissError', id),
   loadingComplete: ({ commit }) => commit('loadingComplete'),
   loadingStart: ({ commit }) => commit('loadingStart'),

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -7,7 +7,7 @@
         aria-live="passive"
         class="sr-only">Admin page loaded</span>
       <h1>BOAC Flight Deck</h1>
-      <div class="d-flex flex-row mt-3 mb-3">
+      <div v-if="user.isAdmin && devAuthEnabled" class="d-flex flex-row mt-3 mb-3">
         <div class="mr-3">
           <img
             id="avatar-verify-blur"

--- a/tests/test_api/test_auth_controller.py
+++ b/tests/test_api/test_auth_controller.py
@@ -45,7 +45,7 @@ class TestDevAuth:
         app.config['DEVELOPER_AUTH_ENABLED'] = True
         params = {'uid': self.admin_uid, 'password': 'Born 2 Lose'}
         response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     def test_authorized_user_fail(self, app, client):
         """Fails if the chosen UID does not match an authorized user."""
@@ -90,7 +90,7 @@ class TestCasAuth:
         """Fails if CAS can not verify the ticket."""
         response = client.get('/cas/callback?ticket=is_invalid')
         assert response.status_code == 302
-        assert 'casLoginError' in response.location
+        assert 'error' in response.location
 
 
 class TestBecomeUser:

--- a/tests/test_auth/test_dev_auth.py
+++ b/tests/test_auth/test_dev_auth.py
@@ -45,7 +45,7 @@ class TestDevAuth:
         app.config['DEVELOPER_AUTH_ENABLED'] = True
         params = {'uid': self.authorized_uid, 'password': 'Born 2 Lose'}
         response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
-        assert response.status_code == 403
+        assert response.status_code == 401
 
     def test_authorized_user_fail(self, app, client):
         """Fails if the chosen UID does not match an authorized user."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1737

Simplified some code. Improved wording in errors. Popover instead of modal. Hold on to error when `router.ts` does redirect.