### PR TITLE
BOAC-1891, all topics per note: operator.itemgetter requires a sorted list

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -324,14 +324,16 @@ def get_advising_notes(sid):
 def get_advising_note_topics(sid):
     sql = f"""SELECT advising_note_id, note_topic
         FROM {advising_notes_schema()}.advising_note_topics
-        where sid=:sid"""
+        WHERE sid=:sid
+        ORDER BY advising_note_id"""
     return safe_execute_redshift(sql, sid=sid)
 
 
 def get_advising_note_attachments(sid):
     sql = f"""SELECT advising_note_id, sis_file_name
         FROM {advising_notes_schema()}.advising_note_attachments
-        where sid=:sid"""
+        WHERE sid=:sid
+        ORDER BY advising_note_id"""
     return safe_execute_redshift(sql, sid=sid)
 
 

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -23,10 +23,9 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from datetime import timezone
 from itertools import groupby
-import operator
+from operator import itemgetter
 import re
 
 from boac.externals import data_loch
@@ -169,7 +168,7 @@ def _stringify_note_timestamp(dt, date_only=False):
 def _get_advising_note_topics(sid):
     topics = data_loch.get_advising_note_topics(sid)
     topics_by_id = {}
-    for advising_note_id, topics in groupby(topics, key=operator.itemgetter('advising_note_id')):
+    for advising_note_id, topics in groupby(topics, key=itemgetter('advising_note_id')):
         topics_by_id[advising_note_id] = [topic['note_topic'] for topic in topics]
     return topics_by_id
 
@@ -177,7 +176,7 @@ def _get_advising_note_topics(sid):
 def _get_advising_note_attachments(sid):
     attachments = data_loch.get_advising_note_attachments(sid)
     attachments_by_id = {}
-    for advising_note_id, attachments in groupby(attachments, key=operator.itemgetter('advising_note_id')):
+    for advising_note_id, attachments in groupby(attachments, key=itemgetter('advising_note_id')):
         attachments_by_id[advising_note_id] = [attachments['sis_file_name'] for attachments in attachments]
     return attachments_by_id
 

--- a/fixtures/loch.sql
+++ b/fixtures/loch.sql
@@ -236,6 +236,8 @@ INSERT INTO boac_advising_notes.advising_note_topics
 VALUES
 ('11667051-00001', '11667051', 'Good show'),
 ('11667051-00002', '11667051', 'Bad show'),
+('11667051-00003', '11667051', 'Show time'),
+('11667051-00002', '11667051', 'Show off'),
 ('9000000000-00001', '9000000000', 'No show');
 
 INSERT INTO boac_advising_notes.advising_note_attachments

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -61,7 +61,7 @@ class TestMergedAdvisingNote:
         assert notes[1]['updatedBy'] is None
         assert notes[1]['updatedAt'] == '2017-11-01 12:00:00'
         assert notes[1]['read'] is False
-        assert notes[1]['topics'] == ['Bad show']
+        assert notes[1]['topics'] == ['Bad show', 'Show off']
         assert notes[1]['attachments'] == ['photo.jpeg']
         # Non-legacy note
         assert notes[3]['id']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1891

Give `itemgetter` a sorted list _or_ lazy-init `topics_by_id[advising_note_id]` before append topics.