### PR TITLE
BOAC-2079, tool_settings table and protected get/update service-announcement API

### DIFF
--- a/boac/models/tool_setting.py
+++ b/boac/models/tool_setting.py
@@ -1,0 +1,62 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac import db, std_commit
+from boac.lib.util import camelize
+from boac.models.base import Base
+
+
+class ToolSetting(Base):
+    __tablename__ = 'tool_settings'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    key = db.Column(db.String(255), nullable=False, unique=True)
+    value = db.Column(db.String(255), nullable=False)
+
+    def __init__(self, key, value=None):
+        self.key = key
+        self.value = value
+
+    def __repr__(self):
+        return f'<ToolSettings {self.key}, value={self.value}>'
+
+    @classmethod
+    def get_tool_setting(cls, key):
+        setting = cls.query.filter(cls.key == key).first()
+        return setting and setting.value
+
+    @classmethod
+    def upsert(cls, key, value):
+        tool_setting = cls.query.filter_by(key=key).first()
+        if tool_setting:
+            tool_setting.value = str(value)
+        else:
+            tool_setting = cls(key=key, value=str(value))
+            db.session.add(tool_setting)
+        std_commit()
+        return tool_setting
+
+    def to_api_json(self):
+        return {camelize(self.key): self.value}

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -66,6 +66,7 @@ DROP INDEX IF EXISTS public.alerts_sid_idx;
 DROP INDEX IF EXISTS public.alert_views_viewer_id_idx;
 DROP INDEX IF EXISTS public.alert_views_alert_id_idx;
 DROP INDEX IF EXISTS public.student_groups_owner_id_idx;
+DROP INDEX IF EXISTS public.tool_settings_key_idx;
 DROP INDEX IF EXISTS public.idx_notes_fts_index;
 
 --
@@ -90,6 +91,7 @@ ALTER TABLE IF EXISTS ONLY public.topics DROP CONSTRAINT IF EXISTS topics_id_pke
 ALTER TABLE IF EXISTS ONLY public.topics DROP CONSTRAINT IF EXISTS topics_topic_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.university_dept_members DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
 ALTER TABLE IF EXISTS ONLY public.university_depts DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
+ALTER TABLE IF EXISTS ONLY public.tool_settings DROP CONSTRAINT IF EXISTS tool_settings_key_unique_constraint;
 ALTER TABLE IF EXISTS public.json_cache ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.cohort_filters ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.authorized_users ALTER COLUMN id DROP DEFAULT;
@@ -118,6 +120,8 @@ DROP TABLE IF EXISTS public.alembic_version;
 DROP TABLE IF EXISTS public.student_group_members;
 DROP TABLE IF EXISTS public.student_groups;
 DROP SEQUENCE IF EXISTS public.student_groups_id_seq;
+DROP TABLE IF EXISTS public.tool_settings;
+DROP SEQUENCE IF EXISTS public.tool_settings_id_seq;
 DROP TABLE IF EXISTS public.topics;
 DROP SEQUENCE IF EXISTS public.topics_id_seq;
 DROP TABLE IF EXISTS public.university_dept_members;

--- a/scripts/db/migrate/20190506-BOAC-2079/pre_deploy_01_create_tool_settings_table.sql
+++ b/scripts/db/migrate/20190506-BOAC-2079/pre_deploy_01_create_tool_settings_table.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+CREATE TABLE tool_settings (
+  id SERIAL PRIMARY KEY,
+  key VARCHAR(255) NOT NULL,
+  value VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+ALTER TABLE tool_settings ADD CONSTRAINT tool_settings_key_unique_constraint UNIQUE (key);
+CREATE INDEX tool_settings_key_idx ON tool_settings (key);
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -366,6 +366,31 @@ ALTER TABLE ONLY json_cache
 
 --
 
+CREATE TABLE tool_settings (
+    id integer NOT NULL,
+    key character varying NOT NULL,
+    value character varying NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+ALTER TABLE tool_settings OWNER TO boac;
+CREATE SEQUENCE tool_settings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE tool_settings_id_seq OWNER TO boac;
+ALTER SEQUENCE tool_settings_id_seq OWNED BY tool_settings.id;
+ALTER TABLE ONLY tool_settings ALTER COLUMN id SET DEFAULT nextval('tool_settings_id_seq'::regclass);
+ALTER TABLE ONLY tool_settings
+    ADD CONSTRAINT tool_settings_key_unique_constraint UNIQUE (key);
+ALTER TABLE ONLY tool_settings
+    ADD CONSTRAINT tool_settings_pkey PRIMARY KEY (id);
+CREATE INDEX tool_settings_key_idx ON tool_settings USING btree (key);
+
+--
+
 ALTER TABLE ONLY student_group_members
     ADD CONSTRAINT student_group_members_student_group_id_fkey FOREIGN KEY (student_group_id) REFERENCES student_groups(id) ON DELETE CASCADE;
 

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -21,3 +21,26 @@ export function getVersion() {
     .get(`${apiBaseUrl}/api/version`)
     .then(response => response.data, () => null);
 }
+
+export function getServiceAnnouncement() {
+  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+  return axios
+    .get(`${apiBaseUrl}/api/service_announcement`)
+    .then(response => response.data, () => null);
+}
+
+export function updateServiceAnnouncement(text, isLive) {
+  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+  let data = {
+    text: text,
+    isLive: isLive
+  };
+  return axios
+    .post(`${apiBaseUrl}/api/service_announcement/update`, data)
+    .then(response => {
+      const data = response.data;
+      store.commit('context/storeServiceAnnouncement', data);
+      return data;
+    })
+    .catch(error => error);
+}

--- a/src/components/admin/EditServiceAnnouncement.vue
+++ b/src/components/admin/EditServiceAnnouncement.vue
@@ -1,0 +1,62 @@
+<template>
+  <div v-if="user.isAdmin && announcement !== undefined">
+    <h2 class="page-section-header-sub">Service Alert</h2>
+    <div class="p-2">
+      <span
+        v-if="isSaving"
+        role="alert"
+        aria-live="passive"
+        class="sr-only">{{ isPublished ? 'Publishing' : 'Unpublishing' }} the service announcement</span>
+      <b-form-checkbox
+        id="publish-service-announcement"
+        v-model="isPublished"
+        :disabled="isSaving">
+        <span v-if="isSaving"><i class="fa fa-spinner fa-spin"></i> Saving...</span>
+        <span v-if="!isSaving">{{ isPublished ? 'Published' : 'Unpublished' }}</span>
+      </b-form-checkbox>
+      <b-form-textarea
+        id="service-announcement-textarea"
+        v-model="announcement"
+        aria-label="Enter service announcement for users to read"
+        rows="3"
+        max-rows="5"
+        :disabled="isSaving"
+      ></b-form-textarea>
+      <div class="mt-1">
+        <b-btn variant="primary" @click="save">Save</b-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Context from '@/mixins/Context';
+import UserMetadata from '@/mixins/UserMetadata';
+import { getServiceAnnouncement, updateServiceAnnouncement } from '@/api/config';
+
+export default {
+  name: 'EditServiceAnnouncement',
+  mixins: [Context, UserMetadata],
+  data: () => ({
+    announcement: undefined,
+    isPublished: undefined,
+    isSaving: false
+  }),
+  created() {
+    getServiceAnnouncement().then(data => {
+      this.announcement = data.text;
+      this.isPublished = data.isLive;
+    })
+  },
+  methods: {
+    save() {
+      this.isSaving = true;
+      updateServiceAnnouncement(this.announcement, this.isPublished).then(data => {
+        this.announcement = data.text;
+        this.isPublished = data.isLive;
+        this.isSaving = false;
+      });
+    }
+  }
+}
+</script>

--- a/src/layouts/StandardLayout.vue
+++ b/src/layouts/StandardLayout.vue
@@ -31,6 +31,7 @@
             role="alert">
             {{ srAlert }}
           </span>
+          <div v-if="serviceAnnouncement && serviceAnnouncement.isLive">{{ serviceAnnouncement.text }}</div>
           <!-- The ':key' attribute forces component reload when same route is requested with diff id in path. -->
           <router-view :key="stripAnchorRef($route.fullPath)"></router-view>
         </div>

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -12,6 +12,7 @@ export default {
       'featureFlagEditNotes',
       'isDemoModeAvailable',
       'maxAttachmentsPerNote',
+      'serviceAnnouncement',
       'srAlert',
       'supportEmailAddress'
     ])

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -1,12 +1,13 @@
 import _ from 'lodash';
-import { getConfig } from '@/api/config';
+import { getConfig, getServiceAnnouncement } from '@/api/config';
 import Vue from 'vue';
 
 const state = {
   config: undefined,
   errors: [],
   loading: undefined,
-  screenReaderAlert: undefined
+  screenReaderAlert: undefined,
+  serviceAnnouncement: undefined
 };
 
 const getters = {
@@ -20,6 +21,7 @@ const getters = {
   isDemoModeAvailable: (state: any): string => _.get(state.config, 'isDemoModeAvailable'),
   maxAttachmentsPerNote: (state: any): string => _.get(state.config, 'maxAttachmentsPerNote'),
   loading: (state: any): boolean => state.loading,
+  serviceAnnouncement: (state: any): string => state.serviceAnnouncement,
   srAlert: (state: any): string => state.screenReaderAlert,
   supportEmailAddress: (state: any): string => _.get(state.config, 'supportEmailAddress')
 };
@@ -43,10 +45,12 @@ const mutations = {
     Vue.prototype.$eventHub.$emit('error-reported', error);
   },
   screenReaderAlert: (state: any, alert: any) => (state.screenReaderAlert = alert),
-  storeConfig: (state: any, config: any) => (state.config = config)
+  storeConfig: (state: any, config: any) => (state.config = config),
+  storeServiceAnnouncement: (state: any, data: any) => (state.serviceAnnouncement = data),
 };
 
 const actions = {
+  alertScreenReader: ({ commit }, alert) => commit('screenReaderAlert', alert),
   clearAlertsInStore: ({ commit }) => commit('clearAlertsInStore'),
   dismissError: ({ commit }, id) => commit('dismissError', id),
   loadingComplete: ({ commit }) => commit('loadingComplete'),
@@ -56,15 +60,17 @@ const actions = {
       if (state.config) {
         resolve(state.config);
       } else {
-        getConfig().then(config => {
-          commit('storeConfig', config);
-          resolve(config);
+        getServiceAnnouncement().then(data => {
+          commit('storeServiceAnnouncement', data);
+          getConfig().then(config => {
+            commit('storeConfig', config);
+            resolve(config);
+          });
         });
       }
     });
   },
-  reportError: ({ commit }, error) => commit('reportError', error),
-  alertScreenReader: ({ commit }, alert) => commit('screenReaderAlert', alert)
+  reportError: ({ commit }, error) => commit('reportError', error)
 };
 
 export default {

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -72,6 +72,11 @@
             </b-tab>
           </b-tabs>
         </b-card>
+      </div>
+      <div>
+        <EditServiceAnnouncement />
+      </div>
+      <div>
         <Status />
       </div>
     </div>
@@ -81,6 +86,7 @@
 <script>
 import Context from '@/mixins/Context';
 import DemoModeToggle from '@/components/admin/DemoModeToggle';
+import EditServiceAnnouncement from '@/components/admin/EditServiceAnnouncement';
 import Loading from '@/mixins/Loading';
 import Spinner from '@/components/util/Spinner';
 import Status from '@/components/util/Status';
@@ -93,6 +99,7 @@ export default {
   name: 'Admin',
   components: {
     DemoModeToggle,
+    EditServiceAnnouncement,
     Spinner,
     Status
   },


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2079
https://jira.ets.berkeley.edu/jira/browse/BOAC-2080

Server-side (incl. db) work to support get/set of service-announcement. On the front-end, toolSettings are folded in with the 'config' store. This PR includes front-end api and store logic. The textarea/checkbox on Admin page works – the styling on the announcement div and Admin component is not done.