### PR TITLE
BOAC-1917, expand LDAP/CalNet query to include 'expired people'

### DIFF
--- a/boac/externals/calnet.py
+++ b/boac/externals/calnet.py
@@ -71,37 +71,37 @@ class Client:
         conn = ldap3.Connection(self.server, user=self.bind, password=self.password, auto_bind=ldap3.AUTO_BIND_TLS_BEFORE_BIND)
         return conn
 
-    def search_csids(self, csids):
+    def search_csids(self, csids, search_expired=False):
         all_out = []
         for i in range(0, len(csids), BATCH_QUERY_MAXIMUM):
             csids_batch = csids[i:i + BATCH_QUERY_MAXIMUM]
             with self.connect() as conn:
-                search_filter = self._ldap_search_filter(csids_batch, 'berkeleyeducsid')
+                search_filter = self._ldap_search_filter(csids_batch, 'berkeleyeducsid', search_expired)
                 conn.search('dc=berkeley,dc=edu', search_filter, attributes=ldap3.ALL_ATTRIBUTES)
                 all_out += [_attributes_to_dict(entry) for entry in conn.entries]
         return all_out
 
-    def search_uids(self, uids):
+    def search_uids(self, uids, search_expired=False):
         all_out = []
         for i in range(0, len(uids), BATCH_QUERY_MAXIMUM):
             uids_batch = uids[i:i + BATCH_QUERY_MAXIMUM]
             with self.connect() as conn:
-                search_filter = self._ldap_search_filter(uids_batch, 'uid')
+                search_filter = self._ldap_search_filter(uids_batch, 'uid', search_expired)
                 conn.search('dc=berkeley,dc=edu', search_filter, attributes=ldap3.ALL_ATTRIBUTES)
                 all_out += [_attributes_to_dict(entry) for entry in conn.entries]
         return all_out
 
     @classmethod
-    def _ldap_search_filter(cls, ids, id_type):
+    def _ldap_search_filter(cls, ids, id_type, search_expired=False):
         ids_filter = ''.join(f'({id_type}={_id})' for _id in ids)
+        ou_scope = '(ou=expired people)' if search_expired else '(ou=people) (ou=advcon people)'
         return f"""(&
             (objectclass=person)
             (|
                 {ids_filter}
             )
             (|
-                (ou=people)
-                (ou=advcon people)
+                { ou_scope }
             )
         )"""
 

--- a/boac/merged/calnet.py
+++ b/boac/merged/calnet.py
@@ -30,7 +30,10 @@ from boac.models.json_cache import stow
 
 @stow('calnet_user_for_uid_{uid}')
 def get_calnet_user_for_uid(app, uid, force_feed=True):
-    persons = calnet.client(app).search_uids([uid])
+    for search_expired in (False, True):
+        persons = calnet.client(app).search_uids([uid], search_expired)
+        if persons:
+            break
     if not persons and not force_feed:
         return None
     return {
@@ -41,7 +44,10 @@ def get_calnet_user_for_uid(app, uid, force_feed=True):
 
 @stow('calnet_user_for_csid_{csid}')
 def get_calnet_user_for_csid(app, csid):
-    persons = calnet.client(app).search_csids([csid])
+    for search_expired in (False, True):
+        persons = calnet.client(app).search_csids([csid], search_expired)
+        if persons:
+            break
     return {
         **_calnet_user_api_feed(persons[0] if len(persons) else None),
         **{'csid': csid},


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1917

Broadening our calnet query allows us to put off https://jira.ets.berkeley.edu/jira/browse/NS-417  

Plus, we're evaluating advisor data from SIS. When we have a clearer picture we will reconsider a shadow db table in Nessie-land.