### PR TITLE
BOAC-1877 Do not include ex-advisors in Act As list

### DIFF
--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -80,7 +80,9 @@ def authorized_users_api_feed(users, sort_by='lastName'):
         return ()
     profiles = []
     for user in users:
-        profile = calnet.get_calnet_user_for_uid(app, user.uid)
+        profile = calnet.get_calnet_user_for_uid(app, user.uid, force_feed=False)
+        if not profile:
+            continue
         profile['name'] = ((profile.get('firstName') or '') + ' ' + (profile.get('lastName') or '')).strip()
         profile.update({
             'id': user.id,

--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -29,8 +29,10 @@ from boac.models.json_cache import stow
 
 
 @stow('calnet_user_for_uid_{uid}')
-def get_calnet_user_for_uid(app, uid):
+def get_calnet_user_for_uid(app, uid, force_feed=True):
     persons = calnet.client(app).search_uids([uid])
+    if not persons and not force_feed:
+        return None
     return {
         **_calnet_user_api_feed(persons[0] if len(persons) else None),
         **{'uid': uid},

--- a/fixtures/calnet_search_entries.json
+++ b/fixtures/calnet_search_entries.json
@@ -70,6 +70,358 @@
                 "sn": [ "Anderson" ],
                 "uid": [ "1133399" ]
             }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "2040",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "2040" ]
+            },
+            "dn": "uid=2040,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "2040" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "53791",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "53791" ]
+            },
+            "dn": "uid=53791,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "53791" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "95509",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "95509" ]
+            },
+            "dn": "uid=95509,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "95509" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "177473",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "177473" ]
+            },
+            "dn": "uid=177473,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "177473" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "211159",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "211159" ]
+            },
+            "dn": "uid=211159,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "211159" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "242881",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "242881" ]
+            },
+            "dn": "uid=242881,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "242881" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "1049291",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "1049291" ]
+            },
+            "dn": "uid=1049291,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "1049291" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "90412",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "90412" ]
+            },
+            "dn": "uid=90412,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "90412" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "1022796",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "1022796" ]
+            },
+            "dn": "uid=1022796,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "1022796" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "1081940",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "1081940" ]
+            },
+            "dn": "uid=1081940,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "1081940" ]
+            }
+        },
+        {
+            "attributes": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": "6446",
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "6446" ]
+            },
+            "dn": "uid=6446,ou=people,dc=berkeley,dc=edu",
+            "raw": {
+                "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "objectClass": [
+                    "top",
+                    "eduPerson",
+                    "inetorgperson",
+                    "berkeleyEduPerson",
+                    "organizationalperson",
+                    "person",
+                    "ucEduPerson"
+                ],
+                "ou": [ "people" ],
+                "uid": [ "6446" ]
+            }
         }
     ]
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1877

The current logic assumes at a pretty low level that we get faked results from LDAP when real results aren't returned, and so I made the decision optional for now. In a follow-up, I'd like to leave the choice up to higher-level code.