### PR TITLE
NS-532 Update deprecated smart_open signature

### DIFF
--- a/boac/externals/s3.py
+++ b/boac/externals/s3.py
@@ -42,7 +42,7 @@ def build_s3_url(bucket, key, credentials=True):
 def stream_object(bucket, key):
     s3_url = build_s3_url(bucket, key)
     try:
-        return smart_open.smart_open(s3_url, 'rb')
+        return smart_open.open(s3_url, 'rb')
     except Exception as e:
         app.logger.error(f'S3 stream operation failed (bucket={bucket}, key={key})')
         app.logger.exception(e)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-532

Because `smart_open.smart_open` is a little too pushy about its smartness.