### PR TITLE
BOAC-1869, test coverage on legacy note 'author' metadata

### DIFF
--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -62,6 +62,7 @@ def _calnet_user_api_feed(person):
         'csid': _get('csid'),
         'firstName': _get('first_name'),
         'lastName': _get('last_name'),
+        'name': _get('name'),
         'deptCode': dept_code,
         'depts': [dept_name] if dept_name else None,
     }

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -154,10 +154,10 @@ def create_curated_groups():
     advisor_id = AuthorizedUser.find_by_uid('6446').id
     CuratedCohort.create(advisor_id, 'My Students')
     curated_cohort = CuratedCohort.create(advisor_id, 'Cool Kids')
-    CuratedCohort.add_student(curated_cohort.id, '3456789012')  # PaulK
-    CuratedCohort.add_student(curated_cohort.id, '5678901234')  # Sandeep
-    CuratedCohort.add_student(curated_cohort.id, '11667051')    # Deborah
-    CuratedCohort.add_student(curated_cohort.id, '7890123456')  # PaulF
+    CuratedCohort.add_student(curated_cohort.id, '3456789012')
+    CuratedCohort.add_student(curated_cohort.id, '5678901234')
+    CuratedCohort.add_student(curated_cohort.id, '11667051')
+    CuratedCohort.add_student(curated_cohort.id, '7890123456')
 
     coe_advisor = AuthorizedUser.find_by_uid('1133399')
     curated_cohort = CuratedCohort.create(coe_advisor.id, 'Cohort of One')
@@ -230,11 +230,10 @@ def create_cohorts():
             'isInactiveAsc': False,
         },
     )
-    # Sandeep's cohorts
     coe_advisor_uid = '1133399'
     CohortFilter.create(
         uid=coe_advisor_uid,
-        name='Sandeep\'s Students',
+        name='Roberta\'s Students',
         filter_criteria={
             'advisorLdapUids': [coe_advisor_uid],
         },

--- a/fixtures/calnet_search_entries.json
+++ b/fixtures/calnet_search_entries.json
@@ -2,12 +2,8 @@
     "entries": [
         {
             "attributes": {
-                "berkeleyEduAffiliations": [
-                    "AFFILIATE-TYPE-ADVCON-ATTENDEE",
-                    "AFFILIATE-TYPE-ADVCON-STUDENT",
-                    "FORMER-STUDENT"
-                ],
-                "berkeleyEduCSID": "11667051",
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "800700600",
                 "berkeleyEduConfidentialFlag": false,
                 "berkeleyEduEmailRelFlag": false,
                 "berkeleyEduExpDate": "2018-05-23 14:16:42+00:00",
@@ -15,39 +11,17 @@
                     "cn=edu:berkeley:app:calmessages:affiliates,ou=campus groups,dc=berkeley,dc=edu",
                     "cn=edu:berkeley:official:all,ou=campus groups,dc=berkeley,dc=edu",
                     "cn=edu:berkeley:app:auth-cas:auth-default,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:auth-cas:webapp-default:webapp-default-base-allow-not-allow,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:auth-cas:webapp-default:webapp-default-base-affiliations,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:auth-cas:webapp-default:webapp-default-base-plus-allow,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:official:students:summer,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:org:libr:exproxy:ezproxy_allow,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:webapp-default:auth-cas:webapp-default-base-affiliations,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:org:libr:exproxy:ezproxy_access,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:calmessages-mods:graduate-students:grad-student-mods,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:calmessages-mods:graduate-students:grad-student-mods_systemOfRecord,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:calmessages-mods:graduate-students:grad-student-mods_systemOfRecordAndIncludes,ou=campus groups,dc=berkeley,dc=edu",
                     "cn=edu:berkeley:official:all-accounts,ou=campus groups,dc=berkeley,dc=edu"
                 ],
-                "berkeleyEduKerberosPrincipalStringOld": [
-                    "11667051"
-                ],
                 "berkeleyEduModDate": "2016-08-29 14:51:46+00:00",
-                "berkeleyEduOfficialEmail": [
-                    "obear@example.edu"
-                ],
-                "berkeleyEduStuID": "11667051",
-                "cn": [
-                    "Bear, Oski"
-                ],
-                "displayName": "Oski Bear",
-                "givenName": [
-                    "Oski"
-                ],
-                "mail": [
-                    "grrarrrgh@example.com"
-                ],
-                "o": [
-                    "University of California, Berkeley"
-                ],
+                "berkeleyEduOfficialEmail": [ "joni@berkeley.edu" ],
+                "berkeleyEduStuID": "800700600",
+                "cn": [ "Anderson, Roberta Joan" ],
+                "departmentNumber": "QCADV",
+                "displayName": "Roberta Joan Anderson",
+                "givenName": [ "Roberta Joan" ],
+                "mail": [ "joni@gmail.com" ],
+                "o": [ "University of California, Berkeley" ],
                 "objectClass": [
                     "top",
                     "eduPerson",
@@ -57,78 +31,32 @@
                     "person",
                     "ucEduPerson"
                 ],
-                "ou": [
-                    "people"
-                ],
-                "sn": [
-                    "Bear"
-                ],
-                "uid": [
-                    "61889"
-                ]
+                "ou": [ "people" ],
+                "sn": [ "Anderson" ],
+                "uid": [ "1133399" ]
             },
-            "dn": "uid=61889,ou=people,dc=berkeley,dc=edu",
+            "dn": "uid=1133399,ou=people,dc=berkeley,dc=edu",
             "raw": {
-                "berkeleyEduAffiliations": [
-                    "AFFILIATE-TYPE-ADVCON-ATTENDEE",
-                    "AFFILIATE-TYPE-ADVCON-STUDENT",
-                    "FORMER-STUDENT"
-                ],
-                "berkeleyEduCSID": [
-                    "11667051"
-                ],
-                "berkeleyEduConfidentialFlag": [
-                    "false"
-                ],
-                "berkeleyEduEmailRelFlag": [
-                    "false"
-                ],
-                "berkeleyEduExpDate": [
-                    "20180523141642Z"
-                ],
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": [ "800700600" ],
+                "berkeleyEduConfidentialFlag": [ "false" ],
+                "berkeleyEduEmailRelFlag": [ "false" ],
+                "berkeleyEduExpDate": [ "20180523141642Z" ],
                 "berkeleyEduIsMemberOf": [
                     "cn=edu:berkeley:app:calmessages:affiliates,ou=campus groups,dc=berkeley,dc=edu",
                     "cn=edu:berkeley:official:all,ou=campus groups,dc=berkeley,dc=edu",
                     "cn=edu:berkeley:app:auth-cas:auth-default,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:auth-cas:webapp-default:webapp-default-base-allow-not-allow,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:auth-cas:webapp-default:webapp-default-base-affiliations,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:auth-cas:webapp-default:webapp-default-base-plus-allow,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:official:students:summer,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:org:libr:exproxy:ezproxy_allow,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:webapp-default:auth-cas:webapp-default-base-affiliations,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:org:libr:exproxy:ezproxy_access,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:calmessages-mods:graduate-students:grad-student-mods,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:calmessages-mods:graduate-students:grad-student-mods_systemOfRecord,ou=campus groups,dc=berkeley,dc=edu",
-                    "cn=edu:berkeley:app:calmessages-mods:graduate-students:grad-student-mods_systemOfRecordAndIncludes,ou=campus groups,dc=berkeley,dc=edu",
                     "cn=edu:berkeley:official:all-accounts,ou=campus groups,dc=berkeley,dc=edu"
                 ],
-                "berkeleyEduKerberosPrincipalStringOld": [
-                    "11667051"
-                ],
-                "berkeleyEduModDate": [
-                    "20160829145146Z"
-                ],
-                "berkeleyEduOfficialEmail": [
-                    "obear@example.edu"
-                ],
-                "berkeleyEduStuID": [
-                    "11667051"
-                ],
-                "cn": [
-                    "Bear, Oski"
-                ],
-                "displayName": [
-                    "Oski Bear"
-                ],
-                "givenName": [
-                    "Oski"
-                ],
-                "mail": [
-                    "grrarrrgh@example.com"
-                ],
-                "o": [
-                    "University of California, Berkeley"
-                ],
+                "berkeleyEduModDate": [ "20160829145146Z" ],
+                "berkeleyEduOfficialEmail": [ "joni@berkeley.edu" ],
+                "berkeleyEduStuID": [ "800700600" ],
+                "cn": [ "Anderson, Roberta Joan" ],
+                "departmentNumber": [ "QCADV" ],
+                "displayName": [ "Roberta Joan Anderson" ],
+                "givenName": [ "Roberta Joan" ],
+                "mail": [ "joni@berkeley.edu" ],
+                "o": [ "University of California, Berkeley" ],
                 "objectClass": [
                     "top",
                     "eduPerson",
@@ -138,15 +66,9 @@
                     "person",
                     "ucEduPerson"
                 ],
-                "ou": [
-                    "people"
-                ],
-                "sn": [
-                    "Bear"
-                ],
-                "uid": [
-                    "61889"
-                ]
+                "ou": [ "people" ],
+                "sn": [ "Anderson" ],
+                "uid": [ "1133399" ]
             }
         }
     ]

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -9,12 +9,12 @@
       <span :id="`note-${note.id}-message-open`" v-html="note.message"></span>
     </div>
     <div v-if="author" class="mt-2">
-      <div>
+      <div v-if="author.name">
         <a
           :id="`note-${note.id}-author-name`"
           :aria-label="`Go to UC Berkeley Directory page of ${author.firstName} ${author.lastName}`"
-          :href="`https://www.berkeley.edu/directory/results?search-term=${getName(author)}`"
-          target="_blank">{{ getName(author) }}</a>
+          :href="`https://www.berkeley.edu/directory/results?search-term=${author.name}`"
+          target="_blank">{{ author.name }}</a>
         <span v-if="author.role">
           - <span :id="`note-${note.id}-author-role`" class="text-dark">{{ author.role }}</span>
         </span>
@@ -90,9 +90,6 @@ export default {
         }
       }
     }
-  },
-  methods:{
-    getName: user => user.name || `${user.firstName} ${user.lastName}`
   }
 }
 </script>

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -823,8 +823,9 @@ class TestNotes:
         assert response.status_code == 200
         user = response.json
         assert user['csid'] == advisor_sid
-        assert 'deptCode' in user
-        assert 'depts' in user
+        assert user['name'] == 'Roberta Joan Anderson'
+        assert user['deptCode'] == 'QCADV'
+        assert user['depts'] == ['L&S Undergraduate Advising']
 
 
 class TestStudentPhoto:

--- a/tests/test_models/test_cohort_filter.py
+++ b/tests/test_models/test_cohort_filter.py
@@ -123,8 +123,7 @@ class TestCohortFilter:
         """Can be JSONified."""
         cohorts = AuthorizedUser.find_by_uid(coe_advisor_uid).cohort_filters
         assert len(cohorts) == 2
-        jsonified_cohort = cohorts[0].to_api_json()
-        assert jsonified_cohort['name'] == 'Sandeep\'s Students'
+        assert cohorts[0].to_api_json()['name'] == 'Roberta\'s Students'
 
 
 def cohort_count(user_uid):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1869

Repurpose (otherwise unused) `fixtures/calnet_search_entries.json` to verify that legacy advisor name and dept load properly. And, assign `author.name` on server-side.  