### PR TITLE
BOAC-2224 Don't let that old notes checkbox disappear

### DIFF
--- a/src/components/sidebar/SearchForm.vue
+++ b/src/components/sidebar/SearchForm.vue
@@ -90,10 +90,10 @@
           Notes
         </label>
         <b-btn
-          v-if="includeNotes"
           id="search-options-note-filters-toggle"
           class="search-options-panel-toggle search-options-panel-toggle-subpanel"
           variant="link"
+          :class="includeNotes ? 'visible' : 'invisible'"
           @click="showNoteFilters = !showNoteFilters">
           ({{ showNoteFilters ? 'hide' : 'show' }} filters)
         </b-btn>
@@ -211,7 +211,8 @@ export default {
   font-size: 12px;
 }
 .search-options-panel-toggle-subpanel {
-  padding-left: 5px;
+  margin-bottom: .5rem;
+  padding: 0 0 0 5px;
 }
 .search-students-form-button {
   min-width: 200px;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2224

As far as I can tell, having the text button wink in and out of existence was confusing Bootstrap's flex implementation. Simply toggling CSS visibility keeps things stable.