### PR TITLE
BOAC-2228 Widen advising note topic input

### DIFF
--- a/src/components/note/AdvisingNoteTopics.vue
+++ b/src/components/note/AdvisingNoteTopics.vue
@@ -7,7 +7,7 @@
     </div>
     <b-container class="pl-0 ml-0">
       <b-form-row class="pb-1">
-        <b-col cols="4">
+        <b-col cols="9">
           <b-input-group>
             <b-form-input
               id="add-note-topic"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2228

This allows a full-width list of options to appear in Safari, and I think is easier to read anyhow.