### PR TITLE
BOAC-855, paginated curated groups

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -31,6 +31,7 @@ from boac.externals import data_loch
 from boac.lib import berkeley
 from boac.models import json_cache
 from boac.models.alert import Alert
+from boac.models.curated_group import CuratedGroupStudent
 from boac.models.job_progress import JobProgress
 from boac.models.json_cache import JsonCache
 from flask import current_app as app
@@ -236,10 +237,10 @@ def update_curated_group_lists():
     """Remove no-longer-accessible students from curated group lists."""
     from boac.models.curated_group import CuratedGroup
     for curated_group in CuratedGroup.query.all():
-        member_sids = [s.sid for s in curated_group.students]
-        available_students = [s['sid'] for s in data_loch.get_student_profiles(member_sids)]
-        if len(member_sids) > len(available_students):
-            unavailable_sids = set(member_sids) - set(available_students)
+        all_sids = CuratedGroupStudent.get_sids(curated_group.id)
+        available_students = [s['sid'] for s in data_loch.get_student_profiles(all_sids)]
+        if len(all_sids) > len(available_students):
+            unavailable_sids = set(all_sids) - set(available_students)
             app.logger.info(f'Deleting inaccessible SIDs from curated group {curated_group.id}: {unavailable_sids}')
             for sid in unavailable_sids:
                 CuratedGroup.remove_student(curated_group.id, sid)

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -227,10 +227,6 @@ def put_notifications(student):
             })
 
 
-def sort_students_by_name(students):
-    return sorted(students, key=lambda s: (s['lastName'], s['firstName']))
-
-
 def translate_grading_basis(code):
     bases = {
         'CNC': 'C/NC',
@@ -260,8 +256,8 @@ def get_my_curated_groups():
     curated_groups = []
     user_id = current_user.id
     for curated_group in CuratedGroup.get_curated_groups_by_owner_id(user_id):
-        api_json = curated_group.to_api_json(sids_only=True, include_students=False)
-        students = [{'sid': s['sid']} for s in api_json['students']]
+        api_json = curated_group.to_api_json()
+        students = [{'sid': sid} for sid in CuratedGroup.get_all_sids(curated_group.id)]
         students_with_alerts = Alert.include_alert_counts_for_students(
             viewer_user_id=user_id,
             group={'students': students},

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -38,14 +38,6 @@ cohort_filter_owners = db.Table(
 )
 
 
-class CuratedGroupStudent(db.Model):
-    __tablename__ = 'student_group_members'
-
-    curated_group_id = db.Column('student_group_id', db.Integer, db.ForeignKey('student_groups.id'), primary_key=True)
-    sid = db.Column('sid', db.String(80), primary_key=True)
-    curated_group = db.relationship('CuratedGroup', back_populates='students')
-
-
 class UniversityDeptMember(Base):
     __tablename__ = 'university_dept_members'
 

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -152,25 +152,21 @@ def load_development_data():
 
 
 def create_curated_groups():
-    admin_id = AuthorizedUser.find_by_uid('2040').id
-    CuratedGroup.create(admin_id, 'My Students')
+    admin_user = AuthorizedUser.find_by_uid('2040')
+    CuratedGroup.create(admin_user.id, 'My Students')
 
-    advisor_id = AuthorizedUser.find_by_uid('6446').id
-    CuratedGroup.create(advisor_id, 'My Students')
-    curated_group = CuratedGroup.create(advisor_id, 'Curated group with four ASC students and one student from COE')
+    asc_advisor = AuthorizedUser.find_by_uid('6446')
+    CuratedGroup.create(asc_advisor.id, 'My Students')
+
+    curated_group = CuratedGroup.create(asc_advisor.id, 'Four students')
     CuratedGroup.add_student(curated_group.id, '3456789012')
     CuratedGroup.add_student(curated_group.id, '5678901234')
     CuratedGroup.add_student(curated_group.id, '11667051')
     CuratedGroup.add_student(curated_group.id, '7890123456')
-    # TODO: When the BOA business rules change and all advisors have access to all students
-    #  then the following SID will be served to the ASC advisor who owns the group. See BOAC-2130
-    coe_student_sid = '9000000000'
-    CuratedGroup.add_student(curated_group.id, coe_student_sid)
 
     coe_advisor = AuthorizedUser.find_by_uid('1133399')
     curated_group = CuratedGroup.create(coe_advisor.id, 'I have one student')
-    CuratedGroup.add_student(curated_group.id, '7890123456')  # PaulF
-
+    CuratedGroup.add_student(curated_group.id, '7890123456')
     std_commit(allow_test_environment=True)
 
 

--- a/src/api/curated.ts
+++ b/src/api/curated.ts
@@ -50,10 +50,15 @@ export function deleteCuratedGroup(id) {
     .catch(error => error);
 }
 
-export function getCuratedGroup(id) {
-  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+export function getCuratedGroup(
+  id: number,
+  orderBy: string,
+  offset: number,
+  limit: number
+) {
+  const apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
-    .get(`${apiBaseUrl}/api/curated_group/${id}`)
+    .get(`${apiBaseUrl}/api/curated_group/${id}?orderBy=${orderBy}&offset=${offset}&limit${limit}`)
     .then(response => response.data, () => null);
 }
 

--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -29,6 +29,7 @@ export default {
     map: _.map,
     mapValues: _.mapValues,
     merge: _.merge,
+    multiply: _.multiply,
     orderBy: _.orderBy,
     partition: _.partition,
     putFocusNextTick(id, cssSelector = null) {

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.models.authorized_user import AuthorizedUser
-from boac.models.curated_group import CuratedGroup
+from boac.models.curated_group import CuratedGroup, CuratedGroupStudent
 import pytest
 import simplejson as json
 
@@ -50,56 +50,51 @@ def admin_user_session(fake_auth):
 
 
 @pytest.fixture()
-def asc_curated_group():
+def asc_curated_groups():
     advisor = AuthorizedUser.find_by_uid(asc_advisor_uid)
-    name = 'Curated group with four ASC students and one student from COE'
-    groups = CuratedGroup.get_curated_groups_by_owner_id(advisor.id)
-    return next((g for g in groups if g.name == name), None)
+    return CuratedGroup.get_curated_groups_by_owner_id(advisor.id)
 
 
 @pytest.fixture()
-def coe_advisor_group():
+def coe_advisor_groups():
     advisor = AuthorizedUser.find_by_uid(coe_advisor_uid)
-    return CuratedGroup.get_curated_groups_by_owner_id(advisor.id)[0]
+    return CuratedGroup.get_curated_groups_by_owner_id(advisor.id)
 
 
 class TestGetCuratedGroup:
     """Curated Group API."""
 
-    def test_not_authenticated(self, client):
+    @staticmethod
+    def _api_get_curated_group(
+            client,
+            curated_group_id,
+            order_by='last_name',
+            offset=0,
+            limit=50,
+            expected_status_code=200,
+    ):
+        response = client.get(f'/api/curated_group/{curated_group_id}?offset={offset}&limit={limit}&orderBy={order_by}')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    @staticmethod
+    def _api_students_with_alerts(client, curated_group_id, expected_status_code=200):
+        response = client.get(f'/api/curated_group/{curated_group_id}/students_with_alerts')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_not_authenticated(self, asc_curated_groups, client):
         """Anonymous user is rejected."""
-        assert client.get('/api/curated_groups/my').status_code == 401
+        self._api_get_curated_group(client, asc_curated_groups[0].id, expected_status_code=401)
 
-    def test_unauthorized(self, asc_curated_group, admin_user_session, client):
+    def test_unauthorized(self, asc_curated_groups, admin_user_session, client):
         """403 if user does not own the group."""
-        assert client.get(f'/api/curated_group/{asc_curated_group.id}').status_code == 403
+        self._api_get_curated_group(client, asc_curated_groups[0].id, expected_status_code=403)
 
-    def test_coe_curated_groups(self, client, coe_advisor):
-        """Returns curated groups of COE advisor."""
-        response = client.get('/api/curated_groups/my')
-        assert response.status_code == 200
-        groups = response.json
-        assert len(groups) == 1
-        group = groups[0]
-        assert 'id' in group
-        assert 'alertCount' in group
-        assert 'studentCount' in group
-        assert group['name'] == 'I have one student'
-
-    def test_asc_curated_groups(self, client, fake_auth):
-        """Returns curated groups of ASC advisor."""
-        fake_auth.login(asc_advisor_uid)
-        response = client.get('/api/curated_groups/my')
-        assert response.status_code == 200
-        groups = response.json
-        assert len(groups) == 2
-        assert 'name' in groups[0]
-        assert 'studentCount' in groups[0]
-
-    def test_curated_group_includes_alert_count(self, asc_advisor, asc_curated_group, client, create_alerts):
+    def test_curated_group_includes_alert_count(self, asc_advisor, asc_curated_groups, client, create_alerts):
         """Includes alert count per student."""
-        response = client.get(f'/api/curated_group/{asc_curated_group.id}')
-        students = response.json.get('students')
+        api_json = self._api_get_curated_group(client, asc_curated_groups[0].id)
+        students = api_json.get('students')
         assert students
         for student in students:
             assert isinstance(student.get('alertCount'), int)
@@ -107,85 +102,58 @@ class TestGetCuratedGroup:
         assert student_with_alerts
         assert student_with_alerts['alertCount'] == 3
 
-    def test_curated_group_includes_term_gpas(self, asc_advisor, asc_curated_group, client):
-        students = client.get(f'/api/curated_group/{asc_curated_group.id}').json['students']
+    def test_curated_group_includes_term_gpa(self, asc_advisor, asc_curated_groups, client):
+        api_json = self._api_get_curated_group(client, asc_curated_groups[0].id)
+        students = api_json['students']
         deborah = next(s for s in students if s['firstName'] == 'Deborah')
         assert len(deborah['termGpa']) == 4
         assert deborah['termGpa'][0] == {'termName': 'Spring 2018', 'gpa': 2.9}
         assert deborah['termGpa'][3] == {'termName': 'Spring 2016', 'gpa': 3.8}
 
-
-class TestMyCuratedGroups:
-    """Curated Group API."""
-
-    def test_students_without_alerts(self, asc_advisor, asc_curated_group, client, create_alerts, db_session):
-        """Students with alerts per group id."""
-        students_with_alerts = client.get(f'/api/curated_group/{asc_curated_group.id}/students_with_alerts').json
-        assert len(students_with_alerts) == 2
-        assert students_with_alerts[0]['alertCount'] == 3
-
-        student = client.get('/api/student/61889').json
-        alert_to_dismiss = student['notifications']['alert'][0]['id']
-        client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
-        students_with_alerts = client.get(f'/api/curated_group/{asc_curated_group.id}/students_with_alerts').json
-        assert students_with_alerts[0]['alertCount'] == 2
-
-    def test_curated_group_detail_includes_students_without_alerts(
+    def test_curated_group_includes_students_without_alerts(
             self,
             asc_advisor,
-            asc_curated_group,
+            asc_curated_groups,
             client,
             create_alerts,
     ):
         """Includes students in response."""
-        group = client.get(f'/api/curated_group/{asc_curated_group.id}').json
-        alert_counts = [s.get('alertCount') for s in group['students']]
-        assert alert_counts == [3, 0, 0, 1]
+        api_json = self._api_get_curated_group(client, asc_curated_groups[0].id, order_by='first_name')
+        last_names = [s.get('lastName') for s in api_json['students']]
+        assert last_names == ['Davies', 'Farestveit', 'Kerschen', 'Jayaprakash']
+        alert_counts = [s.get('alertCount') for s in api_json['students']]
+        assert alert_counts == [3, 0, 1, 0]
 
-    def test_excludes_sids_per_advisor_access_privileges(self, asc_advisor, asc_curated_group, client, create_alerts):
-        """Excludes SIDs in curated-group view based on advisor's access privileges."""
-        actual_student_count = len(asc_curated_group.students)
-        assert actual_student_count == 5
-        expected_student_count = 4
-        coe_student_sid = '9000000000'
+    def test_order_by_level(self, asc_advisor, asc_curated_groups, client):
+        """Includes students in response."""
+        api_json = self._api_get_curated_group(client, asc_curated_groups[0].id, order_by='level', offset=1, limit=2)
+        names = [f"{s.get('level')} ({s.get('lastName')})" for s in api_json['students']]
+        assert names == ['Junior (Kerschen)', 'Senior (Farestveit)']
 
-        group = client.get(f'/api/curated_group/{asc_curated_group.id}').json
-        assert len(group['students']) == expected_student_count
-        # Adjusted student count should be consistent across the curated_group API
-        my_groups = client.get('/api/curated_groups/my').json
-        group = next((g for g in my_groups if g['id'] == asc_curated_group.id), None)
-        assert group['studentCount'] == expected_student_count
-        # Group by id
-        group = client.get(f'/api/curated_group/{asc_curated_group.id}').json
-        assert group['studentCount'] == expected_student_count
-        # Group with alerts
-        students = client.get(f'/api/curated_group/{asc_curated_group.id}/students_with_alerts').json
-        assert not next((s for s in students if s['sid'] == coe_student_sid), None)
+    def test_order_by_major(self, asc_advisor, asc_curated_groups, client):
+        """Includes students in response."""
+        api_json = self._api_get_curated_group(client, asc_curated_groups[0].id, order_by='major', offset=1)
+        majors = [f"{s.get('majors')[0]} ({s.get('lastName')})" for s in api_json['students']]
+        assert majors == [
+            'English BA (Kerschen)',
+            'Letters & Sci Undeclared UG (Jayaprakash)',
+            'Nuclear Engineering BS (Farestveit)',
+        ]
 
-    def test_group_includes_student_summary(self, asc_advisor, asc_curated_group, client, create_alerts):
-        """Returns summary details but not full term and analytics data."""
-        students = client.get(f'/api/curated_group/{asc_curated_group.id}/students_with_alerts').json
-        assert students[0]['cumulativeGPA'] == 3.8
-        assert students[0]['cumulativeUnits'] == 101.3
-        assert students[0]['expectedGraduationTerm']['name'] == 'Fall 2019'
-        assert students[0]['level'] == 'Junior'
-        assert students[0]['termGpa'][0]['gpa'] == 2.9
-        assert len(students[0]['majors']) == 2
-
-    def test_curated_group_detail_includes_analytics(self, asc_advisor, asc_curated_group, client, create_alerts):
+    def test_curated_group_detail_includes_analytics(self, asc_advisor, asc_curated_groups, client, create_alerts):
         """Returns all students with full term and analytics data."""
-        group = client.get(f'/api/curated_group/{asc_curated_group.id}').json
-        student = group['students'][0]
+        api_json = self._api_get_curated_group(client, asc_curated_groups[0].id)
+        student = api_json['students'][0]
         assert student['cumulativeGPA'] == 3.8
         assert student['cumulativeUnits'] == 101.3
         assert student['level'] == 'Junior'
         assert len(student['majors']) == 2
         assert 'analytics' in student
 
-    def test_curated_group_detail_includes_athletics(self, asc_advisor, asc_curated_group, client):
+    def test_curated_group_detail_includes_athletics(self, asc_advisor, asc_curated_groups, client):
         """Returns student athletes."""
-        group = client.get(f'/api/curated_group/{asc_curated_group.id}').json
-        students = group['students']
+        api_json = self._api_get_curated_group(client, asc_curated_groups[0].id)
+        students = api_json['students']
         teams = students[0]['athleticsProfile']['athletics']
         assert len(teams) == 2
         assert teams[0]['name'] == 'Women\'s Field Hockey'
@@ -193,27 +161,143 @@ class TestMyCuratedGroups:
         assert teams[1]['name'] == 'Women\'s Tennis'
         assert teams[1]['groupCode'] == 'WTE'
 
-    def test_curated_group_detail_omits_athletics_non_asc(self, client, coe_advisor, coe_advisor_group):
+    def test_curated_group_detail_omits_athletics_non_asc(self, client, coe_advisor, coe_advisor_groups):
         """Omits student athletes from COE group."""
-        group = client.get(f'/api/curated_group/{coe_advisor_group.id}').json
-        assert 'athleticsProfile' not in group['students'][0]
+        api_json = self._api_get_curated_group(client, coe_advisor_groups[0].id)
+        assert 'athleticsProfile' not in api_json['students'][0]
 
-    def test_my_curated_groups_by_sid(self, client, coe_advisor, coe_advisor_group):
+    def test_students_without_alerts(self, asc_advisor, asc_curated_groups, client, create_alerts, db_session):
+        """Students with alerts per group id."""
+        api_json = self._api_students_with_alerts(client, asc_curated_groups[0].id)
+        assert len(api_json) == 2
+        assert api_json[0]['alertCount'] == 3
+
+        student = client.get('/api/student/61889').json
+        alert_to_dismiss = student['notifications']['alert'][0]['id']
+        client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
+        students_with_alerts = client.get(f'/api/curated_group/{asc_curated_groups[0].id}/students_with_alerts').json
+        assert students_with_alerts[0]['alertCount'] == 2
+
+    def test_group_includes_student_summary(self, asc_advisor, asc_curated_groups, client, create_alerts):
+        """Returns summary details but not full term and analytics data."""
+        api_json = self._api_students_with_alerts(client, asc_curated_groups[0].id)
+        assert api_json[0]['cumulativeGPA'] == 3.8
+        assert api_json[0]['cumulativeUnits'] == 101.3
+        assert api_json[0]['expectedGraduationTerm']['name'] == 'Fall 2019'
+        assert api_json[0]['level'] == 'Junior'
+        assert api_json[0]['termGpa'][0]['gpa'] == 2.9
+        assert len(api_json[0]['majors']) == 2
+
+
+class TestMyCuratedGroups:
+    """Curated Group API."""
+
+    @staticmethod
+    def _api_my_curated_groups(client, expected_status_code=200):
+        response = client.get('/api/curated_groups/my')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    @staticmethod
+    def _api_my_curated_groups_by_sid(client, sid, expected_status_code=200):
+        response = client.get(f'/api/curated_groups/my/{sid}')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_not_authenticated(self, client):
+        """Anonymous user is rejected."""
+        self._api_my_curated_groups(client, expected_status_code=401)
+
+    def test_excludes_sids_per_advisor_access_privileges(self, client, create_alerts, fake_auth):
+        """Excludes SIDs in curated-group view based on advisor's access privileges."""
+        advisor_uid = '1081940'
+        fake_auth.login(advisor_uid)
+        curated_group = CuratedGroup.create(
+            owner_id=AuthorizedUser.find_by_uid(advisor_uid).id,
+            name='Four ASC students, one COE student',
+        )
+        CuratedGroup.add_student(curated_group.id, '3456789012')
+        CuratedGroup.add_student(curated_group.id, '5678901234')
+        CuratedGroup.add_student(curated_group.id, '11667051')
+        CuratedGroup.add_student(curated_group.id, '7890123456')
+        # TODO: When the BOA business rules change and all advisors have access to all students
+        #  then the following SID will be served to the ASC advisor who owns the group. See BOAC-2130
+        coe_student_sid = '9000000000'
+        CuratedGroup.add_student(curated_group.id, coe_student_sid)
+
+        actual_student_count = len(CuratedGroupStudent.get_sids(curated_group_id=curated_group.id))
+        assert actual_student_count == 5
+        expected_student_count = 4
+
+        response = client.get(f'/api/curated_group/{curated_group.id}')
+        assert response.status_code == 200
+        assert len(response.json['students']) == expected_student_count
+        # Adjusted student count should be consistent across the curated_group API
+        api_json = self._api_my_curated_groups(client)
+        group = next((g for g in api_json if g['id'] == curated_group.id), None)
+        assert group['studentCount'] == expected_student_count
+        # Group by id
+        response = client.get(f'/api/curated_group/{curated_group.id}')
+        assert response.status_code == 200
+        assert response.json['studentCount'] == expected_student_count
+        # Group with alerts
+        response = client.get(f'/api/curated_group/{curated_group.id}/students_with_alerts')
+        assert response.status_code == 200
+        assert not next((s for s in response.json if s['sid'] == coe_student_sid), None)
+
+    def test_coe_curated_groups(self, client, coe_advisor):
+        """Returns curated groups of COE advisor."""
+        api_json = self._api_my_curated_groups(client)
+        assert len(api_json) == 1
+        group = api_json[0]
+        assert 'id' in group
+        assert 'alertCount' in group
+        assert 'studentCount' in group
+        assert group['name'] == 'I have one student'
+
+    def test_asc_curated_groups(self, asc_advisor, client):
+        """Returns curated groups of ASC advisor."""
+        api_json = self._api_my_curated_groups(client)
+        group = api_json[0]
+        assert group['name'] == 'Four students'
+        assert len(group['students']) == 4
+        assert group['studentCount'] == 4
+
+    def test_not_authenticated_curated_groups_by_sid(self, client):
+        """Anonymous user is rejected."""
+        assert self._api_my_curated_groups_by_sid(client, sid='7890123456', expected_status_code=401)
+
+    def test_curated_groups_by_sid(self, client, coe_advisor, coe_advisor_groups):
         """API delivers accurate set of student SIDs."""
-        ids = client.get(f'/api/curated_groups/my/{coe_advisor_group.students[0].sid}').json
-        assert ids == [coe_advisor_group.id]
+        sids = CuratedGroup.get_all_sids(curated_group_id=coe_advisor_groups[0].id)
+        sample_sid = sids[0]
+        assert self._api_my_curated_groups_by_sid(client, sid=sample_sid) == [coe_advisor_groups[0].id]
 
 
 class TestAddStudents:
     """Curated Group API."""
 
-    def test_not_authenticated(self, asc_curated_group, client):
-        """Anonymous user is rejected."""
-        assert _api_add_students(client, asc_curated_group.id, expected_status_code=401, sids=['2345678901'])
+    @staticmethod
+    def _api_add_students(client, curated_group_id, expected_status_code=200, return_student_profiles=False, sids=()):
+        response = client.post(
+            '/api/curated_group/students/add',
+            data=json.dumps({
+                'curatedGroupId': curated_group_id,
+                'returnStudentProfiles': return_student_profiles,
+                'sids': sids,
+            }),
+            content_type='application/json',
+        )
+        assert response.status_code == expected_status_code
+        return response.json
 
-    def test_unauthorized(self, asc_curated_group, admin_user_session, client):
+    def test_not_authenticated(self, asc_curated_groups, client):
+        """Anonymous user is rejected."""
+        assert self._api_add_students(client, asc_curated_groups[0].id, expected_status_code=401, sids=['2345678901'])
+
+    def test_unauthorized(self, asc_curated_groups, admin_user_session, client):
         """403 if user does not own the group."""
-        assert _api_add_students(client, asc_curated_group.id, expected_status_code=403, sids=['2345678901'])
+        assert self._api_add_students(client, asc_curated_groups[0].id, expected_status_code=403, sids=['2345678901'])
 
     def test_add_student(self, asc_advisor, client):
         """Create a group and add a student."""
@@ -221,10 +305,10 @@ class TestAddStudents:
         group = _api_create_group(client, name=group_name)
         assert group['studentCount'] == 0
         sid = '2345678901'
-        updated_group = _api_add_students(client, group['id'], sids=[sid])
+        updated_group = self._api_add_students(client, group['id'], sids=[sid])
         assert updated_group['name'] == group_name
         assert updated_group['studentCount'] == 1
-        assert updated_group['students'] == [{'sid': sid}]
+        assert updated_group['students'][0]['sid'] == sid
 
     def test_add_students(self, asc_advisor, client):
         """Create group and add students."""
@@ -233,17 +317,18 @@ class TestAddStudents:
         assert group['name'] == name
         assert group['studentCount'] == 2
         # Add students
-        updated_group = _api_add_students(client, group['id'], sids=['7890123456'])
-        students = updated_group['students']
-        students.sort(key=lambda s: s['sid'])
-        assert students == [
-            {'sid': '11667051'},
-            {'sid': '2345678901'},
-            {'sid': '7890123456'},
-        ]
+        updated_group = self._api_add_students(
+            client,
+            group['id'],
+            return_student_profiles=True,
+            sids=['7890123456'],
+        )
         assert updated_group['studentCount'] == 3
+        students = updated_group['students']
+        sids = [s['sid'] for s in students]
+        assert sids == ['11667051', '2345678901', '7890123456']
         # Add more and ask for FULL student profiles in payload
-        updated_group = _api_add_students(
+        updated_group = self._api_add_students(
             client,
             group['id'],
             return_student_profiles=True,
@@ -262,14 +347,14 @@ class TestAddStudents:
 class TestRemoveStudent:
     """Curated Group API."""
 
-    def test_not_authenticated(self, asc_curated_group, client):
+    def test_not_authenticated(self, asc_curated_groups, client):
         """Anonymous user is rejected."""
-        response = client.delete(f'/api/curated_group/{asc_curated_group.id}/remove_student/2345678901')
+        response = client.delete(f'/api/curated_group/{asc_curated_groups[0].id}/remove_student/2345678901')
         assert response.status_code == 401
 
-    def test_unauthorized(self, asc_curated_group, admin_user_session, client):
+    def test_unauthorized(self, asc_curated_groups, admin_user_session, client):
         """403 if user does not own the group."""
-        response = client.delete(f'/api/curated_group/{asc_curated_group.id}/remove_student/2345678901')
+        response = client.delete(f'/api/curated_group/{asc_curated_groups[0].id}/remove_student/2345678901')
         assert response.status_code == 403
 
     def test_remove_student(self, asc_advisor, client):
@@ -278,15 +363,18 @@ class TestRemoveStudent:
         group = _api_create_group(client, name=name)
         group_id = group['id']
         sid = '2345678901'
-        updated_group = _api_add_students(client, group_id, sids=[sid])
-        assert updated_group['name'] == name
-        assert updated_group['students'] == [{'sid': sid}]
-        assert updated_group['studentCount'] == 1
+        response = client.post(
+            '/api/curated_group/students/add',
+            data=json.dumps({'curatedGroupId': group_id, 'sids': [sid]}),
+            content_type='application/json',
+        )
+        assert response.status_code == 200
+        assert response.json['name'] == name
+        assert response.json['studentCount'] == 1
         response = client.delete(f'/api/curated_group/{group_id}/remove_student/{sid}')
         assert response.status_code == 200
         empty_group = response.json
         assert empty_group['name'] == name
-        assert empty_group['students'] == []
         assert empty_group['studentCount'] == 0
 
 
@@ -309,6 +397,10 @@ class TestUpdateCuratedGroup:
         assert response.status_code == 200
         assert client.get(f'/api/curated_group/{group_id}').json['name'] == new_name
 
+
+class TestDeleteCuratedGroup:
+    """Curated Group API."""
+
     def test_delete_group(self, asc_advisor, client):
         """Delete curated group."""
         group = _api_create_group(client, name='Mellow Together')
@@ -322,20 +414,6 @@ def _api_create_group(client, expected_status_code=200, name=None, sids=()):
         '/api/curated_group/create',
         data=json.dumps({
             'name': name,
-            'sids': sids,
-        }),
-        content_type='application/json',
-    )
-    assert response.status_code == expected_status_code
-    return response.json
-
-
-def _api_add_students(client, curated_group_id, expected_status_code=200, return_student_profiles=False, sids=()):
-    response = client.post(
-        '/api/curated_group/students/add',
-        data=json.dumps({
-            'curatedGroupId': curated_group_id,
-            'returnStudentProfiles': return_student_profiles,
             'sids': sids,
         }),
         content_type='application/json',

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -255,7 +255,7 @@ class TestAthleticsStudyCenter:
 
 
 class TestStudentResultsForFilter:
-    """Student API results for filtered cohort criteria."""
+    """Student API."""
 
     sample_filter = {
         'gpaRanges': ['numrange(3, 3.5, \'[)\')', 'numrange(3.5, 4, \'[]\')'],


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-855

I had to remove the SQLAlchemy join on students and load students (or sids) on demand, with offset and limit options. Remember that curated groups are special in that we filter SIDs of the group based on user's `dept_code`.