### PR TITLE
BOAC-1780 Suppress PYTHONPATH for AWS CLI command in .ebextensions

### DIFF
--- a/.ebextensions/03_download_local_configuration.config
+++ b/.ebextensions/03_download_local_configuration.config
@@ -1,10 +1,11 @@
 #
-# Download env appropriate file from S3
+# Download env appropriate file from S3. We temporarily suppress the PYTHONPATH pointing to app dependencies so that they
+# don't interfere with the AWS CLI's own package requirements.
 #
 container_commands:
   01_get_configuration_file:
     command: |
-      aws s3 cp s3://la-deploy-configs/boac/${EB_ENVIRONMENT}.py config/production-local.py
+      PYTHONPATH='' aws s3 cp s3://la-deploy-configs/boac/${EB_ENVIRONMENT}.py config/production-local.py
       printf "\nEB_ENVIRONMENT = '${EB_ENVIRONMENT}'\n\n" >> config/production-local.py
       chown wsgi config/production-local.py
       chmod 400 config/production-local.py


### PR DESCRIPTION
The finally-required BOAC equivalent of https://github.com/ets-berkeley-edu/nessie/pull/30.

To fix (we hope) the failed deploy of #1360 (https://jira.ets.berkeley.edu/jira/browse/BOAC-1780).