### PR TITLE
NS-528, update buildspec to v0.2 spec, use 'runtime versions'

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,13 +1,10 @@
 version: 0.2
 
-eb_codebuild_settings:
-  CodeBuildServiceRole: arn:aws:iam::697877139013:role/service-role/code-build-BOAC-service-role
-  ComputeType: BUILD_GENERAL1_MEDIUM
-  Image: aws/codebuild/nodejs:8.11.0
-  Timeout: 60
-
 phases:
   install:
+    runtime-versions:
+      nodejs: 8
+      python: 3.7
     commands:
       - npm -v
       - npm install


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-528

Read Jira description and overview of syntax in https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec-ref-syntax