### PR TITLE
BOAC-2179, if user is not auth then /api/service_announcement returns None

### DIFF
--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -33,7 +33,7 @@ from boac.lib.http import tolerant_jsonify
 from boac.lib.util import to_bool_or_none
 from boac.models.tool_setting import ToolSetting
 from flask import current_app as app, request
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 
 @app.route('/api/config')
@@ -71,10 +71,12 @@ def app_version():
 
 
 @app.route('/api/service_announcement')
-@login_required
 def get_service_announcement():
-    announcement = _get_service_announcement()
-    return tolerant_jsonify(announcement if current_user.is_admin or announcement['isPublished'] else None)
+    if current_user.is_authenticated:
+        announcement = _get_service_announcement()
+        return tolerant_jsonify(announcement if current_user.is_admin or announcement['isPublished'] else None)
+    else:
+        return tolerant_jsonify(None)
 
 
 @app.route('/api/service_announcement/update', methods=['POST'])

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -93,8 +93,8 @@ class TestServiceAnnouncement:
         return response.json
 
     def test_not_authenticated(self, client, announcement_published):
-        """Rejects anonymous user."""
-        self._api_service_announcement(client, expected_status_code=401)
+        """Returns None to anonymous user."""
+        assert self._api_service_announcement(client) is None
 
     def test_advisor_cannot_read_unpublished(self, client, advisor_session, announcement_unpublished):
         """Advisor does not have access to the unpublished announcement."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2179