### PR TITLE
BOAC-2236, flex-wrap on rows of cohorts/groups in sidebar

### DIFF
--- a/src/components/sidebar/Cohorts.vue
+++ b/src/components/sidebar/Cohorts.vue
@@ -4,7 +4,7 @@
       <div class="ml-2 sidebar-header">
         Cohorts
       </div>
-      <div class="mr-2">
+      <div class="ml-2 mr-2">
         <router-link
           id="cohort-create"
           aria-label="Create cohort"
@@ -16,8 +16,8 @@
     <div
       v-for="cohort in myCohorts"
       :key="cohort.id"
-      class="d-flex justify-content-between sidebar-row-link">
-      <div class="ml-2 mr-1 truncate-with-ellipsis">
+      class="d-flex flex-wrap justify-content-between sidebar-row-link">
+      <div class="ml-2 truncate-with-ellipsis">
         <router-link
           :id="`sidebar-cohort-${cohort.id}`"
           :aria-label="`Cohort ${cohort.name} has ${cohort.totalStudentCount} students`"
@@ -25,7 +25,7 @@
           {{ cohort.name }}
         </router-link>
       </div>
-      <div class="mr-2">
+      <div class="ml-2 mr-2">
         <span
           :id="`sidebar-cohort-${cohort.id}-total-student-count`"
           class="sidebar-pill">{{ cohort.totalStudentCount }}<span class="sr-only">{{ 'student' | pluralize(cohort.totalStudentCount) }}</span>

--- a/src/components/sidebar/CuratedGroups.vue
+++ b/src/components/sidebar/CuratedGroups.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <div class="d-flex justify-content-between mb-1 sidebar-row-link">
+    <div class="d-flex flex-wrap justify-content-between mb-1 sidebar-row-link">
       <div class="ml-2 sidebar-header">
         Curated Groups
       </div>
-      <div class="mr-2">
+      <div class="ml-2 mr-2">
         <router-link
           id="create-curated-group-from-sidebar"
           class="sidebar-create-link"
@@ -17,8 +17,8 @@
     <div
       v-for="(group, index) in myCuratedGroups"
       :key="group.id"
-      class="d-flex justify-content-between sidebar-row-link">
-      <div class="ml-2 mr-1 truncate-with-ellipsis">
+      class="d-flex flex-wrap justify-content-between sidebar-row-link">
+      <div class="ml-2 truncate-with-ellipsis">
         <router-link
           :id="`sidebar-curated-group-${index}`"
           :aria-label="'Curated group ' + group.name + ' has ' + group.studentCount + ' students'"
@@ -26,7 +26,7 @@
           {{ group.name }}
         </router-link>
       </div>
-      <div class="mr-2">
+      <div class="ml-2 mr-2">
         <span
           :id="`sidebar-curated-group-${index}-count`"
           class="sidebar-pill">{{ group.studentCount }}<span class="sr-only">{{ 'student' | pluralize(group.studentCount) }}</span>

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -12,7 +12,9 @@
       <hr class="ml-2 mr-2 section-divider" />
     </div>
     <div class="mb-2 sidebar-row-link">
-      <router-link id="cohorts-all" class="ml-2 mr-2" to="/cohorts/all">Everyone's Cohorts</router-link>
+      <div class="ml-2 mr-2">
+        <router-link id="cohorts-all" to="/cohorts/all">Everyone's Cohorts</router-link>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2236

No QA PR needed here. With narrower sidebar, `flex-wrap` plays well in narrow viewport.