### PR TITLE
BOAC-2300 Fix loading-aware conditional in cohort/group sort

### DIFF
--- a/src/views/Cohort.vue
+++ b/src/views/Cohort.vue
@@ -145,7 +145,7 @@ export default {
       this.setPagination(1);
     });
     this.$eventHub.$on('sortBy-user-preference-change', sortBy => {
-      if (this.loaded()) {
+      if (!this.loading) {
         this.goToPage(1);
         this.screenReaderAlert = `Sort students by ${sortBy}`;
         this.gaCohortEvent(

--- a/src/views/CuratedGroup.vue
+++ b/src/views/CuratedGroup.vue
@@ -99,7 +99,7 @@ export default {
       });
     });
     this.$eventHub.$on('sortBy-user-preference-change', sortBy => {
-      if (this.loaded()) {
+      if (!this.loading) {
         this.goToPage(1);
         this.screenReaderAlert = `Sort students by ${sortBy}`;
         this.gaCuratedEvent(this.curatedGroup.id, this.curatedGroup.name, this.screenReaderAlert);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2300

By an accident of history, `this.loading` is a data value, while `this.loaded()` is a setter function returning nothing.