### PR TITLE
[QA] BOAC-2202, if text is truncated then Safari has full-text tooltip (a problem for demo-mode)

### DIFF
--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -1,6 +1,6 @@
 <template>
   <div :id="`note-${note.id}-outer`" class="advising-note-outer">
-    <div :id="`note-${note.id}-is-closed`" :class="{'truncate': !isOpen}">
+    <div :id="`note-${note.id}-is-closed`" :class="{'truncate': !isOpen}" title="Advising note">
       <span v-if="note.subject" :id="`note-${note.id}-subject-closed`">{{ note.subject }}</span>
       <span v-if="!note.subject && size(note.message)" :id="`note-${note.id}-message-closed`" v-html="note.message"></span>
       <span v-if="!note.subject && !size(note.message)" :id="`note-${note.id}-category-closed`">{{ note.category }}<span v-if="note.subcategory" :id="`note-${note.id}-subcategory-closed`">, {{ note.subcategory }}</span></span>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2202

See suggested solutions in https://zzz.buzz/2017/07/31/prevent-tooltip-over-truncated-text-in-safari

I chose "the most obvious solution ... add a title attribute"