### PR TITLE
BOAC-2011, both /cohorts/all and /admin must handle empty advisor name

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -60,7 +60,7 @@ def all_cohorts():
             'cohorts': sorted(cohorts_per_uid[uid], key=lambda c: c['name']),
         })
         owners.append(owner)
-    owners = sorted(owners, key=lambda o: (o['firstName'], o['lastName']))
+    owners = sorted(owners, key=lambda o: (o.get('name') or ''))
     return tolerant_jsonify(owners)
 
 

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -81,7 +81,7 @@ def authorized_users_api_feed(users, sort_by='lastName'):
     profiles = []
     for user in users:
         profile = calnet.get_calnet_user_for_uid(app, user.uid)
-        profile['name'] = (profile.get('firstName') or '') + ' ' + (profile.get('lastName') or '')
+        profile['name'] = ((profile.get('firstName') or '') + ' ' + (profile.get('lastName') or '')).strip()
         profile.update({
             'id': user.id,
             'isAdmin': user.is_admin,

--- a/boac/lib/cohort_filter_definition.py
+++ b/boac/lib/cohort_filter_definition.py
@@ -304,7 +304,7 @@ def _get_coe_profiles():
         uid = user['uid']
         first_name = user.get('firstName')
         last_name = user.get('lastName')
-        name = f'{first_name} {last_name}' if first_name or last_name else uid
+        name = f'{first_name} {last_name}' if first_name or last_name else f'UID: {uid}'
         profiles.append({'name': name, 'value': uid})
     return sorted(profiles, key=lambda p: p['name'])
 

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -41,7 +41,10 @@
                       :class="{'faint-text pb-2': groupUser.uid === user.uid}"
                       :aria-label="`Go to UC Berkeley Directory page of ${groupUser.name}`"
                       :href="`https://www.berkeley.edu/directory/results?search-term=${groupUser.name}`"
-                      target="_blank">{{ groupUser.name }}</a>
+                      target="_blank">
+                      <span v-if="groupUser.name">{{ groupUser.name }}</span>
+                      <span v-if="!groupUser.name">UID: {{ groupUser.uid }}</span>
+                    </a>
                   </b-col>
                   <b-col v-if="groupUser.uid !== user.uid">
                     <b-btn

--- a/src/views/AllCohorts.vue
+++ b/src/views/AllCohorts.vue
@@ -8,7 +8,10 @@
         <div>There are no saved cohorts</div>
       </div>
       <div v-for="owner in usersWithCohorts" :key="owner.uid">
-        <h2 class="page-section-header-sub">{{ owner.firstName }} {{ owner.lastName }}</h2>
+        <h2 class="page-section-header-sub">
+          <span v-if="owner.name">{{ owner.name }}</span>
+          <span v-if="!owner.name">UID: {{ owner.uid }}</span>
+        </h2>
         <ul>
           <li v-for="cohort in owner.cohorts" :key="cohort.id">
             <router-link :to="'/cohort/' + cohort.id">{{ cohort.name }}</router-link> ({{ cohort.totalStudentCount }})


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2011
https://jira.ets.berkeley.edu/jira/browse/BOAC-1877

In this PR, we treat one symptom of, according to CalNet, former-employee-advisors. The root cause will be handled in https://jira.ets.berkeley.edu/jira/browse/NS-417