### PR TITLE
[QA] BOAC-2303, fix sortable columns: if args _.isNumber then compare w/o type conversion

### DIFF
--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -68,6 +68,8 @@ export default {
     sortComparator: (a, b) => {
       if (_.isNil(a) || _.isNil(b)) {
         return _.isNil(a) ? (_.isNil(b) ? 0 : -1) : 1;
+      } else if (_.isNumber(a) && _.isNumber(b)) {
+        return a < b ? -1 : a > b ? 1 : 0
       } else {
         const aInt = toInt(a);
         const bInt = toInt(b);


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2303

Before this fix, floats were compared via _.toInt() – a world where 3.1 equals 3.9.