### PR TITLE
BOAC-1816: Makes pages wait for user data before finishing loading

### DIFF
--- a/src/mixins/GoogleAnalytics.vue
+++ b/src/mixins/GoogleAnalytics.vue
@@ -1,15 +1,25 @@
 <script>
-import store from '@/store';
 import { event } from 'vue-analytics';
+import { mapGetters } from 'vuex';
 
 export default {
   name: 'GoogleAnalytics',
+  computed: {
+    ...mapGetters('user', ['user'])
+  },
   methods: {
     gaEvent(category, action, label, value) {
-      const user = store.getters['user/user'];
-      event(category, action, label, value, {
-        userId: user.uid
-      });
+      if (this.user) {
+        event(category, action, label, value, {
+          userId: this.user.uid
+        });
+      } else {
+        this.$watch('user', () => {
+          event(category, action, label, value, {
+            userId: this.user.uid
+          });
+        }); 
+      }
     },
     gaCohortEvent(id, name, action) {
       this.gaEvent('Cohort', action, name, id);

--- a/src/mixins/Loading.vue
+++ b/src/mixins/Loading.vue
@@ -5,12 +5,20 @@ import { mapActions, mapGetters } from 'vuex';
 export default {
   name: 'Loading',
   computed: {
-    ...mapGetters('context', ['loading'])
+    ...mapGetters('context', ['loading']),
+    ...mapGetters('user', ['user'])
   },
   beforeCreate: () => store.dispatch('context/loadingStart'),
   methods: {
     ...mapActions('context', ['loadingStart']),
     loaded() {
+      if (this.user) {
+        this.finishLoading();
+      } else {
+        this.$watch('user', this.finishLoading);
+      }
+    },
+    finishLoading() {
       store.dispatch('context/loadingComplete');
       this.$nextTick(() => {
         if (this.$refs.pageHeader) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1816

On pages that have a component or sub-component reliant on the `user` object, the spinner will spin until the `api/profile/my` response is received.