### PR TITLE
BOAC-1809: enables deeplinks for dev auth

### DIFF
--- a/src/components/admin/DevAuth.vue
+++ b/src/components/admin/DevAuth.vue
@@ -63,7 +63,7 @@ export default {
           .then(data => {
             // Auth errors will be caught by axios.interceptors; see error reporting in the file 'main.ts'.
             if (data.isAuthenticated) {
-              this.userAuthenticated().then(() => router.push({ path: '/home' }));
+              this.userAuthenticated().then(() => router.push({ path: router.currentRoute.query.redirect || '/home' }));
             }
           });
       } else {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1809

If unauthenticated user hits a protected route (e.g. /student/999), lands on /login, and authenticates using dev auth, they will be conveniently redirected to /student/999 instead of /home.