### PR TITLE
BOAC-2069, add attachments in /update/note; verify delete note.attachments

### DIFF
--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -33,6 +33,7 @@ from boac.lib.util import camelize
 from boac.merged.calnet import get_calnet_users_for_csids
 from boac.merged.student import get_student_query_scope, narrow_scope_by_criteria
 from boac.models.note import Note
+from boac.models.note_attachment import NoteAttachment
 from boac.models.note_read import NoteRead
 from dateutil.tz import tzutc
 from flask import current_app as app
@@ -154,6 +155,21 @@ def _get_loch_notes_search_results(loch_results, student_rows_by_sid, search_ter
             'updatedAt': _resolve_updated_at(note),
         })
     return results
+
+
+def add_and_remove_attachments(note_id, files, delete_attachment_ids=()):
+    note = Note.find_by_id(note_id=note_id)
+    for file in files:
+        # TODO: Upload file to S3 and then capture bucket + s3_key
+        s3_path_to_attachment = file.filename  # upload_note_attachment(note_id, file.filename, file)
+        NoteAttachment.create(
+            note_id=note.id,
+            path_to_attachment=s3_path_to_attachment,
+            uploaded_by_uid=current_user.uid,
+        )
+    if delete_attachment_ids:
+        for delete_attachment_id in delete_attachment_ids:
+            NoteAttachment.delete(delete_attachment_id)
 
 
 def get_attachment_stream(filename):

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -28,7 +28,6 @@ from datetime import datetime
 from boac import db, std_commit
 from boac.models.base import Base
 from boac.models.university_dept import UniversityDept
-from sqlalchemy import and_
 
 
 cohort_filter_owners = db.Table(
@@ -82,32 +81,3 @@ class AlertView(db.Model):
     dismissed_at = db.Column(db.DateTime)
     viewer = db.relationship('AuthorizedUser', back_populates='alert_views')
     alert = db.relationship('Alert', back_populates='views')
-
-
-class NoteAttachment(db.Model):
-    __tablename__ = 'note_attachments'
-
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
-    note_id = db.Column(db.Integer, db.ForeignKey('notes.id'), nullable=False)
-    path_to_attachment = db.Column('path_to_attachment', db.String(255), nullable=False)
-    uploaded_by_uid = db.Column('uploaded_by_uid', db.String(255), nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
-    deleted_at = db.Column(db.DateTime)
-    note = db.relationship('Note', back_populates='attachments')
-
-    @classmethod
-    def find_by_id(cls, attachment_id):
-        return cls.query.filter(and_(cls.id == attachment_id, cls.deleted_at == None)).first()  # noqa: E711
-
-    @classmethod
-    def delete(cls, attachment_id):
-        attachment = cls.find_by_id(attachment_id)
-        attachment.deleted_at = datetime.now()
-        std_commit()
-
-    def to_api_json(self):
-        return {
-            'id': self.id,
-            'filename': self.path_to_attachment.rsplit('/', 1)[-1],
-            'uploadedBy': self.uploaded_by_uid,
-        }

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -29,6 +29,7 @@ from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
 from boac.models.curated_cohort import CuratedCohort
 from boac.models.note import Note
+from boac.models.note_attachment import NoteAttachment
 from boac.models.university_dept import UniversityDept
 # Models below are included so that db.create_all will find them.
 from boac.models.alert import Alert # noqa
@@ -280,7 +281,11 @@ def create_notes():
         """,
     )
     base_dir = app.config['BASE_DIR']
-    Note.add_attachment(note.id, f'{base_dir}/fixtures/mock_advising_note_attachment_1.txt', '6446')
+    NoteAttachment.create(
+        note_id=note.id,
+        path_to_attachment=f'{base_dir}/fixtures/mock_advising_note_attachment_1.txt',
+        uploaded_by_uid='6446',
+    )
     std_commit(allow_test_environment=True)
 
 

--- a/boac/models/note_attachment.py
+++ b/boac/models/note_attachment.py
@@ -1,0 +1,69 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from datetime import datetime
+
+from boac import db, std_commit
+from sqlalchemy import and_
+
+
+class NoteAttachment(db.Model):
+    __tablename__ = 'note_attachments'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    note_id = db.Column(db.Integer, db.ForeignKey('notes.id'), nullable=False)
+    path_to_attachment = db.Column('path_to_attachment', db.String(255), nullable=False)
+    uploaded_by_uid = db.Column('uploaded_by_uid', db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
+    deleted_at = db.Column(db.DateTime)
+    note = db.relationship('Note', back_populates='attachments')
+
+    def __init__(self, note_id, path_to_attachment, uploaded_by_uid):
+        self.note_id = note_id
+        self.path_to_attachment = path_to_attachment
+        self.uploaded_by_uid = uploaded_by_uid
+
+    @classmethod
+    def find_by_id(cls, attachment_id):
+        return cls.query.filter(and_(cls.id == attachment_id, cls.deleted_at == None)).first()  # noqa: E711
+
+    @classmethod
+    def create(cls, note_id, path_to_attachment, uploaded_by_uid):
+        attachment = cls(note_id=note_id, path_to_attachment=path_to_attachment, uploaded_by_uid=uploaded_by_uid)
+        db.session.add(attachment)
+        std_commit()
+
+    @classmethod
+    def delete(cls, attachment_id):
+        attachment = cls.find_by_id(attachment_id)
+        attachment.deleted_at = datetime.now()
+        std_commit()
+
+    def to_api_json(self):
+        return {
+            'id': self.id,
+            'filename': self.path_to_attachment.rsplit('/', 1)[-1],
+            'uploadedBy': self.uploaded_by_uid,
+        }

--- a/src/api/api-utils.ts
+++ b/src/api/api-utils.ts
@@ -1,0 +1,26 @@
+import _ from 'lodash';
+import store from "@/store";
+import axios from "axios";
+
+export default {
+  postMultipartFormData: (
+    path: string,
+    data: object
+  ) => {
+    const formData = new FormData();
+    _.each(data, (value, key) => {
+      formData.append(key, value);
+    });
+    const apiBaseUrl = store.getters['context/apiBaseUrl'];
+    return axios
+        .post(
+            `${apiBaseUrl}${path}`,
+            formData,
+            {
+              headers: {
+                'Content-Type': 'multipart/form-data'
+              }
+            })
+        .then(response => response.data);
+  }
+};

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import axios from 'axios';
 import store from '@/store';
+import apiUtils from '@/api/api-utils';
 
 export function markRead(noteId) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
@@ -10,33 +11,30 @@ export function markRead(noteId) {
 }
 
 export function createNote(sid: any, subject: string, body: string, attachments: any[]) {
-  const apiBaseUrl = store.getters['context/apiBaseUrl'];
-  const formData = new FormData();
-  formData.append('sid', sid.toString());
-  formData.append('subject', subject);
-  formData.append('body', body);
-  _.each(attachments || [], (attachment, index) => formData.append(`files[${index}]`, attachment));
-  return axios
-    .post(
-        `${apiBaseUrl}/api/notes/create`, formData,
-        {
-          headers: {
-            'Content-Type': 'multipart/form-data'
-          }
-        }
-        )
-    .then(response => response.data);
+  const data = {
+    sid: sid.toString(),
+    subject: subject,
+    body: body
+  };
+  _.each(attachments || [], (attachment, index) => data[`files[${index}]`] = attachment);
+  return apiUtils.postMultipartFormData('/api/notes/create', data);
 }
 
-export function updateNote(noteId: number, subject: string, body: string) {
-  let apiBaseUrl = store.getters['context/apiBaseUrl'];
-  return axios
-    .post(`${apiBaseUrl}/api/notes/update`, {
-      id: noteId,
-      subject: subject,
-      body: body
-    })
-    .then(response => response.data);
+export function updateNote(
+    noteId: number,
+    subject: string,
+    body: string,
+    attachments: any[],
+    deleteAttachmentIds: number[]
+) {
+  const data = {
+    id: noteId,
+    subject: subject,
+    body: body,
+    deleteAttachmentIds: deleteAttachmentIds || []
+  };
+  _.each(attachments || [], (attachment, index) => data[`files[${index}]`] = attachment);
+  return apiUtils.postMultipartFormData('/api/notes/update', data);
 }
 
 export function deleteNote(noteId: number) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2069

* `update_note` can add and remove attachments in a single transaction.
* includes the appropriate front-end work