### PR TITLE
NS-429 Remove vestiges of term-wide analytics averaging

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import get_my_cohorts, is_unauthorized_search, strip_analytics
+from boac.api.util import get_my_cohorts, is_unauthorized_search
 from boac.lib.berkeley import can_view_cohort
 from boac.lib.cohort_filter_definition import translate_filters_to_cohort_criteria
 from boac.lib.http import tolerant_jsonify
@@ -76,7 +76,9 @@ def students_with_alerts(cohort_id):
         alert_profiles_by_sid = {p['sid']: p for p in alert_profiles}
         for student in students:
             student.update(alert_profiles_by_sid[student['sid']])
-            strip_analytics(student)
+            # The enrolled units count is the one piece of term data we want to preserve.
+            if student.get('term'):
+                student['term'] = {'enrolledUnits': student['term'].get('enrolledUnits')}
     else:
         raise ResourceNotFoundError(f'No cohort found with identifier: {cohort_id}')
     return tolerant_jsonify(students)

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -232,15 +232,6 @@ def sort_students_by_name(students):
     return sorted(students, key=lambda s: (s['lastName'], s['firstName']))
 
 
-def strip_analytics(student_term_data):
-    if student_term_data.get('analytics'):
-        del student_term_data['analytics']
-    # The enrolled units count is the one piece of term data we want to preserve.
-    if student_term_data.get('term'):
-        student_term_data['term'] = {'enrolledUnits': student_term_data['term'].get('enrolledUnits')}
-    return student_term_data
-
-
 def translate_grading_basis(code):
     bases = {
         'CNC': 'C/NC',

--- a/fixtures/loch_student_enrollment_term_11667051_2162.json
+++ b/fixtures/loch_student_enrollment_term_11667051_2162.json
@@ -1,9 +1,4 @@
 {
-    "analytics": {
-        "assignmentsSubmitted": null,
-        "currentScore": null,
-        "lastActivity": null
-    },
     "enrolledUnits": 0,
     "enrollments": [
         {

--- a/fixtures/loch_student_enrollment_term_11667051_2172.json
+++ b/fixtures/loch_student_enrollment_term_11667051_2172.json
@@ -1,9 +1,4 @@
 {
-    "analytics": {
-        "assignmentsSubmitted": null,
-        "currentScore": null,
-        "lastActivity": null
-    },
     "enrolledUnits": 10.0,
     "enrollments": [
         {

--- a/fixtures/loch_student_enrollment_term_11667051_2178.json
+++ b/fixtures/loch_student_enrollment_term_11667051_2178.json
@@ -1,18 +1,4 @@
 {
-  "analytics": {
-    "assignmentsSubmitted": {
-      "displayPercentile": "62nd",
-      "percentile": 62
-    },
-    "currentScore": {
-      "displayPercentile": "93rd",
-      "percentile": 93
-    },
-    "lastActivity": {
-      "displayPercentile": "36th",
-      "percentile": 35.666666666666664
-    }
-  },
   "droppedSections": [
     {
       "component": "TUT",

--- a/fixtures/loch_student_enrollment_term_11667051_2182.json
+++ b/fixtures/loch_student_enrollment_term_11667051_2182.json
@@ -1,9 +1,4 @@
 {
-    "analytics": {
-        "assignmentsSubmitted": null,
-        "currentScore": null,
-        "lastActivity": null
-    },
     "enrolledUnits": 3,
     "enrollments": [
         {

--- a/fixtures/loch_student_enrollment_term_11667051_2185.json
+++ b/fixtures/loch_student_enrollment_term_11667051_2185.json
@@ -1,9 +1,4 @@
 {
-  "analytics": {
-      "assignmentsSubmitted": null,
-      "currentScore": null,
-      "lastActivity": null
-  },
   "enrolledUnits": 2,
   "enrollments": [
       {

--- a/fixtures/loch_student_enrollment_term_2345678901_2172.json
+++ b/fixtures/loch_student_enrollment_term_2345678901_2172.json
@@ -1,9 +1,4 @@
 {
-    "analytics": {
-        "assignmentsSubmitted": null,
-        "currentScore": null,
-        "lastActivity": null
-    },
     "enrolledUnits": 10.0,
     "enrollments": [
         {

--- a/fixtures/loch_student_enrollment_term_3456789012_2178.json
+++ b/fixtures/loch_student_enrollment_term_3456789012_2178.json
@@ -1,18 +1,4 @@
 {
-  "analytics": {
-    "assignmentsSubmitted": {
-      "displayPercentile": "81st",
-      "percentile": 81
-    },
-    "currentScore": {
-      "displayPercentile": "73rd",
-      "percentile": 73
-    },
-    "lastActivity": {
-      "displayPercentile": "21st",
-      "percentile": 21
-    }
-  },
   "droppedSections": [
     {
       "component": "TUT",

--- a/fixtures/loch_student_enrollment_term_5678901234_2178.json
+++ b/fixtures/loch_student_enrollment_term_5678901234_2178.json
@@ -1,18 +1,4 @@
 {
-  "analytics": {
-    "assignmentsSubmitted": {
-      "displayPercentile": "81st",
-      "percentile": 81
-    },
-    "currentScore": {
-      "displayPercentile": "73rd",
-      "percentile": 73
-    },
-    "lastActivity": {
-      "displayPercentile": "21st",
-      "percentile": 21
-    }
-  },
   "droppedSections": [
     {
       "component": "TUT",

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -92,7 +92,7 @@ class TestCohortDetail:
         deborah = students_with_alerts[0]
         assert deborah['sid'] == '11667051'
         assert deborah['alertCount'] == 3
-        # Summary student data is included with alert counts, but full term and analytics feeds are not.
+        # Summary student data is included with alert counts, but full term feeds are not.
         assert deborah['cumulativeGPA'] == 3.8
         assert deborah['cumulativeUnits'] == 101.3
         assert deborah['expectedGraduationTerm']['name'] == 'Fall 2019'
@@ -100,7 +100,6 @@ class TestCohortDetail:
         assert len(deborah['majors']) == 2
         assert deborah['term']['enrolledUnits'] == 12.5
         assert deborah['termGpa'][0]['gpa'] == 2.9
-        assert 'analytics' not in deborah
         assert 'enrollments' not in deborah['term']
 
         dave_doolittle = students_with_alerts[1]
@@ -183,7 +182,7 @@ class TestCohortDetail:
         assert athlete['majors'] == ['English BA', 'Nuclear Engineering BS']
 
     def test_includes_cohort_member_current_enrollments(self, asc_advisor_session, asc_owned_cohort, client):
-        """Includes current-term active enrollments and analytics for custom cohort students."""
+        """Includes current-term active enrollments for custom cohort students."""
         response = client.get(f'/api/cohort/{asc_owned_cohort.id}?orderBy=firstName')
         assert response.status_code == 200
         athlete = next(m for m in response.json['students'] if m['firstName'] == 'Deborah')
@@ -194,10 +193,6 @@ class TestCohortDetail:
         assert len(term['enrollments']) == 5
         assert term['enrollments'][0]['displayName'] == 'BURMESE 1A'
         assert len(term['enrollments'][0]['canvasSites']) == 1
-        analytics = athlete['analytics']
-        for metric in ['assignmentsSubmitted', 'currentScore', 'lastActivity']:
-            assert analytics[metric]['percentile'] > 0
-            assert analytics[metric]['displayPercentile'].endswith(('nd', 'rd', 'st', 'th'))
 
     def test_includes_cohort_member_term_gpa(self, asc_advisor_session, asc_owned_cohort, client):
         response = client.get(f'/api/cohort/{asc_owned_cohort.id}?orderBy=firstName')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-429

BOAC no longer attempts to show term-wide averages of analytics data, but the underlying numbers were still being supplied by Nessie until https://github.com/ets-berkeley-edu/nessie/pull/371.