### PR TITLE
[NS-531] Use environment variables to pass app_role to instance profile.

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -78,4 +78,4 @@ Resources:
             "Fn::GetOptionSetting":
               Namespace: "aws:autoscaling:launchconfiguration"
               OptionName: "IamInstanceProfile"
-              DefaultValue: "RTL-app-boa-dev-role"
+              DefaultValue: "$IAM_INSTANCE_PROFILE"


### PR DESCRIPTION
Passes app_roles to the instance profiles vis environment variables. This prevents code changes during stack promotion and deployments. 

https://jira.ets.berkeley.edu/jira/browse/NS-531