### PR TITLE
NS-532 Update smart_open to 1.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ nltk==3.4.0
 psycopg2==2.7.7
 requests==2.21.0
 simplejson==3.16.0
-smart-open==1.8.0
+smart-open==1.8.3
 titlecase==0.12.0
 xmltodict==0.12.0
 https://github.com/python-cas/python-cas/archive/master.zip


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-532

I'm unable to reproduce reported 1.8.3 breakages locally, but the dev environment is made to be broken, so let's try it there.