### PR TITLE
BOAC-2064: Sets author on notes that render in an open state

### DIFF
--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -111,8 +111,19 @@ export default {
     }
   },
   watch: {
-    isOpen(open) {
-      if (open && this.isUndefined(this.author)) {
+    isOpen() {
+      this.setAuthor();
+    }
+  },
+  created() {
+    this.setAuthor();
+  },
+  methods: {
+    downloadUrl(attachment) {
+      return this.apiBaseUrl + '/api/notes/attachment/legacy/' + attachment.sisFilename;
+    },
+    setAuthor() {
+      if (this.isOpen && this.isUndefined(this.author)) {
         if (this.note.author.name) {
           this.author = this.note.author;
         } else {
@@ -134,11 +145,6 @@ export default {
           }
         }
       }
-    }
-  },
-  methods: {
-    downloadUrl(attachment) {
-      return this.apiBaseUrl + '/api/notes/attachment/legacy/' + attachment.sisFilename;
     }
   },
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2064

When editing of a note is saved or cancelled, it causes the AdvisingNote component to go through its lifecycle again - this time in a pre-opened state.  Since the value of `isOpen` is already `true` and doesn't change, the author wasn't being set.  We need to check for this condition when the component is created and set the author if appropriate.