### PR TITLE
BOAC-1969, decouple dev-auth and demo-mode

### DIFF
--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -44,6 +44,7 @@ def app_config():
         'ebEnvironment': app.config['EB_ENVIRONMENT'] if 'EB_ENVIRONMENT' in app.config else None,
         'featureFlagEditNotes': app.config['FEATURE_FLAG_EDIT_NOTES'],
         'googleAnalyticsId': app.config['GOOGLE_ANALYTICS_ID'],
+        'isDemoModeAvailable': app.config['DEMO_MODE_AVAILABLE'],
         'supportEmailAddress': app.config['BOAC_SUPPORT_EMAIL'],
     })
 

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -94,7 +94,7 @@ def authorized_user_groups():
 @app.route('/api/user/demo_mode', methods=['POST'])
 @login_required
 def set_demo_mode():
-    if app.config['DEVELOPER_AUTH_ENABLED']:
+    if app.config['DEMO_MODE_AVAILABLE']:
         in_demo_mode = request.get_json().get('demoMode', None)
         if in_demo_mode is None:
             raise errors.BadRequestError('Parameter \'demoMode\' not found')

--- a/config/default.py
+++ b/config/default.py
@@ -29,6 +29,9 @@ import os
 # Base directory for the application (one level up from this config file).
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
+# In demo mode, student profile pictures and sensitive data will be blurred.
+DEMO_MODE_AVAILABLE = False
+
 # These "INDEX_HTML" defaults are good in boac-dev, boac-qa, etc. See development.py for appropriate local configs.
 INDEX_HTML = 'dist/static/index.html'
 

--- a/config/development.py
+++ b/config/development.py
@@ -26,8 +26,11 @@ ENHANCEMENTS, OR MODIFICATIONS.
 # Development environment.
 DEBUG = True
 
-INDEX_HTML = 'public/index.html'
-VUE_LOCALHOST_BASE_URL = 'http://localhost:8080'
+DEMO_MODE_AVAILABLE = True
 
 # TODO: Remove when note creation is in prod
 FEATURE_FLAG_EDIT_NOTES = True
+
+INDEX_HTML = 'public/index.html'
+
+VUE_LOCALHOST_BASE_URL = 'http://localhost:8080'

--- a/config/test.py
+++ b/config/test.py
@@ -23,18 +23,19 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
-SQLALCHEMY_DATABASE_URI = 'postgres://boac:boac@localhost:5432/boac_test'
-DATA_LOCH_URI = 'postgres://boac:boac@localhost:5432/boac_loch_test'
-DATA_LOCH_RDS_URI = 'postgres://boac:boac@localhost:5432/boac_loch_test'
-TESTING = True
-
-LOGGING_LOCATION = 'STDOUT'
-
 ALERT_INFREQUENT_ACTIVITY_ENABLED = False
 ALERT_WITHDRAWAL_ENABLED = False
 
-INDEX_HTML = 'tests/static/test-index.html'
+DATA_LOCH_RDS_URI = 'postgres://boac:boac@localhost:5432/boac_loch_test'
+DATA_LOCH_URI = 'postgres://boac:boac@localhost:5432/boac_loch_test'
 
 # TODO: Remove when note creation is in prod
 FEATURE_FLAG_EDIT_NOTES = True
+
+INDEX_HTML = 'tests/static/test-index.html'
+
+LOGGING_LOCATION = 'STDOUT'
+
+SQLALCHEMY_DATABASE_URI = 'postgres://boac:boac@localhost:5432/boac_test'
+
+TESTING = True

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -14,7 +14,7 @@
             <div class="b-link-text">{{ user.firstName }}</div><i class="ml-1 fas fa-caret-down b-link-text"></i>
           </div>
         </template>
-        <b-dropdown-item v-if="user.isAdmin || devAuthEnabled" @click="goAdmin">Admin</b-dropdown-item>
+        <b-dropdown-item v-if="user.isAdmin || isDemoModeAvailable" @click="goAdmin">Admin</b-dropdown-item>
         <b-dropdown-item href="#" @click="logOut">Log Out</b-dropdown-item>
         <b-dropdown-item :href="`mailto:${supportEmailAddress}`" target="_blank">Feedback/Help</b-dropdown-item>
       </b-dropdown>

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -10,6 +10,7 @@ export default {
       'devAuthEnabled',
       'errors',
       'featureFlagEditNotes',
+      'isDemoModeAvailable',
       'srAlert',
       'supportEmailAddress'
     ])

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -17,6 +17,7 @@ const getters = {
   errors: (state: any): any => state.errors,
   featureFlagEditNotes: (state: any): any => _.get(state.config, 'featureFlagEditNotes'),
   googleAnalyticsId: (state: any): string => _.get(state.config, 'googleAnalyticsId'),
+  isDemoModeAvailable: (state: any): string => _.get(state.config, 'isDemoModeAvailable'),
   loading: (state: any): boolean => state.loading,
   srAlert: (state: any): string => state.screenReaderAlert,
   supportEmailAddress: (state: any): string => _.get(state.config, 'supportEmailAddress')

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -7,7 +7,7 @@
         aria-live="passive"
         class="sr-only">Admin page loaded</span>
       <h1>BOAC Flight Deck</h1>
-      <div v-if="devAuthEnabled" class="d-flex flex-row mt-3 mb-3">
+      <div v-if="isDemoModeAvailable" class="d-flex flex-row mt-3 mb-3">
         <div class="mr-3">
           <img
             id="avatar-verify-blur"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,13 +23,13 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 import glob
 import json
 import os
 
 import boac.factory
 import pytest
+from tests.util import override_config
 
 
 os.environ['BOAC_ENV'] = 'test'
@@ -41,16 +41,16 @@ class FakeAuth(object):
         self.client = the_client
 
     def login(self, uid):
-        self.app.config['DEVELOPER_AUTH_ENABLED'] = True
-        params = {
-            'uid': uid,
-            'password': self.app.config['DEVELOPER_AUTH_PASSWORD'],
-        }
-        self.client.post(
-            '/api/auth/dev_auth_login',
-            data=json.dumps(params),
-            content_type='application/json',
-        )
+        with override_config(self.app, 'DEVELOPER_AUTH_ENABLED', True):
+            params = {
+                'uid': uid,
+                'password': self.app.config['DEVELOPER_AUTH_PASSWORD'],
+            }
+            self.client.post(
+                '/api/auth/dev_auth_login',
+                data=json.dumps(params),
+                content_type='application/json',
+            )
 
 
 # Because app and db fixtures are only created once per pytest run, individual tests

--- a/tests/test_api/test_admin_controller.py
+++ b/tests/test_api/test_admin_controller.py
@@ -24,6 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 import pytest
+from tests.util import override_config
 
 
 @pytest.fixture()
@@ -56,20 +57,20 @@ class TestCachejobAccess:
 
     def test_api_key_match(self, app, client):
         api_key = 'Hey ho, seely sheepe!'
-        app.config['API_KEY'] = api_key
-        headers = {'app_key': api_key}
-        response = client.get('/api/admin/cachejob', headers=headers)
-        assert response.status_code == 200
-        assert response.headers.get('Content-Type') == 'application/json'
+        with override_config(app, 'API_KEY', api_key):
+            headers = {'app_key': api_key}
+            response = client.get('/api/admin/cachejob', headers=headers)
+            assert response.status_code == 200
+            assert response.headers.get('Content-Type') == 'application/json'
 
     def test_api_key_no_match(self, app, client):
-        app.config['API_KEY'] = 'Hey ho, seely sheepe!'
-        headers = {'app_key': 'I saw the bouncing Bellibone'}
-        response = client.get('/api/admin/cachejob', headers=headers)
-        assert response.status_code == 401
+        with override_config(app, 'API_KEY', 'Hey ho, seely sheepe!'):
+            headers = {'app_key': 'I saw the bouncing Bellibone'}
+            response = client.get('/api/admin/cachejob', headers=headers)
+            assert response.status_code == 401
 
     def test_api_key_disabled(self, app, client):
-        app.config['API_KEY'] = None
-        headers = {'app_key': None}
-        response = client.get('/api/admin/cachejob', headers=headers)
-        assert response.status_code == 401
+        with override_config(app, 'API_KEY', None):
+            headers = {'app_key': None}
+            response = client.get('/api/admin/cachejob', headers=headers)
+            assert response.status_code == 401

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -23,6 +23,10 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+from tests.util import override_config
+
+asc_advisor_uid = '1081940'
+
 
 class TestConfigController:
     """Config API."""
@@ -45,3 +49,13 @@ class TestConfigController:
         assert response.status_code == 200
         assert 'version' in response.json
         assert 'build' in response.json
+
+    def test_demo_mode_on(self, app, client):
+        """Demo-mode/blur is on."""
+        with override_config(app, 'DEMO_MODE_AVAILABLE', True):
+            assert client.get('/api/config').json.get('isDemoModeAvailable')
+
+    def test_demo_mode_off(self, app, client):
+        """Demo-mode/blur is off."""
+        with override_config(app, 'DEMO_MODE_AVAILABLE', False):
+            assert not client.get('/api/config').json.get('isDemoModeAvailable')

--- a/tests/test_auth/test_dev_auth.py
+++ b/tests/test_auth/test_dev_auth.py
@@ -25,6 +25,8 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import json
 
+from tests.util import override_config
+
 
 class TestDevAuth:
     """DevAuth handling."""
@@ -33,45 +35,45 @@ class TestDevAuth:
 
     def test_disabled(self, app, client):
         """Blocks access unless enabled."""
-        app.config['DEVELOPER_AUTH_ENABLED'] = False
-        response = client.post('/api/auth/dev_auth_login')
-        assert response.status_code == 404
-        params = {'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
-        response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
-        assert response.status_code == 404
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', False):
+            response = client.post('/api/auth/dev_auth_login')
+            assert response.status_code == 404
+            params = {'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
+            response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
+            assert response.status_code == 404
 
     def test_password_fail(self, app, client):
         """Fails if no match on developer password."""
-        app.config['DEVELOPER_AUTH_ENABLED'] = True
-        params = {'uid': self.authorized_uid, 'password': 'Born 2 Lose'}
-        response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
-        assert response.status_code == 401
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
+            params = {'uid': self.authorized_uid, 'password': 'Born 2 Lose'}
+            response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
+            assert response.status_code == 401
 
     def test_authorized_user_fail(self, app, client):
         """Fails if the chosen UID does not match an authorized user."""
-        app.config['DEVELOPER_AUTH_ENABLED'] = True
-        params = {'uid': 'A Bad Sort', 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
-        response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
-        assert response.status_code == 403
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
+            params = {'uid': 'A Bad Sort', 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
+            response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
+            assert response.status_code == 403
 
     def test_unauthorized_user(self, app, client):
         """Fails if the chosen UID does not match an authorized user."""
-        app.config['DEVELOPER_AUTH_ENABLED'] = True
-        params = {'uid': '1015674', 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
-        response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
-        assert response.status_code == 403
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
+            params = {'uid': '1015674', 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
+            response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
+            assert response.status_code == 403
 
     def test_known_user_with_correct_password_logs_in(self, app, client):
         """There is a happy path."""
-        app.config['DEVELOPER_AUTH_ENABLED'] = True
-        params = {'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
-        response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
-        assert response.status_code == 200
-        response = client.get('/api/user/status')
-        assert response.status_code == 200
-        assert response.json['uid'] == self.authorized_uid
-        response = client.get('/api/auth/logout')
-        assert response.status_code == 200
-        response = client.get('/api/user/status')
-        assert response.status_code == 200
-        assert response.json['isAnonymous']
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
+            params = {'uid': self.authorized_uid, 'password': app.config['DEVELOPER_AUTH_PASSWORD']}
+            response = client.post('/api/auth/dev_auth_login', data=json.dumps(params), content_type='application/json')
+            assert response.status_code == 200
+            response = client.get('/api/user/status')
+            assert response.status_code == 200
+            assert response.json['uid'] == self.authorized_uid
+            response = client.get('/api/auth/logout')
+            assert response.status_code == 200
+            response = client.get('/api/user/status')
+            assert response.status_code == 200
+            assert response.json['isAnonymous']


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1969

* further use of `override_config`
* review with `?w=1` for a simpler diff