### PR TITLE
BOAC-2104, move dupe logic/styles in new-note and edit-note to manage-attachments

### DIFF
--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -27,50 +27,18 @@
       </span>
     </div>
     <div class="mt-2 mb-2">
-      <div v-if="attachmentError" class="mt-3 mb-3 w-100">
-        <i class="fa fa-exclamation-triangle text-danger pr-1"></i>
-        <span aria-live="polite" role="alert">{{ attachmentError }}</span>
-      </div>
-      <div v-if="size(attachments) <= maxAttachmentsPerNote" class="w-100">
-        <label for="choose-file-for-note-attachment" class="sr-only"><span class="sr-only">Note </span>Attachments</label>
-        <div class="choose-attachment-file-wrapper no-wrap pl-3 pr-3 w-100">
-          Drop file to upload attachment or
-          <b-btn
-            id="choose-file-for-note-attachment"
-            type="file"
-            variant="outline-primary"
-            class="btn-file-upload mt-2 mb-2"
-            size="sm">
-            Browse<span class="sr-only"> for file to upload</span>
-          </b-btn>
-          <b-form-file
-            v-model="attachment"
-            :disabled="size(attachments) === maxAttachmentsPerNote"
-            :state="Boolean(attachment)"
-            :plain="true"
-          ></b-form-file>
-        </div>
-      </div>
-      <div>
-        <ul class="pill-list pl-0">
-          <li
-            v-for="(attachment, index) in attachments"
-            :id="`edit-note-attachment-${index}`"
-            :key="attachment.name"
-            :class="{'mt-2': index === 0}">
-            <span class="pill text-nowrap">
-              <i class="fas fa-paperclip pr-1 pl-1"></i> {{ attachment.displayName }}
-              <b-btn
-                :id="`remove-note-attachment-${index}`"
-                variant="link"
-                class="pr-0 pt-1 pl-0"
-                @click.prevent="removeAttachment(index)">
-                <i class="fas fa-times-circle has-error pl-2"></i>
-              </b-btn>
-            </span>
-          </li>
-        </ul>
-      </div>
+      <ManageNoteAttachments
+        :attachments="attachments"
+        :clear-errors="clearErrors"
+        :put-delete-attachment-id="removeAttachment" />
+      <AreYouSureModal
+        v-if="showConfirmDeleteAttachment"
+        button-label-confirm="Delete"
+        :function-cancel="cancelRemoveAttachment"
+        :function-confirm="confirmedRemoveAttachment"
+        :modal-body="`Are you sure you want to delete the <b>'${displayName(attachments, deleteAttachmentIndex)}'</b> attachment?`"
+        modal-header="Delete Attachment"
+        :show-modal="showConfirmDeleteAttachment" />
     </div>
     <div class="d-flex mt-2 mb-2">
       <div>
@@ -93,14 +61,6 @@
       </div>
     </div>
     <AreYouSureModal
-      v-if="showConfirmDeleteAttachment"
-      button-label-confirm="Delete"
-      :function-cancel="cancelRemoveAttachment"
-      :function-confirm="confirmedRemoveAttachment"
-      :modal-body="`Are you sure you want to delete the <b>'${displayName(attachments, deleteAttachmentIndex)}'</b> attachment?`"
-      modal-header="Delete Attachment"
-      :show-modal="showConfirmDeleteAttachment" />
-    <AreYouSureModal
       v-if="showAreYouSureModal"
       :function-cancel="cancelTheCancel"
       :function-confirm="cancelConfirmed"
@@ -121,6 +81,7 @@
 import AreYouSureModal from '@/components/util/AreYouSureModal';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Context from '@/mixins/Context';
+import ManageNoteAttachments from '@/components/note/ManageNoteAttachments';
 import Util from '@/mixins/Util';
 import { updateNote } from '@/api/notes';
 
@@ -128,7 +89,7 @@ require('@/assets/styles/ckeditor-custom.css');
 
 export default {
   name: 'EditAdvisingNote',
-  components: { AreYouSureModal },
+  components: { AreYouSureModal, ManageNoteAttachments },
   mixins: [Context, Util],
   props: {
     afterCancelled: Function,
@@ -136,11 +97,8 @@ export default {
     note: Object
   },
   data: () => ({
-    attachment: undefined,
-    attachmentError: undefined,
     attachments: undefined,
     body: undefined,
-    deleteAttachmentIndex: undefined,
     deleteAttachmentIds: [],
     editor: ClassicEditor,
     editorConfig: {
@@ -152,27 +110,6 @@ export default {
     showErrorPopover: false,
     subject: undefined
   }),
-  watch: {
-    attachment() {
-      if (this.attachment) {
-        const name = this.attachment.name;
-        const matching = this.filterList(this.attachments, a => name === a.displayName);
-        if (this.size(matching)) {
-          this.attachmentError = `Another attachment has the name '${name}'. Please rename your file.`;
-        } else {
-          this.attachment.displayName = name;
-          this.clearErrors();
-          this.attachments.push(this.attachment);
-          this.alertScreenReader(`Attachment '${name}' added`);
-          if (this.size(this.attachments) === this.maxAttachmentsPerNote) {
-            this.attachmentError = `A note can have no more than ${this.maxAttachmentsPerNote} attachments.`;
-          } else {
-            this.clearErrors();
-          }
-        }
-      }
-    }
-  },
   created() {
     this.alertScreenReader('The edit note form has loaded.');
     this.reset();
@@ -201,18 +138,18 @@ export default {
       this.putFocusNextTick('edit-note-subject');
     },
     clearErrors() {
-      this.attachmentError = null;
       this.error = null;
       this.showErrorPopover = false;
     },
     displayName(attachments, index) {
       return this.size(attachments) <= index ? '' : attachments[index].displayName;
     },
-    removeAttachment(index) {
+    removeAttachment(attachment) {
       this.clearErrors();
+      const index = this.findIndex(this.attachments, {name: attachment.name});
       const removeMe = this.attachments[index];
       if (removeMe.id) {
-        this.deleteAttachmentIndex = index;
+        this.deleteAttachmentIds.push(attachment.id);
         this.showConfirmDeleteAttachment = true;
       } else {
         this.attachments.splice(index, 1);
@@ -225,7 +162,6 @@ export default {
     confirmedRemoveAttachment() {
       this.showConfirmDeleteAttachment = false;
       const attachment = this.attachments[this.deleteAttachmentIndex];
-      this.deleteAttachmentIds.push(attachment.id);
       this.attachments.splice(this.deleteAttachmentIndex, 1);
       this.alertScreenReader(`Attachment '${attachment.displayName}' removed`);
       this.deleteAttachmentIndex = null;
@@ -257,41 +193,6 @@ export default {
 </script>
 
 <style scoped>
-.btn-file-upload {
-  border-color: grey;
-  color: grey;
-}
-.btn-file-upload:hover,
-.btn-file-upload:focus,
-.btn-file-upload:active
-{
-  color: #333;
-  background-color: #aaa;
-}
-.choose-attachment-file-wrapper {
-  position: relative;
-  align-items: center;
-  overflow: hidden;
-  display: inline-block;
-  background-color: #f7f7f7;
-  border: 1px solid #E0E0E0;
-  border-radius: 4px;
-  text-align: center;
-}
-.choose-attachment-file-wrapper input[type=file] {
-  font-size: 100px;
-  position: absolute;
-  left: 0;
-  top: 0;
-  opacity: 0;
-}
-.choose-attachment-file-wrapper:hover,
-.choose-attachment-file-wrapper:focus,
-.choose-attachment-file-wrapper:active
-{
-  color: #333;
-  background-color: #eee;
-}
 .edit-note-form {
   flex-basis: 100%;
 }

--- a/src/components/note/ManageNoteAttachments.vue
+++ b/src/components/note/ManageNoteAttachments.vue
@@ -1,0 +1,134 @@
+<template>
+  <div>
+    <div v-if="attachmentError" class="mt-3 mb-3 w-100">
+      <i class="fa fa-exclamation-triangle text-danger pr-1"></i>
+      <span aria-live="polite" role="alert">{{ attachmentError }}</span>
+    </div>
+    <div v-if="size(attachments) <= maxAttachmentsPerNote" class="w-100">
+      <label for="choose-file-for-note-attachment" class="sr-only"><span class="sr-only">Note </span>Attachments</label>
+      <div class="choose-attachment-file-wrapper no-wrap pl-3 pr-3 w-100">
+        Drop file to upload attachment or
+        <b-btn
+          id="choose-file-for-note-attachment"
+          type="file"
+          variant="outline-primary"
+          class="btn-file-upload mt-2 mb-2"
+          size="sm">
+          Browse<span class="sr-only"> for file to upload</span>
+        </b-btn>
+        <b-form-file
+          v-model="attachment"
+          :disabled="size(attachments) === maxAttachmentsPerNote"
+          :state="Boolean(attachment)"
+          :plain="true"
+        ></b-form-file>
+      </div>
+    </div>
+    <div>
+      <ul class="pill-list pl-0">
+        <li
+          v-for="(attachment, index) in attachments"
+          :id="`new-note-attachment-${index}`"
+          :key="attachment.name"
+          :class="{'mt-2': index === 0}">
+          <span class="pill text-nowrap">
+            <i class="fas fa-paperclip pr-1 pl-1"></i> {{ attachment.displayName }}
+            <b-btn
+              :id="`remove-note-attachment-${index}`"
+              variant="link"
+              class="pr-0 pt-1 pl-0"
+              @click.prevent="remove(attachment)">
+              <i class="fas fa-times-circle has-error pl-2"></i>
+            </b-btn>
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import Context from '@/mixins/Context';
+import Util from '@/mixins/Util';
+
+export default {
+  name: 'ManageNoteAttachments',
+  mixins: [Context, Util],
+  props: {
+    attachments: Array,
+    clearErrors: Function,
+    removeAttachment: Function
+  },
+  data: () => ({
+    attachment: undefined,
+    attachmentError: undefined
+  }),
+  watch: {
+    attachment() {
+      const name = this.attachment.name;
+      const matching = this.filterList(this.attachments, a => name === a.displayName);
+      if (this.size(matching)) {
+        this.attachmentError = `Another attachment has the name '${name}'. Please rename your file.`;
+      } else {
+        this.attachment.displayName = name;
+        this.clearAllErrors();
+        this.attachments.push(this.attachment);
+        this.alertScreenReader(`Attachment '${name}' added`);
+        if (this.size(this.attachments) === this.maxAttachmentsPerNote) {
+          this.attachmentError = `A note can have no more than ${this.maxAttachmentsPerNote} attachments.`;
+        } else {
+          this.clearAllErrors();
+        }
+      }
+    }
+  },
+  methods: {
+    clearAllErrors() {
+      this.attachmentError = null;
+      this.clearErrors();
+    },
+    remove(attachment) {
+      this.clearAllErrors();
+      this.removeAttachment(attachment);
+    }
+  }
+}
+</script>
+
+<style scoped>
+.btn-file-upload {
+  border-color: grey;
+  color: grey;
+}
+.btn-file-upload:hover,
+.btn-file-upload:focus,
+.btn-file-upload:active
+{
+  color: #333;
+  background-color: #aaa;
+}
+.choose-attachment-file-wrapper {
+  position: relative;
+  align-items: center;
+  overflow: hidden;
+  display: inline-block;
+  background-color: #f7f7f7;
+  border: 1px solid #E0E0E0;
+  border-radius: 4px;
+  text-align: center;
+}
+.choose-attachment-file-wrapper input[type=file] {
+  font-size: 100px;
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0;
+}
+.choose-attachment-file-wrapper:hover,
+.choose-attachment-file-wrapper:focus,
+.choose-attachment-file-wrapper:active
+{
+  color: #333;
+  background-color: #eee;
+}
+</style>

--- a/src/components/note/NewNoteModal.vue
+++ b/src/components/note/NewNoteModal.vue
@@ -80,50 +80,10 @@
             </div>
           </div>
           <div v-if="newNoteMode === 'fullScreen'" class="mt-2 mr-3 mb-1 ml-3">
-            <div v-if="attachmentError" class="mt-3 mb-3 w-100">
-              <i class="fa fa-exclamation-triangle text-danger pr-1"></i>
-              <span aria-live="polite" role="alert">{{ attachmentError }}</span>
-            </div>
-            <div v-if="size(attachments) <= maxAttachmentsPerNote" class="w-100">
-              <label for="choose-file-for-note-attachment" class="sr-only"><span class="sr-only">Note </span>Attachments</label>
-              <div class="choose-attachment-file-wrapper no-wrap pl-3 pr-3 w-100">
-                Drop file to upload attachment or
-                <b-btn
-                  id="choose-file-for-note-attachment"
-                  type="file"
-                  variant="outline-primary"
-                  class="btn-file-upload mt-2 mb-2"
-                  size="sm">
-                  Browse<span class="sr-only"> for file to upload</span>
-                </b-btn>
-                <b-form-file
-                  v-model="attachment"
-                  :disabled="size(attachments) === maxAttachmentsPerNote"
-                  :state="Boolean(attachment)"
-                  :plain="true"
-                ></b-form-file>
-              </div>
-            </div>
-            <div>
-              <ul class="pill-list pl-0">
-                <li
-                  v-for="(attachment, index) in attachments"
-                  :id="`new-note-attachment-${index}`"
-                  :key="attachment.name"
-                  :class="{'mt-2': index === 0}">
-                  <span class="pill text-nowrap">
-                    <i class="fas fa-paperclip pr-1 pl-1"></i> {{ attachment.name }}
-                    <b-btn
-                      :id="`remove-note-attachment-${index}`"
-                      variant="link"
-                      class="pr-0 pt-1 pl-0"
-                      @click.prevent="removeAttachment(index)">
-                      <i class="fas fa-times-circle has-error pl-2"></i>
-                    </b-btn>
-                  </span>
-                </li>
-              </ul>
-            </div>
+            <ManageNoteAttachments
+              :attachments="attachments"
+              :clear-errors="clearErrors"
+              :remove-attachment="removeAttachment" />
           </div>
           <hr />
           <div class="d-flex mt-1 mr-3 mb-0 ml-3">
@@ -208,6 +168,7 @@ import AreYouSureModal from '@/components/util/AreYouSureModal';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Context from '@/mixins/Context';
 import FocusLock from 'vue-focus-lock';
+import ManageNoteAttachments from '@/components/note/ManageNoteAttachments';
 import NoteEditSession from "@/mixins/NoteEditSession";
 import Util from '@/mixins/Util';
 import { createNote } from '@/api/notes';
@@ -216,7 +177,7 @@ require('@/assets/styles/ckeditor-custom.css');
 
 export default {
   name: 'NewNoteModal',
-  components: { AreYouSureModal, FocusLock },
+  components: { AreYouSureModal, FocusLock, ManageNoteAttachments },
   mixins: [Context, NoteEditSession, Util],
   props: {
     disable: Boolean,
@@ -224,8 +185,6 @@ export default {
     student: Object
   },
   data: () => ({
-    attachment: undefined,
-    attachmentError: undefined,
     attachments: [],
     body: undefined,
     error: undefined,
@@ -239,23 +198,6 @@ export default {
     showAreYouSureModal: false
   }),
   watch: {
-    attachment() {
-      const name = this.attachment.name;
-      const matching = this.filterList(this.attachments, a => name === a.displayName);
-      if (this.size(matching)) {
-        this.attachmentError = `Another attachment has the name '${name}'. Please rename your file.`;
-      } else {
-        this.attachment.displayName = name;
-        this.clearErrors();
-        this.attachments.push(this.attachment);
-        this.alertScreenReader(`Attachment '${name}' added`);
-        if (this.size(this.attachments) === this.maxAttachmentsPerNote) {
-          this.attachmentError = `A note can have no more than ${this.maxAttachmentsPerNote} attachments.`;
-        } else {
-          this.clearErrors();
-        }
-      }
-    },
     body(b) {
       if (b) this.clearErrors();
     },
@@ -285,7 +227,6 @@ export default {
       this.putFocusNextTick('create-note-subject');
     },
     clearErrors() {
-      this.attachmentError = null;
       this.error = null;
       this.showErrorPopover = false;
     },
@@ -321,9 +262,9 @@ export default {
        this.setNewNoteMode('open');
        this.putFocusNextTick('create-note-subject');
     },
-    removeAttachment(index) {
-      this.clearErrors();
-      this.alertScreenReader(`Attachment '${this.attachments[index].name}' removed`);
+    removeAttachment(attachment) {
+      this.alertScreenReader(`Attachment '${attachment.name}' removed`);
+      const index = this.findIndex(this.attachments, {name: attachment.name});
       this.attachments.splice(index, 1);
     },
     reset() {
@@ -337,41 +278,6 @@ export default {
 </script>
 
 <style scoped>
-.btn-file-upload {
-  border-color: grey;
-  color: grey;
-}
-.btn-file-upload:hover,
-.btn-file-upload:focus,
-.btn-file-upload:active
-{
-  color: #333;
-  background-color: #aaa;
-}
-.choose-attachment-file-wrapper {
-  position: relative;
-  align-items: center;
-  overflow: hidden;
-  display: inline-block;
-  background-color: #f7f7f7;
-  border: 1px solid #E0E0E0;
-  border-radius: 4px;
-  text-align: center;
-}
-.choose-attachment-file-wrapper input[type=file] {
-  font-size: 100px;
-  position: absolute;
-  left: 0;
-  top: 0;
-  opacity: 0;
-}
-.choose-attachment-file-wrapper:hover,
-.choose-attachment-file-wrapper:focus,
-.choose-attachment-file-wrapper:active
-{
-  color: #333;
-  background-color: #eee;
-}
 .fa-icon-size {
   font-size: 28px;
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2104

I hope this manage-attachments component will make the impl of BOAC-2104 easier.