### PR TITLE
BOAC-1841, rich-text editor for note details (ckeditor5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -842,6 +842,72 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@ckeditor/ckeditor5-basic-styles": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-10.1.0.tgz",
+      "integrity": "sha512-OenBNiowZsW2ZZasrA8FMr508uvWii+B3oF0blzaVIDjb7zDpbAan9Otuisxz/YGMcQpoDnSaVnYtBCTqov1EQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^11.1.0",
+        "@ckeditor/ckeditor5-ui": "^11.2.0"
+      }
+    },
+    "@ckeditor/ckeditor5-build-classic": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-11.2.0.tgz",
+      "integrity": "sha512-wpJf9C8wtnskaFF82BH17AxKITPgXgmlm4ro6QzCd2vYSCSReLkAVL3+OBuSocgxfePAqnrAO6yWjQrYtg8whw=="
+    },
+    "@ckeditor/ckeditor5-core": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-11.1.0.tgz",
+      "integrity": "sha512-iwSV1SUBITOxncuIVbGv/xFwkZ1Sd0Po/8CRn+p6r5mq91T73L6nMC+MUfT52W9Z/12DfjAz4hRMsabLqRbkIQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-engine": "^12.0.0",
+        "@ckeditor/ckeditor5-utils": "^11.1.0",
+        "lodash-es": "^4.17.10"
+      }
+    },
+    "@ckeditor/ckeditor5-engine": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-12.0.0.tgz",
+      "integrity": "sha512-tRgI4kyPq4UaS9eIZoeMhzNwOKqNV/HC6dAD5JZxghnPsuqAwGlOjGygGVCje7j8I3byTFgaxS5xWFwwnn3fqQ==",
+      "requires": {
+        "@ckeditor/ckeditor5-utils": "^11.1.0",
+        "lodash-es": "^4.17.10"
+      }
+    },
+    "@ckeditor/ckeditor5-theme-lark": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-12.0.0.tgz",
+      "integrity": "sha512-+ZemhL8jpvUNgS3JdkP4eLR+au8/GQcjiwExLp350CwSklOaQk5hApYB7F/3z6sLuZbjxg1M6a9/QarwQJpWDg==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "^11.2.0"
+      }
+    },
+    "@ckeditor/ckeditor5-ui": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-11.2.0.tgz",
+      "integrity": "sha512-V8fxKRwfZdXy011IyxuHX+1FawboMEBBKqdoY2zdVv5zdwsMQRq5jvFUEAeowAXdc7mx0b3zKnafVNUV5Imr0g==",
+      "requires": {
+        "@ckeditor/ckeditor5-core": "^11.1.0",
+        "@ckeditor/ckeditor5-theme-lark": "^12.0.0",
+        "@ckeditor/ckeditor5-utils": "^11.1.0",
+        "lodash-es": "^4.17.10"
+      }
+    },
+    "@ckeditor/ckeditor5-utils": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-11.1.0.tgz",
+      "integrity": "sha512-QgjK5BHs2krdqv8OY7qR0SMEKePcLaBo+b26oh3vMuzdC0KckMytbngn+uIGRoGBiKiza5RwI51Wk4Y8zxKMxQ==",
+      "requires": {
+        "ckeditor5": "^11.2.0",
+        "lodash-es": "^4.17.10"
+      }
+    },
+    "@ckeditor/ckeditor5-vue": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-1.0.0-beta.1.tgz",
+      "integrity": "sha512-CTNyEdofAfmhVomkft6kYEmbh6yRvZMzkvCC4bHZ8LOBHBY7QWkWXP3gbs19SvimUV7PfnsrsDE093aI0SyXqQ=="
+    },
     "@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz",
@@ -2774,6 +2840,11 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
+    },
+    "ckeditor5": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-11.2.0.tgz",
+      "integrity": "sha512-hP6lxCj0bDGv/yhtdYxuASjZbho0zpVKu5x7rNHSjwcsIKeJleRf3TQCxECcG6Mhmuigf6gV4JZzOp+0zLz2rA=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -7798,6 +7869,11 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash-es": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "dependencies": {
     "@babel/core": "^7.2.2",
     "@babel/runtime": "^7.3.1",
+    "@ckeditor/ckeditor5-basic-styles": "^10.1.0",
+    "@ckeditor/ckeditor5-build-classic": "^11.2.0",
+    "@ckeditor/ckeditor5-ui": "^11.2.0",
+    "@ckeditor/ckeditor5-vue": "^1.0.0-beta.1",
     "axios": "^0.18.0",
     "bootstrap-vue": "^2.0.0-rc.13",
     "d3": "5.7.0",

--- a/src/assets/styles/ckeditor-custom.css
+++ b/src/assets/styles/ckeditor-custom.css
@@ -1,0 +1,89 @@
+#note-details .ck-editor__editable {
+  height: 180px;
+  width: 100%;
+}
+:root {
+  /* Overrides the border radius setting in the theme. */
+  --ck-border-radius: 4px;
+  /* Overrides the default font size in the theme. */
+  --ck-font-size-base: 12px;
+  /* Helper variables to avoid duplication in the colors. */
+  --ck-custom-background: hsl(270, 1%, 29%);
+  --ck-custom-foreground: hsl(255, 3%, 18%);
+  --ck-custom-border: hsl(300, 1%, 22%);
+  --ck-custom-white: hsl(0, 0%, 100%);
+  /* -- BOAC custom colors. ------------------------------------------------------------- */
+  --boac-white: hsl(270, 1%, 29%);
+  --boac-color-button-default-background: hsl(0, 0%, 95%);
+  --boac-color-button-default-hover-background: hsl(0, 0%, 80%);
+  --boac-color-button-default-active-background: hsl(0, 0%, 85%);
+  --boac-color-button-default-active-shadow: hsl(0, 0%, 75%);
+
+  --boac-color-button-on-background: hsl(0, 0%, 75%);
+  --boac-color-button-on-hover-background: hsl(0, 0%, 65%);
+  --boac-color-button-on-active-background: hsl(0, 0%, 65%);
+  --boac-color-button-on-active-shadow: hsl(0, 0%, 50%);
+  --boac-color-button-on-disabled-background: hsl(0, 0%, 85%);
+  /* -- Overrides generic colors. ------------------------------------------------------------- */
+  --ck-color-base-foreground: var(--ck-custom-background);
+  --ck-color-focus-border: hsl(208, 90%, 62%);
+  --ck-color-text: var(--boac-white);
+  --ck-color-shadow-drop: hsla(0, 0%, 0%, 0.2);
+  --ck-color-shadow-inner: hsla(0, 0%, 0%, 0.1);
+  /* -- Overrides the default .ck-button class colors. ---------------------------------------- */
+  --ck-color-button-default-background: var(--boac-color-button-default-background);
+  --ck-color-button-default-hover-background: var(--boac-color-button-default-hover-background);
+  --ck-color-button-default-active-background: var(--boac-color-button-default-active-background);
+  --ck-color-button-default-active-shadow: var(--boac-color-button-default-active-shadow);
+  --ck-color-button-default-disabled-background: var(--boac-color-button-on-disabled-background);
+  /* ---------------------------------------- */
+  --ck-color-button-on-background: var(--boac-color-button-on-background);
+  --ck-color-button-on-hover-background: var(--boac-color-button-on-hover-background);
+  --ck-color-button-on-active-background: var(--boac-color-button-on-active-background);
+  --ck-color-button-on-active-shadow: var(--boac-color-button-on-active-shadow);
+  --ck-color-button-on-disabled-background: var(--boac-color-button-on-disabled-background);
+  /* ---------------------------------------- */
+  --ck-color-button-action-background: hsl(168, 76%, 42%);
+  --ck-color-button-action-hover-background: hsl(168, 76%, 38%);
+  --ck-color-button-action-active-background: hsl(168, 76%, 36%);
+  --ck-color-button-action-active-shadow: hsl(168, 75%, 34%);
+  --ck-color-button-action-disabled-background: var(--boac-color-button-on-disabled-background);
+  --ck-color-button-action-text: var(--ck-custom-white);
+  /* ---------------------------------------- */
+  --ck-color-button-save: hsl(120, 100%, 46%);
+  --ck-color-button-cancel: hsl(15, 100%, 56%);
+  /* -- Overrides the default .ck-dropdown class colors. -------------------------------------- */
+  --ck-color-dropdown-panel-background: var(--boac-color-button-default-background);
+  --ck-color-dropdown-panel-border: var(--ck-custom-foreground);
+  /* -- Overrides the default .ck-input class colors. ----------------------------------------- */
+  --ck-color-input-background: var(--ck-custom-white);
+  --ck-color-input-border: hsl(257, 3%, 43%);
+  --ck-color-input-text: hsl(0, 0%, 98%);
+  --ck-color-input-disabled-background: hsl(255, 4%, 21%);
+  --ck-color-input-disabled-border: hsl(250, 3%, 38%);
+  --ck-color-input-disabled-text: hsl(0, 0%, 46%);
+  /* -- Overrides the default .ck-list class colors. ------------------------------------------ */
+  --ck-color-list-background: var(--ck-custom-background);
+  --ck-color-list-button-hover-background: var(--ck-color-base-foreground);
+  --ck-color-list-button-on-background: var(--ck-color-base-active);
+  --ck-color-list-button-on-background-focus: var(--ck-color-base-active-focus);
+  --ck-color-list-button-on-text: var(--ck-color-base-background);
+  /* -- Overrides the default .ck-balloon-panel class colors. --------------------------------- */
+  /*--ck-color-panel-background: var(--ck-custom-background);*/
+  /*--ck-color-panel-border: var(--ck-custom-border);*/
+  /* -- Overrides the default .ck-toolbar class colors. --------------------------------------- */
+  --ck-color-toolbar-background: var(--ck-custom-white);
+  --ck-color-toolbar-border: var(--ck-custom-white);
+  /* -- Overrides the default .ck-tooltip class colors. --------------------------------------- */
+  --ck-color-tooltip-background: hsl(252, 7%, 14%);
+  --ck-color-tooltip-text: hsl(0, 0%, 93%);
+  /* -- Overrides the default colors used by the ckeditor5-image package. --------------------- */
+  --ck-color-image-caption-background: hsl(0, 0%, 97%);
+  --ck-color-image-caption-text: hsl(0, 0%, 20%);
+  /* -- Overrides the default colors used by the ckeditor5-widget package. -------------------- */
+  --ck-color-widget-blurred-border: hsl(0, 0%, 87%);
+  --ck-color-widget-hover-border: hsl(43, 100%, 68%);
+  --ck-color-widget-editable-focus-background: var(--ck-custom-white);
+  /* -- Overrides the default colors used by the ckeditor5-link package. ---------------------- */
+  --ck-color-link-default: hsl(190, 100%, 75%);
+}

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -6,7 +6,7 @@
       <span v-if="!note.subject && !size(note.message)">{{ note.category }}, {{ note.subcategory }}</span>
     </div>
     <div v-if="isOpen && note.subject && note.message" class="mt-2">
-      {{ note.message }}
+      <span v-html="note.message"></span>
     </div>
     <div v-if="author" class="mt-2">
       <a

--- a/src/components/note/NewNoteModal.vue
+++ b/src/components/note/NewNoteModal.vue
@@ -22,7 +22,7 @@
         'modal-open modal-saving': mode === 'saving'
       }">
       <form @submit.prevent="create()">
-        <div class="d-flex align-items-end pt-3">
+        <div class="d-flex align-items-end pt-2 mb-1">
           <div class="flex-grow-1 new-note-header font-weight-bolder">
             New Note
           </div>
@@ -51,8 +51,8 @@
             </b-btn>
           </div>
         </div>
-        <hr />
-        <div class="m-3">
+        <hr class="m-0" />
+        <div class="mt-2 mr-3 mb-1 ml-3">
           <div>
             <label for="create-note-subject" class="input-label mb-1"><span class="sr-only">Note </span>Subject</label>
           </div>
@@ -68,12 +68,14 @@
           <div>
             <label for="create-note-body" class="input-label mt-3 mb-1">Note Details</label>
           </div>
-          <div>
-            <textarea id="create-note-body" v-model="body"></textarea>
+          <div id="note-details">
+            <span id="create-note-body">
+              <ckeditor v-model="body" :editor="editor" :config="editorConfig"></ckeditor>
+            </span>
           </div>
         </div>
         <hr />
-        <div class="d-flex justify-content-end m-3">
+        <div class="d-flex justify-content-end mt-1 mr-3 mb-0 ml-3">
           <div>
             <b-btn
               id="create-note"
@@ -126,8 +128,11 @@
 </template>
 
 <script>
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Util from '@/mixins/Util';
 import { createNote } from '@/api/notes';
+
+require('@/assets/styles/ckeditor-custom.css');
 
 export default {
   name: 'NewNoteModal',
@@ -143,7 +148,11 @@ export default {
     mode: undefined,
     showErrorPopover: false,
     screenReaderAlert: undefined,
-    subject: undefined
+    subject: undefined,
+    editor: ClassicEditor,
+    editorConfig: {
+      toolbar: ['bold', 'italic', 'bulletedList', 'numberedList', 'link'],
+    }
   }),
   watch: {
     body(str) {
@@ -209,10 +218,6 @@ export default {
 </script>
 
 <style scoped>
-textarea {
-  height: 120px;
-  width: 100%;
-}
 .fa-icon-size {
   font-size: 28px;
 }
@@ -244,7 +249,7 @@ textarea {
   border: 1px solid #aaa;
   bottom: 0;
   box-shadow: 0 0 10px #ccc;
-  height: 420px;
+  height: 480px;
   position: fixed;
   right: 30px;
   transition: height 0.5s;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import App from './App.vue';
 import axios from 'axios';
 import BootstrapVue from 'bootstrap-vue';
+import CKEditor from '@ckeditor/ckeditor5-vue';
 import filters from './filters';
 import Highcharts from 'highcharts';
 import HighchartsMore from 'highcharts/highcharts-more';
@@ -32,6 +33,7 @@ axios.interceptors.response.use(response => response, function(error) {
 Vue.config.productionTip = false;
 Vue.use(BootstrapVue);
 Vue.use(require('vue-lodash'));
+Vue.use(CKEditor);
 
 HighchartsMore(Highcharts);
 Vue.use(VueHighcharts, { Highcharts });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1841

Styles are customized according to [docs](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/ui/theme-customization.html). Injecting aria attributes in toolbar is not possible with `ckeditor5`. Work remains in assessing accessibility.