### PR TITLE
NS-528, remove sudo from buildspec.yml

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,8 +15,8 @@ phases:
 
   build:
     commands:
-      - sudo npm install -g @vue/cli
-      - sudo npm run build-vue
+      - npm install -g @vue/cli
+      - npm run build-vue
       - mv ./dist/static/vue/* ./dist/static/
 
   post_build:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-528

`sudo` is not available on CodeBuild's transient Docker image – maybe because `root` is default user in new 0.2 spec.  So `sudo` is out. (We tested this change, from my working branch, on boac-dev pipeline and deploy succeeded.) 