### PR TITLE
BOAC-2302, 'continueEdit-if-back-button' logic in /cohort is fooled by clicking around sidebar

### DIFF
--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -81,6 +81,7 @@ export default {
       }
     },
     split: _.split,
+    startsWith: _.startsWith,
     stripHtmlAndTrim: html => {
       let text = html && html.replace(/<([^>]+)>/ig,"");
       text = text && text.replace(/&nbsp;/g, '');

--- a/src/views/Cohort.vue
+++ b/src/views/Cohort.vue
@@ -117,8 +117,8 @@ export default {
     }
   },
   mounted() {
-    const continueExistingSession =
-      this.$routerHistory.hasForward() && this.size(this.filters);
+    const forwardPath = this.$routerHistory.hasForward() && this.get(this.$routerHistory.next(), 'path');
+    const continueExistingSession = this.startsWith(forwardPath, '/student') && this.size(this.filters);
     if (continueExistingSession) {
       this.pageNumber = this.pagination.currentPage;
       this.setPageTitle(this.cohortName);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2302

The 'continueExistingSession' logic allows users to click to (1) view a student and then (2) use back-button to return to the working state of cohort view. For example, page number and filter edits are preserved.

In the 'continueExistingSession' logic, we're getting false-positives from `$routerHistory.hasForward()` when user is clicking around links in sidebar. This PR avoids such false-positives by only supporting back button when user goes /cohort to /student and then back-button to /cohort. IMO, this is an intuitive limit on back-button support.
