### PR TITLE
BOAC-1967, if create/edit note in progress then 'Are you sure?' if navigating away

### DIFF
--- a/src/mixins/NoteEditSession.vue
+++ b/src/mixins/NoteEditSession.vue
@@ -1,0 +1,19 @@
+<script>
+import { mapActions, mapGetters } from 'vuex';
+
+export default {
+  name: 'NoteEditSession',
+  computed: {
+    ...mapGetters('noteEditSession', [
+      'editingNoteId',
+      'newNoteMode'
+    ])
+  },
+  methods: {
+    ...mapActions('noteEditSession', [
+      'editExistingNoteId',
+      'setNewNoteMode'
+    ])
+  }
+};
+</script>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import cohort from '@/store/modules/cohort';
 import cohortEditSession from '@/store/modules/cohort-edit-session';
 import context from '@/store/modules/context';
 import curated from '@/store/modules/curated';
+import noteEditSession from '@/store/modules/note-edit-session';
 import user from '@/store/modules/user';
 import Vue from 'vue';
 import Vuex from 'vuex';
@@ -14,6 +15,7 @@ export default new Vuex.Store({
     cohortEditSession,
     context,
     curated,
+    noteEditSession,
     user
   },
   strict: process.env.NODE_ENV !== 'production'

--- a/src/store/modules/note-edit-session.ts
+++ b/src/store/modules/note-edit-session.ts
@@ -1,0 +1,27 @@
+const state = {
+  editingNoteId: undefined,
+  newNoteMode: undefined
+};
+
+const getters = {
+  editingNoteId: (state: any): number => state.editingNoteId,
+  newNoteMode: (state: any): string => state.newNoteMode
+};
+
+const mutations = {
+  editExistingNoteId: (state: any, id: number) => (state.editingNoteId = id),
+  setNewNoteMode: (state: any, mode: string) => (state.newNoteMode = mode)
+};
+
+const actions = {
+  editExistingNoteId: ({ commit }, id: number) => commit('editExistingNoteId', id),
+  setNewNoteMode: ({ commit }, mode: string) => commit('setNewNoteMode', mode)
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+};

--- a/src/views/Student.vue
+++ b/src/views/Student.vue
@@ -18,6 +18,12 @@
       </div>
       <div class="m-3">
         <AcademicTimeline :student="student" />
+        <AreYouSureModal
+          v-if="showAreYouSureModal"
+          :function-cancel="cancelTheCancel"
+          :function-confirm="cancelConfirmed"
+          modal-header="Discard unsaved note?"
+          :show-modal="showAreYouSureModal" />
       </div>
       <div>
         <StudentClasses :student="student" />
@@ -28,7 +34,9 @@
 
 <script>
 import AcademicTimeline from '@/components/student/profile/AcademicTimeline';
+import AreYouSureModal from '@/components/util/AreYouSureModal';
 import Loading from '@/mixins/Loading';
+import NoteEditSession from '@/mixins/NoteEditSession';
 import Scrollable from '@/mixins/Scrollable';
 import Spinner from '@/components/util/Spinner';
 import StudentClasses from '@/components/student/profile/StudentClasses';
@@ -42,19 +50,35 @@ export default {
   name: 'Student',
   components: {
     AcademicTimeline,
+    AreYouSureModal,
     Spinner,
     StudentClasses,
     StudentProfileGPA,
     StudentProfileHeader,
     StudentProfileUnits
   },
-  mixins: [Loading, Scrollable, Util],
+  mixins: [Loading, NoteEditSession, Scrollable, Util],
   data: () => ({
+    cancelTheCancel: undefined,
+    cancelConfirmed: undefined,
     showAllTerms: false,
+    showAreYouSureModal: false,
     student: {
       termGpa: []
     }
   }),
+  beforeRouteLeave(to, from, next) {
+    if (this.newNoteMode || this.editingNoteId) {
+      this.cancelConfirmed = () => next();
+      this.cancelTheCancel = () => {
+        this.showAreYouSureModal = false;
+        next(false);
+      };
+      this.showAreYouSureModal = true;
+    } else {
+      next();
+    }
+  },
   created() {
     const uid = this.get(this.$route, 'params.uid');
     getStudent(uid).then(data => {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1967

Vuex store used to watch `newNoteMode` and `editingNoteId`.  Only the top-level `Student` can use `beforeRouteLeave()` (which captures the navigate-away event) because it's the component registered in `router.ts`. See docs: https://router.vuejs.org/guide/advanced/navigation-guards.html#in-component-guards