### PR TITLE
BOAC-2043, '/api/notes/attachment/upload' API with tests; put id pkey on note_attachments table

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -117,6 +117,26 @@ def download_attachment(attachment_filename):
     return r
 
 
+@app.route('/api/notes/attachment/upload', methods=['POST'])
+@login_required
+def upload_attachment():
+    note_id = request.form.get('noteId', None)
+    if not note_id:
+        raise BadRequestError('Attachment upload requires \'noteId\'')
+    note = Note.find_by_id(note_id=note_id)
+    if note.author_uid != current_user.uid:
+        raise ForbiddenRequestError('Sorry, you are not the author of this note.')
+    if 'file' not in request.files:
+        raise BadRequestError('No file object in HTTP request')
+    file = request.files['file']
+    filename = file.filename and file.filename.strip()
+    if not filename:
+        raise BadRequestError('Invalid file or none selected')
+    path_to_attachment = 'TODO: upload attachment to S3'  # upload_note_attachment(note_id, file.filename, file)
+    attachment = Note.add_attachment(note.id, path_to_attachment)
+    return tolerant_jsonify(attachment.to_api_json())
+
+
 def _get_name(user):
     first_name = user.get('firstName')
     last_name = user.get('lastName')

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -53,11 +53,15 @@ def get_advising_notes(sid):
     for legacy_note in legacy_notes:
         note_id = legacy_note['id']
         note = {camelize(key): legacy_note[key] for key in legacy_note.keys()}
-        notes_by_id[note_id] = note_to_compatible_json(note, legacy_topics.get(note_id), legacy_attachments.get(note_id))
+        notes_by_id[note_id] = note_to_compatible_json(
+            note=note,
+            topics=legacy_topics.get(note_id),
+            attachments=legacy_attachments.get(note_id),
+        )
         notes_by_id[note_id]['isLegacy'] = True
     for note in [n.to_api_json() for n in Note.get_notes_by_sid(sid)]:
         note_id = note['id']
-        notes_by_id[str(note_id)] = note_to_compatible_json(note)
+        notes_by_id[str(note_id)] = note_to_compatible_json(note=note, attachments=note.get('attachments'))
     if not notes_by_id.values():
         return None
     notes_read = NoteRead.get_notes_read_by_user(current_user.id, notes_by_id.keys())

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -87,8 +87,15 @@ class AlertView(db.Model):
 class NoteAttachment(db.Model):
     __tablename__ = 'note_attachments'
 
-    note_id = db.Column(db.Integer, db.ForeignKey('notes.id'), primary_key=True)
-    path_to_attachment = db.Column('path_to_attachment', db.String(255), primary_key=True)
+    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    note_id = db.Column(db.Integer, db.ForeignKey('notes.id'))
+    path_to_attachment = db.Column('path_to_attachment', db.String(255))
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
     deleted_at = db.Column(db.DateTime)
     note = db.relationship('Note', back_populates='attachments')
+
+    def to_api_json(self):
+        return {
+            'id': self.id,
+            'filename': self.path_to_attachment.rsplit('/', 1)[-1],
+        }

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -108,14 +108,10 @@ class Note(Base):
     @classmethod
     def add_attachment(cls, note_id, path_to_attachment):
         note = cls.find_by_id(note_id=note_id)
-        if note:
-            attachment = NoteAttachment(
-                note_id=note.id,
-                path_to_attachment=path_to_attachment,
-            )
-            db.session.add(attachment)
-            std_commit()
-        return note
+        attachment = NoteAttachment(note_id=note.id, path_to_attachment=path_to_attachment)
+        db.session.add(attachment)
+        std_commit()
+        return attachment
 
     @classmethod
     def get_notes_by_sid(cls, sid):
@@ -132,6 +128,7 @@ class Note(Base):
     def to_api_json(self):
         return {
             'id': self.id,
+            'attachments': [a.to_api_json() for a in self.attachments],
             'authorUid': self.author_uid,
             'authorName': self.author_name,
             'authorRole': self.author_role,

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -36,6 +36,7 @@ SET row_security = off;
 
 ALTER TABLE IF EXISTS ONLY public.notes DROP CONSTRAINT IF EXISTS notes_author_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_note_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_note_id_path_to_attachment_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.notes_read DROP CONSTRAINT IF EXISTS notes_read_viewer_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_user_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_cohort_filter_id_fkey;
@@ -91,6 +92,7 @@ ALTER TABLE IF EXISTS public.alerts ALTER COLUMN id DROP DEFAULT;
 DROP MATERIALIZED VIEW IF EXISTS public.notes_fts_index;
 DROP TABLE IF EXISTS public.notes;
 DROP TABLE IF EXISTS public.note_attachments;
+DROP SEQUENCE IF EXISTS public.note_attachments_id_seq;
 DROP TABLE IF EXISTS public.notes_read;
 DROP SEQUENCE IF EXISTS public.json_cache_id_seq;
 DROP TABLE IF EXISTS public.json_cache;

--- a/scripts/db/migrate/20190409-BOAC-2043/pre_deploy_01_create_note_attachments_table.sql
+++ b/scripts/db/migrate/20190409-BOAC-2043/pre_deploy_01_create_note_attachments_table.sql
@@ -1,6 +1,14 @@
 BEGIN;
 
+ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_note_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_note_id_path_to_attachment_unique_constraint;
+DROP INDEX IF EXISTS public.note_attachments_note_id_idx;
+ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_pkey;
+DROP TABLE IF EXISTS public.note_attachments;
+DROP SEQUENCE IF EXISTS public.note_attachments_id_seq;
+
 CREATE TABLE note_attachments (
+    id SERIAL NOT NULL,
     note_id INTEGER NOT NULL,
     path_to_attachment character varying(255) NOT NULL,
     created_at timestamp with time zone NOT NULL,
@@ -8,7 +16,11 @@ CREATE TABLE note_attachments (
 );
 
 ALTER TABLE ONLY note_attachments
-    ADD CONSTRAINT note_attachments_pkey PRIMARY KEY (note_id, path_to_attachment);
+    ADD CONSTRAINT note_attachments_pkey PRIMARY KEY (id);
+
+ALTER TABLE note_attachments
+    ADD CONSTRAINT note_attachments_note_id_path_to_attachment_unique_constraint
+        UNIQUE (note_id, path_to_attachment);
 
 CREATE INDEX note_attachments_note_id_idx ON note_attachments USING btree (note_id);
 

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -195,14 +195,26 @@ USING gin(fts_index);
 --
 
 CREATE TABLE note_attachments (
+    id integer NOT NULL,
     note_id INTEGER NOT NULL,
     path_to_attachment character varying(255) NOT NULL,
     created_at timestamp with time zone NOT NULL,
     deleted_at timestamp with time zone
 );
 ALTER TABLE note_attachments OWNER TO boac;
+CREATE SEQUENCE note_attachments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE note_attachments_id_seq OWNER TO boac;
+ALTER SEQUENCE note_attachments_id_seq OWNED BY note_attachments.id;
+ALTER TABLE ONLY note_attachments ALTER COLUMN id SET DEFAULT nextval('note_attachments_id_seq'::regclass);
 ALTER TABLE ONLY note_attachments
-    ADD CONSTRAINT note_attachments_pkey PRIMARY KEY (note_id, path_to_attachment);
+    ADD CONSTRAINT note_attachments_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY note_attachments
+    ADD CONSTRAINT note_attachments_note_id_path_to_attachment_unique_constraint UNIQUE (note_id, path_to_attachment);
 CREATE INDEX note_attachments_note_id_idx ON note_attachments USING btree (note_id);
 
 --

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -80,7 +80,7 @@ class TestMergedAdvisingNote:
         assert notes[3]['updatedAt']
         assert notes[3]['read'] is False
         assert notes[3]['topics'] is None
-        assert notes[3]['attachments'] is None
+        assert len(notes[3]['attachments']) == 1
 
     def test_get_advising_notes_ucbconversion_attachment(self, app, fake_auth):
         fake_auth.login(coe_advisor)
@@ -94,10 +94,17 @@ class TestMergedAdvisingNote:
     def test_get_advising_notes_cs_attachment(self, app, fake_auth):
         fake_auth.login(coe_advisor)
         notes = get_advising_notes('11667051')
+        assert len(notes) == 4
         assert notes[1]['attachments'] == [
             {
                 'sisFilename': '11667051_00002_2.jpeg',
                 'userFilename': 'brigitte_photo.jpeg',
+            },
+        ]
+        assert notes[-1]['attachments'] == [
+            {
+                'id': 1,
+                'filename': 'mock_advising_note_attachment.txt',
             },
         ]
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2043

Introduced `id` pkey on `note_attachments` table cuz the front-end cannot work with composite key `note_id` + `path_to_attachment`.  The pre-deploy script will make the adjustment if run again on BOA db.