### PR TITLE
BOAC-2222, fix tooltips: revert highcharts to 6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6718,9 +6718,9 @@
       "dev": true
     },
     "highcharts": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-7.1.1.tgz",
-      "integrity": "sha512-BQtWDQmH4AweQNFLGJCHBQwv9tj9kyp35bp2FFpmNBm7LOecCQdLjvZNgUKvCsKzBzJJIywcwWu4QEcAkPGCjg=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-6.2.0.tgz",
+      "integrity": "sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ=="
     },
     "highlight.js": {
       "version": "9.15.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "axios": "^0.18.0",
     "bootstrap-vue": "^2.0.0-rc.20",
     "d3": "5.9.2",
-    "highcharts": "7.1.1",
+    "highcharts": "6.2.0",
     "vue": "^2.6.10",
     "vue-analytics": "^5.16.4",
     "vue-class-component": "^7.1.0",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2222

We can revisit this mystery if/when we need the latest [highcharts](https://github.com/highcharts/highcharts).