### PR TITLE
BOAC-2071, refactor away 'curated_cohort' naming; remove cohorts/groups from /api/profile/my

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -211,8 +211,8 @@ def load_term(term_id=berkeley.current_term_id()):
     if term_id == berkeley.current_term_id():
         JobProgress().update(f'About to load filtered cohort counts')
         load_filtered_cohort_counts()
-        JobProgress().update(f'About to update curated cohort memberships')
-        update_curated_cohort_lists()
+        JobProgress().update(f'About to update curated group memberships')
+        update_curated_group_lists()
 
 
 def refresh_alerts(term_id):
@@ -232,15 +232,14 @@ def load_filtered_cohort_counts():
         cohort.to_api_json(include_students=False, include_alerts_for_user_id=owner_id)
 
 
-def update_curated_cohort_lists():
-    """Remove no-longer-accessible students from curated cohort lists."""
-    from boac.models.curated_cohort import CuratedCohort
-    for cohort in CuratedCohort.query.all():
-        member_sids = [s.sid for s in cohort.students]
+def update_curated_group_lists():
+    """Remove no-longer-accessible students from curated group lists."""
+    from boac.models.curated_group import CuratedGroup
+    for curated_group in CuratedGroup.query.all():
+        member_sids = [s.sid for s in curated_group.students]
         available_students = [s['sid'] for s in data_loch.get_student_profiles(member_sids)]
         if len(member_sids) > len(available_students):
-            cohort_id = cohort.id
             unavailable_sids = set(member_sids) - set(available_students)
-            app.logger.info(f'Deleting inaccessible SIDs from cohort ID {cohort_id} : {unavailable_sids}')
+            app.logger.info(f'Deleting inaccessible SIDs from curated group {curated_group.id}: {unavailable_sids}')
             for sid in unavailable_sids:
-                CuratedCohort.remove_student(cohort_id, sid)
+                CuratedGroup.remove_student(curated_group.id, sid)

--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -49,5 +49,5 @@ def get_section(term_id, section_id):
         raise ResourceNotFoundError(f'No section {section_id} in term {term_id}')
     student_profiles = get_course_student_profiles(term_id, section_id, offset=offset, limit=limit, featured=featured)
     section.update(student_profiles)
-    Alert.include_alert_counts_for_students(viewer_user_id=current_user.id, cohort=student_profiles)
+    Alert.include_alert_counts_for_students(viewer_user_id=current_user.id, group=student_profiles)
     return tolerant_jsonify(section)

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -36,8 +36,7 @@ from flask_login import current_user, login_required
 
 @app.route('/api/profile/my')
 def my_profile():
-    exclude_cohorts = util.to_bool_or_none(request.args.get('excludeCohorts'))
-    return tolerant_jsonify(current_user_profile(exclude_cohorts))
+    return tolerant_jsonify(current_user_profile())
 
 
 @app.route('/api/profile/<uid>')

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -356,12 +356,12 @@ class Alert(Base):
         cls.create_or_activate(sid=sid, alert_type='withdrawal', key=key, message=message)
 
     @classmethod
-    def include_alert_counts_for_students(cls, viewer_user_id, cohort):
-        sids = cohort.get('sids') if 'sids' in cohort else [s['sid'] for s in cohort.get('students', [])]
+    def include_alert_counts_for_students(cls, viewer_user_id, group):
+        sids = group.get('sids') if 'sids' in group else [s['sid'] for s in group.get('students', [])]
         alert_counts = cls.current_alert_counts_for_sids(viewer_user_id, sids)
-        if 'students' in cohort:
+        if 'students' in group:
             counts_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}
-            for student in cohort.get('students'):
+            for student in group.get('students'):
                 sid = student['sid']
                 student['alertCount'] = counts_per_sid.get(sid) if sid in counts_per_sid else 0
         return alert_counts

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -242,7 +242,10 @@ class CohortFilter(Base, UserMixin):
                     'students': results['students'],
                 })
             if include_alerts_for_user_id:
-                alert_count_per_sid = Alert.include_alert_counts_for_students(viewer_user_id=include_alerts_for_user_id, cohort=results)
+                alert_count_per_sid = Alert.include_alert_counts_for_students(
+                    viewer_user_id=include_alerts_for_user_id,
+                    group=results,
+                )
                 cohort_json.update({
                     'alerts': alert_count_per_sid,
                 })

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -38,12 +38,12 @@ cohort_filter_owners = db.Table(
 )
 
 
-class CuratedCohortStudent(db.Model):
+class CuratedGroupStudent(db.Model):
     __tablename__ = 'student_group_members'
 
-    curated_cohort_id = db.Column('student_group_id', db.Integer, db.ForeignKey('student_groups.id'), primary_key=True)
+    curated_group_id = db.Column('student_group_id', db.Integer, db.ForeignKey('student_groups.id'), primary_key=True)
     sid = db.Column('sid', db.String(80), primary_key=True)
-    curated_cohort = db.relationship('CuratedCohort', back_populates='students')
+    curated_group = db.relationship('CuratedGroup', back_populates='students')
 
 
 class UniversityDeptMember(Base):

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -27,7 +27,7 @@ from boac import db, std_commit
 from boac.lib.berkeley import BERKELEY_DEPT_NAME_TO_CODE
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
-from boac.models.curated_cohort import CuratedCohort
+from boac.models.curated_group import CuratedGroup
 from boac.models.university_dept import UniversityDept
 # Models below are included so that db.create_all will find them.
 from boac.models.alert import Alert # noqa
@@ -153,19 +153,19 @@ def load_development_data():
 
 def create_curated_groups():
     admin_id = AuthorizedUser.find_by_uid('2040').id
-    CuratedCohort.create(admin_id, 'My Students')
+    CuratedGroup.create(admin_id, 'My Students')
 
     advisor_id = AuthorizedUser.find_by_uid('6446').id
-    CuratedCohort.create(advisor_id, 'My Students')
-    curated_cohort = CuratedCohort.create(advisor_id, 'Cool Kids')
-    CuratedCohort.add_student(curated_cohort.id, '3456789012')
-    CuratedCohort.add_student(curated_cohort.id, '5678901234')
-    CuratedCohort.add_student(curated_cohort.id, '11667051')
-    CuratedCohort.add_student(curated_cohort.id, '7890123456')
+    CuratedGroup.create(advisor_id, 'My Students')
+    curated_group = CuratedGroup.create(advisor_id, 'Cool Kids')
+    CuratedGroup.add_student(curated_group.id, '3456789012')
+    CuratedGroup.add_student(curated_group.id, '5678901234')
+    CuratedGroup.add_student(curated_group.id, '11667051')
+    CuratedGroup.add_student(curated_group.id, '7890123456')
 
     coe_advisor = AuthorizedUser.find_by_uid('1133399')
-    curated_cohort = CuratedCohort.create(coe_advisor.id, 'Cohort of One')
-    CuratedCohort.add_student(curated_cohort.id, '7890123456')  # PaulF
+    curated_group = CuratedGroup.create(coe_advisor.id, 'I have one student')
+    CuratedGroup.add_student(curated_group.id, '7890123456')  # PaulF
 
     std_commit(allow_test_environment=True)
 

--- a/src/api/curated.ts
+++ b/src/api/curated.ts
@@ -6,7 +6,7 @@ export function addStudents(curatedGroup, sids) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
     .post(`${apiBaseUrl}/api/curated_group/students/add`, {
-      curatedCohortId: curatedGroup.id,
+      curatedGroupId: curatedGroup.id,
       sids: sids
     })
     .then(response => {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -11,7 +11,7 @@ export function getUserStatus() {
 export function getUserProfile() {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
-    .get(`${apiBaseUrl}/api/profile/my?excludeCohorts=true`)
+    .get(`${apiBaseUrl}/api/profile/my`)
     .then(response => response.data, () => null);
 }
 

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from boac import std_commit
 from boac.models.alert import Alert
 from boac.models.cohort_filter import CohortFilter
-from boac.models.curated_cohort import CuratedCohort
+from boac.models.curated_group import CuratedGroup
 import pytest
 
 
@@ -44,19 +44,18 @@ class TestCacheUtils:
         assert '2178_90100' == alerts[0]['key']
         assert 'BURMESE 1A midterm grade of D+.' == alerts[0]['message']
 
-    def test_update_curated_cohort_lists(self, app):
-        from boac.api.cache_utils import update_curated_cohort_lists
-        cohort = CuratedCohort.query.filter_by(name='Cool Kids').first()
-        cohort_id = cohort.id
-        original_sids = [s.sid for s in cohort.students]
+    def test_update_curated_group_lists(self, app):
+        from boac.api.cache_utils import update_curated_group_lists
+        curated_group = CuratedGroup.query.filter_by(name='Cool Kids').first()
+        original_sids = [s.sid for s in curated_group.students]
         sid_not_in_data_loch = '19040616'
-        CuratedCohort.add_student(cohort_id, sid_not_in_data_loch)
+        CuratedGroup.add_student(curated_group.id, sid_not_in_data_loch)
         std_commit(allow_test_environment=True)
-        revised_sids = [s.sid for s in CuratedCohort.find_by_id(cohort_id).students]
+        revised_sids = [s.sid for s in CuratedGroup.find_by_id(curated_group.id).students]
         assert sid_not_in_data_loch in revised_sids
-        update_curated_cohort_lists()
+        update_curated_group_lists()
         std_commit(allow_test_environment=True)
-        final_sids = [s.sid for s in CuratedCohort.find_by_id(cohort_id).students]
+        final_sids = [s.sid for s in CuratedGroup.find_by_id(curated_group.id).students]
         assert sid_not_in_data_loch not in final_sids
         assert set(final_sids) == set(original_sids)
 

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.models.authorized_user import AuthorizedUser
-from boac.models.curated_cohort import CuratedCohort
+from boac.models.curated_group import CuratedGroup
 import pytest
 import simplejson as json
 
@@ -52,13 +52,13 @@ def admin_user_session(fake_auth):
 @pytest.fixture()
 def groups_of_asc_advisor():
     advisor = AuthorizedUser.find_by_uid(asc_advisor_uid)
-    return CuratedCohort.get_curated_cohorts_by_owner_id(advisor.id)
+    return CuratedGroup.get_curated_groups_by_owner_id(advisor.id)
 
 
 @pytest.fixture()
 def groups_of_coe_advisor():
     advisor = AuthorizedUser.find_by_uid(coe_advisor_uid)
-    return CuratedCohort.get_curated_cohorts_by_owner_id(advisor.id)
+    return CuratedGroup.get_curated_groups_by_owner_id(advisor.id)
 
 
 class TestGetCuratedGroup:
@@ -83,7 +83,7 @@ class TestGetCuratedGroup:
         assert 'id' in group
         assert 'alertCount' in group
         assert 'studentCount' in group
-        assert group['name'] == 'Cohort of One'
+        assert group['name'] == 'I have one student'
 
     def test_asc_curated_groups(self, client, fake_auth):
         """Returns curated groups of ASC advisor."""
@@ -115,7 +115,7 @@ class TestGetCuratedGroup:
         assert deborah['termGpa'][3] == {'termName': 'Spring 2016', 'gpa': 3.8}
 
 
-class TestMyCuratedCohorts:
+class TestMyCuratedGroups:
     """Curated Group API."""
 
     def test_students_without_alerts(self, asc_advisor, client, create_alerts, groups_of_asc_advisor, db_session):
@@ -186,8 +186,8 @@ class TestMyCuratedCohorts:
         assert ids == [group.id]
 
 
-class TestCuratedCohortCreate:
-    """Curated Cohort Create API."""
+class TestCuratedGroupCreate:
+    """Curated Group API."""
 
     def test_add_multiple_students_to_curated_group(self, asc_advisor, client):
         """Create group and add students."""
@@ -208,7 +208,7 @@ class TestCuratedCohortCreate:
         response = client.post(
             '/api/curated_group/students/add',
             data=json.dumps({
-                'curatedCohortId': group['id'],
+                'curatedGroupId': group['id'],
                 'sids': ['7890123456', 'ABC'],
             }),
             content_type='application/json',


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2071

* Remove `myCohorts` and `myCurated` from `/api/my/profile` because the front-end manages those lists separately. See https://github.com/ets-berkeley-edu/boac/pull/1195 
* This refactor is a nice start to enhancing the API – clarity in naming.  