### PR TITLE
BOAC-2079, tool_settings table and protected get-settings API

### DIFF
--- a/boac/api/tool_settings_controller.py
+++ b/boac/api/tool_settings_controller.py
@@ -1,0 +1,55 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.api.util import admin_required
+from boac.lib.http import tolerant_jsonify
+from boac.models.tool_setting import ToolSetting
+from flask import current_app as app, request
+from flask_login import current_user, login_required
+
+
+@app.route('/api/tool_settings', methods=['POST'])
+@login_required
+def get_tool_settings():
+    params = request.get_json()
+    api_json = {}
+    keys = params.get('keys')
+    if isinstance(keys, list) and len(keys):
+        settings = ToolSetting.get_tool_settings(keys)
+        if settings:
+            for setting in settings:
+                if setting.is_public or current_user.is_admin:
+                    api_json.update(setting.to_api_json())
+    return tolerant_jsonify(api_json)
+
+
+@app.route('/api/tool_setting/upsert', methods=['POST'])
+@admin_required
+def upsert_tool_setting():
+    params = request.get_json()
+    key = params.get('key')
+    value = params.get('value')
+    # NOTE: The 'is_public' property cannot be modified via API
+    return tolerant_jsonify(ToolSetting.upsert(key, value).to_api_json())

--- a/boac/models/tool_setting.py
+++ b/boac/models/tool_setting.py
@@ -1,0 +1,64 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac import db, std_commit
+from boac.lib.util import camelize
+from boac.models.base import Base
+
+
+class ToolSetting(Base):
+    __tablename__ = 'tool_settings'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    key = db.Column(db.String(255), nullable=False)
+    value = db.Column(db.String(255), nullable=False)
+    is_public = db.Column(db.Boolean, default=False, nullable=False)
+
+    def __init__(self, key, value=None, is_public=False):
+        self.key = key
+        self.value = value
+        self.is_public = is_public
+
+    def __repr__(self):
+        return f'<ToolSettings {self.key}, value={self.value}, is_public={self.is_public}>'
+
+    @classmethod
+    def get_tool_settings(cls, keys):
+        return cls.query.filter(cls.key.in_(keys)).all()
+
+    @classmethod
+    def upsert(cls, key, value, is_public=False):
+        tool_setting = cls.query.filter_by(key=key).first()
+        if tool_setting:
+            tool_setting.value = value
+            tool_setting.is_public = is_public
+        else:
+            tool_setting = cls(key=key, value=value, is_public=is_public)
+            db.session.add(tool_setting)
+        std_commit()
+        return tool_setting
+
+    def to_api_json(self):
+        return {camelize(self.key): self.value}

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -60,6 +60,7 @@ def register_routes(app):
     import boac.api.search_controller
     import boac.api.student_controller
     import boac.api.status_controller
+    import boac.api.tool_settings_controller
     import boac.api.user_controller
 
     # Register error handlers.

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -66,6 +66,7 @@ DROP INDEX IF EXISTS public.alerts_sid_idx;
 DROP INDEX IF EXISTS public.alert_views_viewer_id_idx;
 DROP INDEX IF EXISTS public.alert_views_alert_id_idx;
 DROP INDEX IF EXISTS public.student_groups_owner_id_idx;
+DROP INDEX IF EXISTS public.tool_settings_key_idx;
 DROP INDEX IF EXISTS public.idx_notes_fts_index;
 
 --
@@ -90,6 +91,7 @@ ALTER TABLE IF EXISTS ONLY public.topics DROP CONSTRAINT IF EXISTS topics_id_pke
 ALTER TABLE IF EXISTS ONLY public.topics DROP CONSTRAINT IF EXISTS topics_topic_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.university_dept_members DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
 ALTER TABLE IF EXISTS ONLY public.university_depts DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
+ALTER TABLE IF EXISTS ONLY public.tool_settings DROP CONSTRAINT IF EXISTS tool_settings_key_unique_constraint;
 ALTER TABLE IF EXISTS public.json_cache ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.cohort_filters ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.authorized_users ALTER COLUMN id DROP DEFAULT;
@@ -118,6 +120,8 @@ DROP TABLE IF EXISTS public.alembic_version;
 DROP TABLE IF EXISTS public.student_group_members;
 DROP TABLE IF EXISTS public.student_groups;
 DROP SEQUENCE IF EXISTS public.student_groups_id_seq;
+DROP TABLE IF EXISTS public.tool_settings;
+DROP SEQUENCE IF EXISTS public.tool_settings_id_seq;
 DROP TABLE IF EXISTS public.topics;
 DROP SEQUENCE IF EXISTS public.topics_id_seq;
 DROP TABLE IF EXISTS public.university_dept_members;

--- a/scripts/db/migrate/20190506-BOAC-2079/pre_deploy_01_create_tool_settings_table.sql
+++ b/scripts/db/migrate/20190506-BOAC-2079/pre_deploy_01_create_tool_settings_table.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+CREATE TABLE tool_settings (
+  id SERIAL PRIMARY KEY,
+  key VARCHAR(255) NOT NULL,
+  value VARCHAR(255) NOT NULL,
+  is_public BOOLEAN default FALSE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  PRIMARY KEY (id)
+);
+
+ALTER TABLE tool_settings ADD CONSTRAINT tool_settings_key_unique_constraint UNIQUE (key);
+CREATE INDEX tool_settings_key_idx ON tool_settings (key);
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -366,6 +366,32 @@ ALTER TABLE ONLY json_cache
 
 --
 
+CREATE TABLE tool_settings (
+    id integer NOT NULL,
+    key character varying NOT NULL,
+    value character varying NOT NULL,
+    is_public boolean default FALSE NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+ALTER TABLE tool_settings OWNER TO boac;
+CREATE SEQUENCE tool_settings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE tool_settings_id_seq OWNER TO boac;
+ALTER SEQUENCE tool_settings_id_seq OWNED BY tool_settings.id;
+ALTER TABLE ONLY tool_settings ALTER COLUMN id SET DEFAULT nextval('tool_settings_id_seq'::regclass);
+ALTER TABLE ONLY tool_settings
+    ADD CONSTRAINT tool_settings_key_unique_constraint UNIQUE (key);
+ALTER TABLE ONLY tool_settings
+    ADD CONSTRAINT tool_settings_pkey PRIMARY KEY (id);
+CREATE INDEX tool_settings_key_idx ON tool_settings USING btree (key);
+
+--
+
 ALTER TABLE ONLY student_group_members
     ADD CONSTRAINT student_group_members_student_group_id_fkey FOREIGN KEY (student_group_id) REFERENCES student_groups(id) ON DELETE CASCADE;
 

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -21,3 +21,10 @@ export function getVersion() {
     .get(`${apiBaseUrl}/api/version`)
     .then(response => response.data, () => null);
 }
+
+export function getToolSettings(keys: string[]) {
+  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+  return axios
+    .post(`${apiBaseUrl}/api/tool_settings`, { keys: keys })
+    .then(response => response.data, () => null);
+}

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { getConfig } from '@/api/config';
+import { getConfig, getToolSettings } from '@/api/config';
 import Vue from 'vue';
 
 const state = {
@@ -18,8 +18,10 @@ const getters = {
   featureFlagEditNotes: (state: any): any => _.get(state.config, 'featureFlagEditNotes'),
   googleAnalyticsId: (state: any): string => _.get(state.config, 'googleAnalyticsId'),
   isDemoModeAvailable: (state: any): string => _.get(state.config, 'isDemoModeAvailable'),
+  isServiceAlertPublished: (state: any): string => _.get(state.config, 'isServiceAlertPublished'),
   maxAttachmentsPerNote: (state: any): string => _.get(state.config, 'maxAttachmentsPerNote'),
   loading: (state: any): boolean => state.loading,
+  serviceAlert: (state: any): string => _.get(state.config, 'serviceAlert'),
   srAlert: (state: any): string => state.screenReaderAlert,
   supportEmailAddress: (state: any): string => _.get(state.config, 'supportEmailAddress')
 };
@@ -47,6 +49,7 @@ const mutations = {
 };
 
 const actions = {
+  alertScreenReader: ({ commit }, alert) => commit('screenReaderAlert', alert),
   clearAlertsInStore: ({ commit }) => commit('clearAlertsInStore'),
   dismissError: ({ commit }, id) => commit('dismissError', id),
   loadingComplete: ({ commit }) => commit('loadingComplete'),
@@ -57,14 +60,19 @@ const actions = {
         resolve(state.config);
       } else {
         getConfig().then(config => {
-          commit('storeConfig', config);
-          resolve(config);
+          const keys = [
+            'SERVICE_ALERT',
+            'IS_SERVICE_ALERT_PUBLISHED'
+          ];
+          getToolSettings(keys).then(toolSettings => {
+            commit('storeConfig', _.assignIn(config, toolSettings));
+            resolve(config);
+          });
         });
       }
     });
   },
-  reportError: ({ commit }, error) => commit('reportError', error),
-  alertScreenReader: ({ commit }, alert) => commit('screenReaderAlert', alert)
+  reportError: ({ commit }, error) => commit('reportError', error)
 };
 
 export default {

--- a/tests/test_api/test_tool_settings_controller.py
+++ b/tests/test_api/test_tool_settings_controller.py
@@ -1,0 +1,135 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from datetime import datetime
+
+from boac.lib.util import camelize
+from boac.models.tool_setting import ToolSetting
+import pytest
+import simplejson as json
+
+
+@pytest.fixture()
+def admin_session(fake_auth):
+    fake_auth.login('2040')
+
+
+@pytest.fixture()
+def advisor_session(fake_auth):
+    fake_auth.login('1081940')
+
+
+@pytest.fixture()
+def mock_tool_settings():
+    return [_create(is_public=False), _create(is_public=True), _create(is_public=False)]
+
+
+class TestGetToolSettings:
+    """Tool Settings API."""
+
+    @staticmethod
+    def _api_tool_settings(client, keys, expected_status_code=200):
+        response = client.post(
+            '/api/tool_settings',
+            content_type='application/json',
+            data=json.dumps({'keys': keys}),
+        )
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_not_authenticated(self, client):
+        """Rejects anonymous user."""
+        tool_setting = _create(is_public=True)
+        self._api_tool_settings(client, keys=[tool_setting.key], expected_status_code=401)
+
+    def test_authenticated_advisor(self, advisor_session, client, mock_tool_settings):
+        """Only serves public settings to non-admin user."""
+        keys = [s.key for s in mock_tool_settings]
+        api_json = self._api_tool_settings(client, keys=keys)
+        assert len(api_json) == 1
+        expected = mock_tool_settings[1]
+        assert api_json == {
+            camelize(expected.key): expected.value,
+        }
+
+    def test_authenticated_admin(self, admin_session, client, mock_tool_settings):
+        """Serves all tool settings to admin user."""
+        api_json = self._api_tool_settings(client, keys=[s.key for s in mock_tool_settings])
+        assert len(api_json) == 3
+        for setting in mock_tool_settings:
+            assert api_json[camelize(setting.key)] == setting.value
+
+
+class TestUpsertToolSettings:
+    """Tool Settings API."""
+
+    @staticmethod
+    def _api_upsert_settings(client, key, value, expected_status_code=200):
+        response = client.post(
+            '/api/tool_setting/upsert',
+            content_type='application/json',
+            data=json.dumps({'key': key, 'value': value}),
+        )
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_not_authenticated(self, client):
+        """Rejects anonymous user."""
+        self._api_upsert_settings(
+            client,
+            key=f'KEY_{datetime.now().timestamp()}',
+            value='The sun goes down and the world goes dancing',
+            expected_status_code=401,
+        )
+
+    def test_not_authorized(self, advisor_session, client):
+        """Rejects non-admin user."""
+        self._api_upsert_settings(
+            client,
+            key=f'KEY_{datetime.now().timestamp()}',
+            value='Abigail, Belle of Kilronan',
+            expected_status_code=401,
+        )
+
+    def test_tool_setting_upsert(self, admin_session, client):
+        """Create new tool setting."""
+        key = f'KEY_SNAKE_CASE'
+        value = 'Papa was a rodeo'
+        api_json = self._api_upsert_settings(client, key=key, value=value)
+        assert api_json['keySnakeCase'] == value
+        settings = ToolSetting.get_tool_settings([key])
+        assert len(settings) == 1
+        assert settings[0].key == key
+        assert settings[0].value == value
+        assert settings[0].is_public is False
+
+
+def _create(is_public=False):
+    now = datetime.now().timestamp()
+    return ToolSetting.upsert(
+        key=f'KEY_{now}',
+        value=f'value-{now}',
+        is_public=is_public,
+    )


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2079
https://jira.ets.berkeley.edu/jira/browse/BOAC-2080

Server-side (incl. db) work to support get/set of tool_settings. On the front-end, `toolSettings` are folded in with the 'config' store. In next PR, the `Context` mixin will make serviceAlert available to templates and Admin view will post to '/api/tool_setting/upsert'.