### PR TITLE
BOAC-1938, screenreader alerts (eg, from modal) go to shared, polite sr-only

### DIFF
--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -5,6 +5,13 @@
       <span v-if="!note.subject && size(note.message)" v-html="note.message"></span>
       <span v-if="!note.subject && !size(note.message)">{{ note.category }}<span v-if="note.subcategory">, {{ note.subcategory }}</span></span>
     </div>
+    <div v-if="isOpen">
+      <b-btn
+        class="sr-only"
+        @click.stop="editNote(note)">
+        Edit Note
+      </b-btn>
+    </div>
     <div v-if="isOpen && note.subject && note.message" class="mt-2">
       <span :id="`note-${note.id}-message-open`" v-html="note.message"></span>
     </div>
@@ -80,6 +87,7 @@ export default {
   name: 'AdvisingNote',
   mixins: [Context, UserMetadata, Util],
   props: {
+    editNote: Function,
     isOpen: Boolean,
     note: Object
   },

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -1,6 +1,5 @@
 <template>
   <form v-click-outside="cancel" @submit.prevent="save()">
-    <div id="sr-alert-edit-note" class="sr-only" aria-live="polite">{{ screenReaderAlert }}</div>
     <div>
       <label id="edit-note-subject-label" class="font-weight-bold" for="edit-note-subject">Subject</label>
     </div>
@@ -32,14 +31,14 @@
         <b-btn class="btn-primary-color-override" variant="primary" @click="save()">Save</b-btn>
       </div>
       <div>
-        <b-btn variant="link" @click="cancel()">Cancel</b-btn>
+        <b-btn variant="link" @click.stop="cancel()" @keypress.enter.stop="cancel()">Cancel</b-btn>
       </div>
     </div>
     <AreYouSureModal
       v-if="showAreYouSureModal"
       :function-cancel="cancelTheCancel"
       :function-confirm="cancelConfirmed"
-      modal-header="Discard unsaved note changes?"
+      modal-header="Discard unsaved note?"
       :show-modal="showAreYouSureModal" />
     <b-popover
       v-if="showErrorPopover"
@@ -55,6 +54,7 @@
 <script>
 import AreYouSureModal from '@/components/util/AreYouSureModal';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import Context from '@/mixins/Context';
 import Util from '@/mixins/Util';
 import { updateNote } from '@/api/notes';
 
@@ -63,7 +63,7 @@ require('@/assets/styles/ckeditor-custom.css');
 export default {
   name: 'EditAdvisingNote',
   components: { AreYouSureModal },
-  mixins: [Util],
+  mixins: [Context, Util],
   props: {
     afterCancelled: Function,
     afterSaved: Function,
@@ -76,13 +76,12 @@ export default {
       toolbar: ['bold', 'italic', 'bulletedList', 'numberedList', 'link'],
     },
     error: undefined,
-    screenReaderAlert: undefined,
     showAreYouSureModal: false,
     showErrorPopover: false,
     subject: undefined
   }),
   created() {
-    this.screenReaderAlert = 'The edit note form has loaded.';
+    this.alertScreenReader('The edit note form has loaded.');
     this.reset();
   },
   methods: {
@@ -94,11 +93,12 @@ export default {
       }
     },
     cancelConfirmed() {
-      this.screenReaderAlert = 'Edit note form cancelled.';
+      this.alertScreenReader('Edit note form cancelled.');
       this.afterCancelled();
       this.reset();
     },
     cancelTheCancel() {
+      this.alertScreenReader('Continue editing note.');
       this.showAreYouSureModal = false;
       this.putFocusNextTick('edit-note-subject');
     },
@@ -120,7 +120,7 @@ export default {
       } else {
         this.error = 'Subject is required';
         this.showErrorPopover = true;
-        this.screenReaderAlert = `Validation failed: ${this.error}`;
+        this.alertScreenReader(`Validation failed: ${this.error}`);
         this.putFocusNextTick('edit-note-subject');
       }
     }

--- a/src/components/note/NewNoteModal.vue
+++ b/src/components/note/NewNoteModal.vue
@@ -1,6 +1,5 @@
 <template>
   <div v-click-outside="clickOutside">
-    <div id="sr-alert-new-note" class="sr-only" aria-live="polite">{{ screenReaderAlert }}</div>
     <div>
       <b-btn
         id="new-note-button"
@@ -137,6 +136,7 @@
 <script>
 import AreYouSureModal from '@/components/util/AreYouSureModal';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import Context from '@/mixins/Context';
 import Util from '@/mixins/Util';
 import { createNote } from '@/api/notes';
 
@@ -145,7 +145,7 @@ require('@/assets/styles/ckeditor-custom.css');
 export default {
   name: 'NewNoteModal',
   components: { AreYouSureModal },
-  mixins: [Util],
+  mixins: [Context, Util],
   props: {
     disable: Boolean,
     onModeChange: Function,
@@ -158,7 +158,6 @@ export default {
     isMinimizing: false,
     mode: undefined,
     showErrorPopover: false,
-    screenReaderAlert: undefined,
     subject: undefined,
     editor: ClassicEditor,
     editorConfig: {
@@ -191,7 +190,7 @@ export default {
     cancelConfirmed() {
       this.showAreYouSureModal = false;
       this.reset();
-      this.screenReaderAlert = "Cancelled create new note";
+      this.alertScreenReader("Cancelled create new note");
     },
     cancelTheCancel() {
       this.showAreYouSureModal = false;
@@ -214,25 +213,25 @@ export default {
         createNote(this.student.sid, this.subject, this.body).then(data => {
           this.reset();
           this.onSuccessfulCreate(data);
-          this.screenReaderAlert = "New note saved";
+          this.alertScreenReader("New note saved.");
         });
       } else {
         this.error = 'Subject is required';
         this.showErrorPopover = true;
-        this.screenReaderAlert = `Validation failed: ${this.error}`;
+        this.alertScreenReader(`Validation failed: ${this.error}`);
         this.putFocusNextTick('create-note-subject');
       }
     },
     maximize() {
       this.mode = 'open';
-      this.screenReaderAlert = "The create-note form is visible";
+      this.alertScreenReader("Create note form is visible.");
       this.putFocusNextTick('create-note-subject');
     },
     minimize() {
       this.isMinimizing = true;
       this.mode = 'minimized';
       setTimeout(() => this.isMinimizing = false, 300);
-      this.screenReaderAlert = "The create-note form minimized";
+      this.alertScreenReader("Create note form minimized.");
     },
     openNewNoteModal() {
        this.mode = 'open';

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -3,7 +3,6 @@
     <div class="d-flex justify-content-between">
       <div>
         <h2 class="student-section-header">Academic Timeline</h2>
-        <div id="screen-reader-alert" class="sr-only" aria-live="polite">{{ screenReaderAlert }}</div>
         <div class="d-flex mt-3 mb-3">
           <div class="align-self-center mr-3">Filter Type:</div>
           <div>
@@ -76,7 +75,8 @@
               <b-btn
                 variant="link"
                 class="pl-0"
-                @click.stop="onEditNoteClick(message)">
+                @keypress.enter.stop="editNote(message)"
+                @click.stop="editNote(message)">
                 Edit Note
               </b-btn>
             </div>
@@ -100,6 +100,7 @@
               <span v-if="message.type !== 'note'">{{ message.message }}</span>
               <AdvisingNote
                 v-if="message.type === 'note' && message.transientId !== editingMessageId"
+                :edit-note="editNote"
                 :note="message"
                 :is-open="includes(openMessages, message.transientId)" />
               <EditAdvisingNote
@@ -237,11 +238,11 @@ export default {
   },
   watch: {
     filter() {
-      this.screenReaderAlert = this.describeTheActiveTab();
+      this.alertScreenReader(this.describeTheActiveTab());
       this.openMessages = [];
     },
     isShowingAll() {
-      this.screenReaderAlert = this.describeTheActiveTab();
+      this.alertScreenReader(this.describeTheActiveTab());
     }
   },
   created() {
@@ -257,7 +258,7 @@ export default {
       });
     });
     this.sortMessages();
-    this.screenReaderAlert = 'Academic Timeline has loaded';
+    this.alertScreenReader('Academic Timeline has loaded');
     this.isTimelineLoading = false;
   },
   methods: {
@@ -269,7 +270,7 @@ export default {
       note.subject = subject;
       note.body = note.message = body;
       this.editingMessageId = null;
-      this.screenReaderAlert = 'Changes to note have been saved';
+      this.alertScreenReader('Changes to note have been saved');
     },
     describeTheActiveTab() {
       const inViewCount =
@@ -304,7 +305,7 @@ export default {
       this.sortMessages();
       this.gaNoteEvent(note.id, `Advisor ${this.user.uid} created note`, 'create');
     },
-    onEditNoteClick(message) {
+    editNote(message) {
       this.editingMessageId = message.transientId;
       this.putFocusNextTick('edit-note-subject');
     },

--- a/src/layouts/Login.vue
+++ b/src/layouts/Login.vue
@@ -76,7 +76,7 @@ export default {
       if (this.size(this.errors)) {
         this.errorMessages = this.map(this.errors, 'message');
         this.putFocusNextTick('splash-sign-in');
-        this.clearErrorsInStore();
+        this.clearAlertsInStore();
       }
     },
     logIn() {

--- a/src/layouts/StandardLayout.vue
+++ b/src/layouts/StandardLayout.vue
@@ -24,6 +24,7 @@
       </div>
       <div class="index-container-content">
         <div id="content" class="body-text">
+          <span v-if="srAlert" class="sr-only" aria-live="polite">{{ srAlert }}</span>
           <!-- The ':key' attribute forces component reload when same route is requested with diff id in path. -->
           <router-view :key="stripAnchorRef($route.fullPath)"></router-view>
         </div>
@@ -34,6 +35,7 @@
 </template>
 
 <script>
+import Context from '@/mixins/Context';
 import Footer from '@/components/Footer';
 import HeaderMenu from '@/components/HeaderMenu';
 import Loading from '@/mixins/Loading';
@@ -47,7 +49,7 @@ export default {
     HeaderMenu,
     Sidebar
   },
-  mixins: [Loading, Util],
+  mixins: [Context, Loading, Util],
   created() {
     this.putFocusNextTick('home-header');
   },

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -10,14 +10,16 @@ export default {
       'devAuthEnabled',
       'errors',
       'featureFlagEditNotes',
+      'srAlert',
       'supportEmailAddress'
     ])
   },
   methods: {
     ...mapActions('context', [
-      'clearErrorsInStore',
+      'clearAlertsInStore',
       'dismissError',
-      'reportError'
+      'reportError',
+      'alertScreenReader'
     ])
   }
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -137,7 +137,7 @@ const router = new Router({
 
 router.beforeEach((to: any, from: any, next: any) => {
   store.dispatch('context/loadConfig').then(() => {
-    store.dispatch('context/clearErrorsInStore').then(() => next());
+    store.dispatch('context/clearAlertsInStore').then(() => next());
   });
 });
 

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -5,7 +5,8 @@ import Vue from 'vue';
 const state = {
   config: undefined,
   errors: [],
-  loading: undefined
+  loading: undefined,
+  screenReaderAlert: undefined
 };
 
 const getters = {
@@ -17,11 +18,15 @@ const getters = {
   featureFlagEditNotes: (state: any): any => _.get(state.config, 'featureFlagEditNotes'),
   googleAnalyticsId: (state: any): string => _.get(state.config, 'googleAnalyticsId'),
   loading: (state: any): boolean => state.loading,
+  srAlert: (state: any): string => state.screenReaderAlert,
   supportEmailAddress: (state: any): string => _.get(state.config, 'supportEmailAddress')
 };
 
 const mutations = {
-  clearErrorsInStore: (state: any) => (state.errors = []),
+  clearAlertsInStore: (state: any) => {
+    state.errors = [];
+    state.screenReaderAlert = undefined;
+  },
   dismissError: (state: any, id: number) => {
     const indexOf = state.errors.findIndex((e: any) => e.id === id);
     if (indexOf > -1) {
@@ -35,11 +40,12 @@ const mutations = {
     state.errors.push(error);
     Vue.prototype.$eventHub.$emit('error-reported', error);
   },
+  screenReaderAlert: (state: any, alert: any) => (state.screenReaderAlert = alert),
   storeConfig: (state: any, config: any) => (state.config = config)
 };
 
 const actions = {
-  clearErrorsInStore: ({ commit }) => commit('clearErrorsInStore'),
+  clearAlertsInStore: ({ commit }) => commit('clearAlertsInStore'),
   dismissError: ({ commit }, id) => commit('dismissError', id),
   loadingComplete: ({ commit }) => commit('loadingComplete'),
   loadingStart: ({ commit }) => commit('loadingStart'),
@@ -55,7 +61,8 @@ const actions = {
       }
     });
   },
-  reportError: ({ commit }, error) => commit('reportError', error)
+  reportError: ({ commit }, error) => commit('reportError', error),
+  alertScreenReader: ({ commit }, alert) => commit('screenReaderAlert', alert)
 };
 
 export default {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1938

Having screenreader-alerts managed via `context` (vuex store) allows modals to close without user missing the announcement. This PR also puts sr-only "edit note" button after note subject in tab order. 