### PR TITLE
[BOAC-2235] Changing AWS auth scheme to use STS tokens and app_roles.

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -78,4 +78,4 @@ Resources:
             "Fn::GetOptionSetting":
               Namespace: "aws:autoscaling:launchconfiguration"
               OptionName: "IamInstanceProfile"
-              DefaultValue: "aws-elasticbeanstalk-ec2-role"
+              DefaultValue: "RTL-app-boa-dev-role"

--- a/.ebextensions/12_set_default_region.config
+++ b/.ebextensions/12_set_default_region.config
@@ -1,0 +1,6 @@
+#
+# Set AWS Default region for sts token to be created in required region.
+#
+container_commands:
+  01_set_default_region:
+    command: 'export AWS_DEFAULT_REGION=us-west-2'

--- a/boac/externals/s3.py
+++ b/boac/externals/s3.py
@@ -31,18 +31,15 @@ import smart_open
 """Client code to run file operations against S3."""
 
 
-def build_s3_url(bucket, key, credentials=True):
-    if credentials:
-        credentials = ':'.join([app.config['AWS_ACCESS_KEY_ID'], app.config['AWS_SECRET_ACCESS_KEY']])
-        return f's3://{credentials}@{bucket}/{key}'
-    else:
-        return f's3://{bucket}/{key}'
+def build_s3_url(bucket, key):
+    return f's3://{bucket}/{key}'
 
 
 def stream_object(bucket, key):
     s3_url = build_s3_url(bucket, key)
+    session = _get_session()
     try:
-        return smart_open.open(s3_url, 'rb')
+        return smart_open.open(s3_url, 'rb', transport_params=dict(session=session))
     except Exception as e:
         app.logger.error(f'S3 stream operation failed (bucket={bucket}, key={key})')
         app.logger.exception(e)
@@ -54,13 +51,29 @@ def put_file_to_s3(bucket, key, path_to_file):
 
 
 def put_binary_data_to_s3(bucket, key, binary_data):
-    _get_client().put_object(Body=binary_data, Bucket=bucket, Key=key, ServerSideEncryption='AES256')
+    _get_client().put_object(Body=binary_data, Bucket=bucket, Key=key, ServerSideEncryption=app.config['DATA_LOCH_S3_ENCRYPTION'])
+
+
+def _get_sts_credentials():
+    sts_client = boto3.client('sts')
+    role_arn = app.config['AWS_APP_ROLE_ARN']
+    assumed_role_object = sts_client.assume_role(
+        RoleArn=role_arn,
+        RoleSessionName='AssumeAppRoleSession',
+        DurationSeconds=900,
+    )
+    return assumed_role_object['Credentials']
+
+
+def _get_session():
+    credentials = _get_sts_credentials()
+    return boto3.Session(
+        aws_access_key_id=credentials['AccessKeyId'],
+        aws_secret_access_key=credentials['SecretAccessKey'],
+        aws_session_token=credentials['SessionToken'],
+    )
 
 
 def _get_client():
-    return boto3.client(
-        's3',
-        aws_access_key_id=app.config['AWS_ACCESS_KEY_ID'],
-        aws_secret_access_key=app.config['AWS_SECRET_ACCESS_KEY'],
-        region_name=app.config['DATA_LOCH_S3_REGION'],
-    )
+    session = _get_session()
+    return session.client('s3', region_name=app.config['DATA_LOCH_S3_REGION'])

--- a/config/default.py
+++ b/config/default.py
@@ -76,8 +76,7 @@ ABBREVIATED_WORDS = ['APR', 'EAP', 'PNP', 'SAP']
 API_KEY = None
 
 # BOAC-specific AWS credentials.
-AWS_ACCESS_KEY_ID = 'key'
-AWS_SECRET_ACCESS_KEY = 'secret'
+AWS_APP_ROLE_ARN = 'aws:arn::<account>:role/<app_boa_role>'
 
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
 CAS_LOGOUT_URL = 'https://auth-test.berkeley.edu/cas/logout'
@@ -101,6 +100,7 @@ DATA_LOCH_SIS_SCHEMA = 'sis_data'
 DATA_LOCH_STUDENT_SCHEMA = 'student'
 
 DATA_LOCH_S3_REGION = 'us-west-2'
+DATA_LOCH_S3_ENCRYPTION = 'AES256'
 DATA_LOCH_S3_ADVISING_NOTE_BUCKET = 'advising-note-bucket'
 DATA_LOCH_S3_ADVISING_NOTE_ATTACHMENT_PATH = 'attachment-path'
 DATA_LOCH_S3_BOA_NOTE_ATTACHMENTS_PATH = 'boa-attachment-path'

--- a/config/test.py
+++ b/config/test.py
@@ -26,6 +26,8 @@ ENHANCEMENTS, OR MODIFICATIONS.
 ALERT_INFREQUENT_ACTIVITY_ENABLED = False
 ALERT_WITHDRAWAL_ENABLED = False
 
+AWS_APP_ROLE_ARN = 'arn:aws:iam::123456789012:role/test-role'
+
 DATA_LOCH_RDS_URI = 'postgres://boac:boac@localhost:5432/boac_loch_test'
 DATA_LOCH_URI = 'postgres://boac:boac@localhost:5432/boac_loch_test'
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -31,7 +31,7 @@ import moto
 
 @contextmanager
 def mock_legacy_note_attachment(app):
-    with moto.mock_s3():
+    with moto.mock_s3(), moto.mock_sts():
         bucket = app.config['DATA_LOCH_S3_ADVISING_NOTE_BUCKET']
         s3 = boto3.resource('s3', app.config['DATA_LOCH_S3_REGION'])
         s3.create_bucket(Bucket=bucket)
@@ -42,7 +42,7 @@ def mock_legacy_note_attachment(app):
 
 @contextmanager
 def mock_advising_note_s3_bucket(app):
-    with moto.mock_s3():
+    with moto.mock_s3(), moto.mock_sts():
         bucket = app.config['DATA_LOCH_S3_ADVISING_NOTE_BUCKET']
         s3 = boto3.resource('s3', app.config['DATA_LOCH_S3_REGION'])
         s3.create_bucket(Bucket=bucket)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2235

1) Boto authentication is switched to create session using STS credentials. This limits credential exposure. The commit changes the auth scheme for BOA while interacting with AWS services like S3. A Short term credential(includes temp key, secret, token) is created for every interaction which is alive for 15 minutes duration using STS service. Permissions are given to the developer group to assume roles in the context of the app and environment they will be running which limits cross stack access, limiting the blast radius.  

2) Elastic Beanstalk changes to represent the use of IAM instance roles. IAM instance profile on EC2 servers will have the app_role attached to it which provides the same permissions for instances to assume roles and interact with AWS services. 

3) S3 Encryption mode will be part of configs going forward so that S3 encryption schemes can be changed as necessary by the Dev Sec Ops team while rotating encryption keys and policies without functionality disruption.

