### PR TITLE
BOAC-1914 Friendly filenames for CS-sourced attachments

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -74,12 +74,12 @@ def create_note():
 @app.route('/api/notes/attachment/<attachment_filename>', methods=['GET'])
 @login_required
 def download_attachment(attachment_filename):
-    attachment_stream = get_attachment_stream(attachment_filename)
-    if not attachment_stream:
+    stream_data = get_attachment_stream(attachment_filename)
+    if not stream_data or not stream_data['stream']:
         raise ResourceNotFoundError('Attachment not found')
-    r = Response(attachment_stream)
+    r = Response(stream_data['stream'])
     r.headers['Content-Type'] = 'application/octet-stream'
-    r.headers.add('Content-Disposition', 'attachment', filename=attachment_filename)
+    r.headers.add('Content-Disposition', 'attachment', filename=stream_data['filename'])
     return r
 
 

--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -333,7 +333,7 @@ def get_advising_note_attachment(sid, filename, scope):
     query_tables, query_filter, query_bindings = get_students_query(scope=scope)
     if not query_tables:
         return None
-    sql = f"""SELECT advising_note_id, sis_file_name
+    sql = f"""SELECT advising_note_id, created_by, sis_file_name, user_file_name
         {query_tables}
         JOIN {advising_notes_schema()}.advising_note_attachments ana
         ON sas.sid = :sid
@@ -344,7 +344,7 @@ def get_advising_note_attachment(sid, filename, scope):
 
 
 def get_advising_note_attachments(sid):
-    sql = f"""SELECT advising_note_id, sis_file_name
+    sql = f"""SELECT advising_note_id, created_by, sis_file_name, user_file_name
         FROM {advising_notes_schema()}.advising_note_attachments
         WHERE sid=:sid
         ORDER BY advising_note_id"""

--- a/fixtures/loch.sql
+++ b/fixtures/loch.sql
@@ -86,9 +86,11 @@ CREATE TABLE boac_advising_notes.advising_note_attachments
     sid VARCHAR NOT NULL,
     attachment_seq_nr INT,
     attachment_date DATE,
+    created_by VARCHAR NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    sis_file_name VARCHAR NOT NULL
+    sis_file_name VARCHAR NOT NULL,
+    user_file_name VARCHAR NOT NULL
 );
 
 CREATE TABLE boac_analytics.section_mean_gpas
@@ -241,11 +243,11 @@ VALUES
 ('9000000000-00001', '9000000000', 'No show');
 
 INSERT INTO boac_advising_notes.advising_note_attachments
-(advising_note_id, sid, attachment_seq_nr, attachment_date, created_at, updated_at, sis_file_name)
+(advising_note_id, sid, attachment_seq_nr, attachment_date, created_by, created_at, updated_at, sis_file_name, user_file_name)
 VALUES
-('11667051-00001', '11667051', 1, '2017-10-31', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '11667051-00001_form.pdf'),
-('11667051-00002', '11667051', 2, '2017-10-31', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '11667051-00002_photo.jpeg'),
-('9000000000-00002', '9000000000', 2, '2017-10-31', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '9000000000-00002_dog_eaten_homework.pdf');
+('11667051-00001', '11667051', 1, '2017-10-31', 'UCBCONVERSION', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '11667051_00001_1.pdf', 'efac7b10-c3f2-11e4-9bbd-ab6a6597d26f.pdf'),
+('11667051-00002', '11667051', 2, '2017-10-31', '1234', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '11667051_00002_2.jpeg', 'brigitte_photo.jpeg'),
+('9000000000-00002', '9000000000', 1, '2017-10-31', '4567', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '9000000000_00002_1.pdf', 'dog_eaten_homework.pdf');
 
 INSERT INTO boac_analytics.section_mean_gpas
 (sis_term_id, sis_section_id, gpa_term_id, avg_gpa)

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -47,7 +47,7 @@
       <ul class="pill-list pl-0">
         <li
           v-for="(attachment, index) in note.attachments"
-          :key="attachment"
+          :key="attachment.sisFilename"
           class="mt-2"
           @click.stop>
           <a
@@ -55,12 +55,12 @@
             :id="`note-${note.id}-attachment-${index}`"
             :href="downloadUrl(attachment)"
             class="pill text-nowrap">
-            <i class="fas fa-paperclip"></i> {{ attachment }}
+            <i class="fas fa-paperclip"></i> {{ attachment.userFilename || attachment.sisFilename }}
           </a>
           <span
             v-if="isPreCsNote"
             :id="`note-${note.id}-attachment-${index}`"
-            class="pill text-nowrap"><i class="fas fa-paperclip"></i> {{ attachment }}
+            class="pill text-nowrap"><i class="fas fa-paperclip"></i> {{ attachment.userFilename || attachment.sisFilename }}
           </span>
         </li>
       </ul>
@@ -119,7 +119,7 @@ export default {
   },
   methods: {
     downloadUrl(attachment) {
-      return this.apiBaseUrl + '/api/notes/attachment/' + attachment;
+      return this.apiBaseUrl + '/api/notes/attachment/' + attachment.sisFilename;
     }
   },
 }

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -153,21 +153,21 @@ class TestStreamNoteAttachments:
 
     def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
-        assert client.get('/api/notes/attachment/9000000000-00002_dog_eaten_homework.pdf').status_code == 401
+        assert client.get('/api/notes/attachment/9000000000_00002_1.pdf').status_code == 401
 
     def test_stream_attachment(self, app, client, fake_auth):
         with mock_advising_note_attachment(app):
             fake_auth.login(coe_advisor_uid)
-            response = client.get('/api/notes/attachment/9000000000-00002_dog_eaten_homework.pdf')
+            response = client.get('/api/notes/attachment/9000000000_00002_1.pdf')
             assert response.status_code == 200
             assert response.headers['Content-Type'] == 'application/octet-stream'
-            assert response.headers['Content-Disposition'] == 'attachment; filename=9000000000-00002_dog_eaten_homework.pdf'
+            assert response.headers['Content-Disposition'] == 'attachment; filename=dog_eaten_homework.pdf'
             assert response.data == b'When in the course of human events, it becomes necessarf arf woof woof woof'
 
     def test_stream_attachment_reports_unauthorized_files_not_found(self, app, client, fake_auth):
         with mock_advising_note_attachment(app):
             fake_auth.login(asc_advisor_uid)
-            response = client.get('/api/notes/attachment/9000000000-00002_dog_eaten_homework.pdf')
+            response = client.get('/api/notes/attachment/9000000000_00002_1.pdf')
             assert response.status_code == 404
 
     def test_stream_attachment_reports_missing_files_not_found(self, app, client, fake_auth):

--- a/tests/util.py
+++ b/tests/util.py
@@ -33,7 +33,7 @@ import moto
 def mock_advising_note_attachment(app):
     with moto.mock_s3():
         bucket = app.config['DATA_LOCH_S3_ADVISING_NOTE_BUCKET']
-        key = f"{app.config['DATA_LOCH_S3_ADVISING_NOTE_ATTACHMENT_PATH']}/9000000000/9000000000-00002_dog_eaten_homework.pdf"
+        key = f"{app.config['DATA_LOCH_S3_ADVISING_NOTE_ATTACHMENT_PATH']}/9000000000/9000000000_00002_1.pdf"
         s3 = boto3.resource('s3', app.config['DATA_LOCH_S3_REGION'])
         s3.create_bucket(Bucket=bucket)
         s3.Object(bucket, key).put(Body='When in the course of human events, it becomes necessarf arf woof woof woof')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1914

The predictably formatted `attachment.sisFilename` is always used for API calls. We give display preference to `attachment.userFilename` when available (non-UCBCONVERSION attachments).