### PR TITLE
BOAC-1880, notes table captures advisor's current name, role, and depts

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError
-from boac.api.util import feature_flag_create_notes
+from boac.api.util import current_user_profile, feature_flag_create_notes, get_dept_codes, get_dept_role
 from boac.lib.http import tolerant_jsonify
 from boac.merged.student import note_to_compatible_json
 from boac.models.note import Note
@@ -52,11 +52,27 @@ def create_note():
     body = params.get('body', None)
     if not sid or not subject or not body:
         raise BadRequestError('Note creation requires \'subject\', \'body\', and \'sid\'')
+    profile = current_user_profile()
+    dept_codes = get_dept_codes(current_user)
+    if len(dept_codes):
+        # TODO: We capture one 'role' and yet user could have multiple, one per dept.
+        role = get_dept_role(current_user.department_memberships[0])
+    else:
+        role = 'BOAC Admin User' if current_user.is_admin else None
     note = Note.create(
-        author_id=current_user.id,
+        author_uid=current_user.uid,
+        author_name=_get_name(profile),
+        author_role=role,
+        author_dept_codes=dept_codes,
         subject=subject,
         body=body,
         sid=sid,
     )
     note_json = note_to_compatible_json(note.to_api_json())
     return tolerant_jsonify(note_json)
+
+
+def _get_name(user):
+    first_name = user.get('firstName')
+    last_name = user.get('lastName')
+    return '' if not (first_name or last_name) else (first_name if not last_name else f'{first_name} {last_name}')

--- a/boac/externals/calnet.py
+++ b/boac/externals/calnet.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 import os
 import ssl
 
@@ -34,6 +33,7 @@ SCHEMA_DICT = {
     'berkeleyEduAffiliations': 'affiliations',
     'berkeleyEduCSID': 'csid',
     'berkeleyEduOfficialEmail': 'campus_email',
+    'departmentNumber': 'dept_code',
     'cn': 'sortable_name',
     'displayName': 'name',
     'mail': 'email',

--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 import re
 
 from flask import current_app as app
@@ -182,7 +181,10 @@ BERKELEY_DEPT_NAME_TO_CODE = {
     'Athletic Study Center': 'UWASC',
     'College of Engineering': 'COENG',
     'Department of Physics': 'PHYSI',
+    'L&S Undergraduate Advising': 'QCADV',
 }
+
+BERKELEY_DEPT_CODE_TO_NAME = {value: key for key, value in BERKELEY_DEPT_NAME_TO_CODE.items()}
 
 
 def current_term_id():

--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -24,6 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.externals import calnet
+from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME
 from boac.models.json_cache import stow
 
 
@@ -53,9 +54,14 @@ def get_calnet_users_for_csids(app, csids):
 def _calnet_user_api_feed(person):
     def _get(key):
         return person and person[key]
+
+    dept_code = _get('dept_code')
+    dept_name = BERKELEY_DEPT_CODE_TO_NAME.get(dept_code)
     return {
         'uid': _get('uid'),
         'csid': _get('csid'),
         'firstName': _get('first_name'),
         'lastName': _get('last_name'),
+        'deptCode': dept_code,
+        'depts': [dept_name] if dept_name else None,
     }

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -250,9 +250,11 @@ def create_cohorts():
 
 
 def create_notes():
-    coe_author_id = AuthorizedUser.find_by_uid('1133399').id
     Note.create(
-        author_id=coe_author_id,
+        author_uid='1133399',
+        author_name='Roberta Joan Anderson',
+        author_role='Advisor',
+        author_dept_codes=['COENG'],
         sid='3456789012',
         subject='The hissing of summer lawns',
         body="""
@@ -260,9 +262,11 @@ def create_notes():
             See the blue pools in the squinting sun. Hear the hissing of summer lawns
         """,
     )
-    asc_author_id = AuthorizedUser.find_by_uid('6446').id
     Note.create(
-        author_id=asc_author_id,
+        author_uid='6446',
+        author_name='Joni Mitchell',
+        author_role='Director',
+        author_dept_codes=['UWASC'],
         sid='11667051',
         subject='In France they kiss on main street',
         body="""

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -25,26 +25,33 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from boac import db, std_commit
 from boac.models.base import Base
+from sqlalchemy.dialects.postgresql import ARRAY
 
 
 class Note(Base):
     __tablename__ = 'notes'
 
     id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
-    author_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False)
-    sid = db.Column('sid', db.String(80), nullable=False)
+    author_uid = db.Column(db.String(255), nullable=False)
+    author_name = db.Column(db.String(255), nullable=False)
+    author_role = db.Column(db.String(255), nullable=False)
+    author_dept_codes = db.Column(ARRAY(db.String), nullable=False)
+    sid = db.Column(db.String(80), nullable=False)
     subject = db.Column(db.String(255), nullable=False)
     body = db.Column(db.Text, nullable=False)
 
-    def __init__(self, author_id, sid, subject, body):
-        self.author_id = author_id
+    def __init__(self, author_uid, author_name, author_role, author_dept_codes, sid, subject, body):
+        self.author_uid = author_uid
+        self.author_name = author_name
+        self.author_role = author_role
+        self.author_dept_codes = author_dept_codes
         self.sid = sid
         self.subject = subject
         self.body = body
 
     @classmethod
-    def create(cls, author_id, sid, subject, body):
-        note = cls(author_id, sid, subject, body)
+    def create(cls, author_uid, author_name, author_role, author_dept_codes, sid, subject, body):
+        note = cls(author_uid, author_name, author_role, author_dept_codes, sid, subject, body)
         db.session.add(note)
         std_commit()
         return note
@@ -56,7 +63,10 @@ class Note(Base):
     def to_api_json(self):
         return {
             'id': self.id,
-            'authorId': self.author_id,
+            'authorUid': self.author_uid,
+            'authorName': self.author_name,
+            'authorRole': self.author_role,
+            'authorDeptCodes': self.author_dept_codes,
             'sid': self.sid,
             'subject': self.subject,
             'body': self.body,

--- a/scripts/db/migrate/20190220-BOAC-1835/DEV_ONLY_drop_notes_table.sql
+++ b/scripts/db/migrate/20190220-BOAC-1835/DEV_ONLY_drop_notes_table.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX IF EXISTS public.notes_author_id_idx;
+DROP TABLE IF EXISTS notes;
+
+COMMIT;

--- a/scripts/db/migrate/20190220-BOAC-1835/pre_deploy_01_create_notes_table.sql
+++ b/scripts/db/migrate/20190220-BOAC-1835/pre_deploy_01_create_notes_table.sql
@@ -2,7 +2,10 @@ BEGIN;
 
 CREATE TABLE notes (
   id SERIAL PRIMARY KEY,
-  author_id INTEGER NOT NULL REFERENCES authorized_users (id) ON DELETE CASCADE,
+  author_uid VARCHAR(255) NOT NULL,
+  author_name VARCHAR(255) NOT NULL,
+  author_role VARCHAR(255) NOT NULL,
+  author_dept_codes VARCHAR[] NOT NULL,
   sid VARCHAR(80) NOT NULL,
   subject VARCHAR(255) NOT NULL,
   body text NOT NULL,
@@ -10,7 +13,7 @@ CREATE TABLE notes (
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
-CREATE INDEX notes_author_id_idx ON notes USING btree (author_id);
+CREATE INDEX notes_author_uid_idx ON notes USING btree (author_uid);
 
 -- Done
 

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -157,7 +157,10 @@ CREATE INDEX notes_read_viewer_id_idx ON notes_read USING btree (viewer_id);
 
 CREATE TABLE notes (
     id INTEGER NOT NULL,
-    author_id INTEGER NOT NULL,
+    author_uid VARCHAR(255) NOT NULL,
+    author_name VARCHAR(255) NOT NULL,
+    author_role VARCHAR(255) NOT NULL,
+    author_dept_codes VARCHAR[] NOT NULL,
     sid VARCHAR(80) NOT NULL,
     subject VARCHAR(255) NOT NULL,
     body text NOT NULL,
@@ -175,7 +178,7 @@ ALTER TABLE notes_id_seq OWNER TO boac;
 ALTER SEQUENCE notes_id_seq OWNED BY notes.id;
 ALTER TABLE ONLY notes ALTER COLUMN id SET DEFAULT nextval('notes_id_seq'::regclass);
 ALTER TABLE ONLY notes ADD CONSTRAINT notes_pkey PRIMARY KEY (id);
-CREATE INDEX notes_author_id_idx ON notes USING btree (author_id);
+CREATE INDEX notes_author_uid_idx ON notes USING btree (author_uid);
 CREATE INDEX notes_sid_idx ON notes USING btree (sid);
 
 --
@@ -310,10 +313,6 @@ ALTER TABLE ONLY cohort_filter_owners
 
 --
 
-ALTER TABLE ONLY notes
-    ADD CONSTRAINT notes_author_id_fkey FOREIGN KEY (author_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
-
---
 
 ALTER TABLE ONLY notes_read
     ADD CONSTRAINT notes_read_viewer_id_fkey FOREIGN KEY (viewer_id) REFERENCES authorized_users(id) ON DELETE CASCADE;

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -22,10 +22,10 @@ export function getUserByCsid(csid) {
     .then(response => response.data, () => null);
 }
 
-export function getUser(id) {
+export function getUserByUid(uid) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
-    .get(`${apiBaseUrl}/api/user/${id}`)
+    .get(`${apiBaseUrl}/api/user/by_uid/${uid}`)
     .then(response => response.data, () => null);
 }
 

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -89,6 +89,11 @@ class TestCreateNotes:
         note_id = new_note.get('id')
         assert new_note['read'] is False
         assert isinstance(note_id, int) and note_id > 0
+        assert new_note['author']['uid'] == advisor_uid
+        assert 'name' in new_note['author']
+        assert new_note['author']['role'] == 'Advisor'
+        assert new_note['author']['depts'] == ['College of Engineering']
+        # Get notes per SID and compare
         notes = _get_notes(client, student['uid'])
         match = next((n for n in notes if n['id'] == note_id), None)
         assert match and match['subject'] == subject
@@ -108,6 +113,8 @@ class TestUpdateNotes:
         assert len(all_notes_unread) == 4
         for note in all_notes_unread:
             assert note['read'] is False
+            if note['id'] == '11667051-00001':
+                isinstance(note['author']['depts'], list)
         response = client.post('/api/notes/11667051-00001/mark_read')
         assert response.status_code == 201
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -132,18 +132,18 @@ class TestUserProfile:
 class TestUserById:
     """User Profile API."""
 
-    def test_user_by_id_not_authenticated(self, client):
+    def test_user_by_uid_not_authenticated(self, client):
         """Returns 401 when not authenticated."""
         user = AuthorizedUser.find_by_uid('1081940')
-        response = client.get(f'/api/user/{user.id}')
+        response = client.get(f'/api/user/by_uid/{user.uid}')
         assert response.status_code == 401
 
-    def test_user_by_id(self, client, fake_auth):
+    def test_user_by_uid(self, client, fake_auth):
         """Delivers CalNet profile."""
         fake_auth.login('2040')
         uid = '1081940'
         user = AuthorizedUser.find_by_uid(uid)
-        response = client.get(f'/api/user/{user.id}')
+        response = client.get(f'/api/user/by_uid/{user.uid}')
         assert response.status_code == 200
         assert response.json['uid'] == uid
 

--- a/tests/test_merged/test_student.py
+++ b/tests/test_merged/test_student.py
@@ -73,7 +73,7 @@ class TestMergedStudent:
         assert notes[1]['attachments'] == ['photo.jpeg']
         # Non-legacy note
         assert notes[3]['id']
-        assert notes[3]['author']['id']
+        assert notes[3]['author']['uid'] == '6446'
         assert notes[3]['sid'] == '11667051'
         assert notes[3]['subject'] == 'In France they kiss on main street'
         assert 'My darling dime store thief' in notes[3]['body']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1880

I will drop/create the `notes` table if/when merged. (QA approved the dropping of test data in dev.) The `/api/user/{id}` endpoint is not `get_by_uid`. 