### PR TITLE
BOAC-2153, remove dupe curatedGroupCheckboxClick() to avoid duplicate key db error

### DIFF
--- a/src/components/curated/CuratedGroupSelector.vue
+++ b/src/components/curated/CuratedGroupSelector.vue
@@ -47,14 +47,12 @@
           v-for="group in myCuratedGroups"
           :id="`curated-group-${group.id}-menu-item`"
           :key="group.id"
-          class="b-dd-item-override"
-          :aria-label="`Hit return key to add students to curated group '${group.name}'`"
-          @click="curatedGroupCheckboxClick(group)">
+          class="b-dd-item-override">
           <input
             :id="`curated-group-${group.id}-checkbox`"
             type="checkbox"
-            :aria-label="`Hit space-bar to add students to curated group '${group.name}'`"
-            @click="curatedGroupCheckboxClick(group)" />
+            :aria-label="`Add students to curated group '${group.name}'`"
+            @click.prevent="curatedGroupCheckboxClick(group)" />
           <label
             :id="`curated-group-${group.id}-name`"
             :for="`curated-group-${group.id}-checkbox`"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2153

Dupe was introduced in attempt to support keyboard-only use of dropdown – I will reopen BOAC-1736. (I also removed dupe aria-label.)