### PR TITLE
BOAC-2271, add column 'sids' to cohort_filters for fast batch note creation

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -225,7 +225,7 @@ def load_filtered_cohort_counts():
     from boac.models.cohort_filter import CohortFilter
     for cohort in CohortFilter.query.all():
         # Remove!
-        cohort.update_student_count(None)
+        cohort.update_sids_and_student_count(None, None)
         cohort.update_alert_count(None)
         # The db schema supports multiple cohort owners but in the real world it is one owner per cohort.
         owner_id = cohort.owners[0].id if len(cohort.owners) else None

--- a/boac/api/menu_controller.py
+++ b/boac/api/menu_controller.py
@@ -40,5 +40,5 @@ def all_cohort_filter_options():
 @app.route('/api/menu/cohort/translate_filter_criteria_to_menu', methods=['POST'])
 @login_required
 def translate_cohort_filter_to_menu():
-    criteria = get_param(request.get_json(), 'filterCriteria')
+    criteria = get_param(request.get_json(), 'criteria')
     return tolerant_jsonify(translate_cohort_filter(criteria))

--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -26,7 +26,6 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import re
 
 from flask import current_app as app
-import numpy as np
 
 
 """A utility module collecting logic specific to the Berkeley campus."""
@@ -446,16 +445,6 @@ def is_authorized_to_use_boac(user):
 
 def get_dept_codes(user):
     return [m.university_dept.dept_code for m in user.department_memberships] if user else None
-
-
-def can_view_cohort(user, cohort):
-    if user.is_admin:
-        return True
-    my_dept_codes = get_dept_codes(user)
-    cohort_dept_codes = []
-    if cohort.owners:
-        cohort_dept_codes = np.concatenate([get_dept_codes(o) for o in cohort.owners])
-    return np.in1d(my_dept_codes, cohort_dept_codes)
 
 
 def section_is_eligible_for_alerts(enrollment, section):

--- a/boac/lib/cohort_filter_definition.py
+++ b/boac/lib/cohort_filter_definition.py
@@ -28,7 +28,6 @@ from copy import deepcopy
 from boac.api.util import authorized_users_api_feed
 from boac.externals import data_loch
 from boac.lib.berkeley import BERKELEY_DEPT_NAME_TO_CODE, COE_ETHNICITIES_PER_CODE, get_dept_codes
-from boac.lib.util import to_bool_or_none as to_bool
 from boac.merged import athletics
 from boac.merged.student import get_student_query_scope
 from boac.models.authorized_user import AuthorizedUser
@@ -222,22 +221,6 @@ def translate_cohort_filter(criteria=None):
                     else:
                         rows.append(_translate_filter_row(definition, selected))
     return rows
-
-
-def translate_filters_to_cohort_criteria(filters):
-    criteria = {}
-    for filter_ in filters:
-        key = filter_['key']
-        type_ = filter_['type']
-        value = filter_['value']
-        if type_ == 'boolean':
-            criteria[key] = to_bool(value)
-        elif type_ == 'array':
-            criteria[key] = criteria.get(key) or []
-            criteria[key].append(value)
-        elif type_ == 'range':
-            criteria[key] = value
-    return criteria
 
 
 def get_cohort_filter_options(existing_filters):

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -23,11 +23,13 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+from datetime import datetime
 import json
 
 from boac import db, std_commit
 from boac.api.errors import InternalServerError
 from boac.lib import util
+from boac.lib.util import to_bool_or_none as to_bool
 from boac.merged import athletics
 from boac.merged.student import query_students
 from boac.models.alert import Alert
@@ -36,7 +38,8 @@ from boac.models.authorized_user import cohort_filter_owners
 from boac.models.base import Base
 from flask_login import UserMixin
 from sqlalchemy import text
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import deferred, undefer
 
 
 class CohortFilter(Base, UserMixin):
@@ -45,6 +48,8 @@ class CohortFilter(Base, UserMixin):
     id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
     name = db.Column(db.String(255), nullable=False)
     filter_criteria = db.Column(JSONB, nullable=False)
+    # Fetching a large array literal from Postgres can be expensive. We defer until invoking code demands it.
+    sids = deferred(db.Column(ARRAY(db.String(80))))
     student_count = db.Column(db.Integer)
     alert_count = db.Column(db.Integer)
     owners = db.relationship('AuthorizedUser', secondary=cohort_filter_owners, back_populates='cohort_filters')
@@ -58,37 +63,47 @@ class CohortFilter(Base, UserMixin):
             name={self.name},
             owners={self.owners},
             filter_criteria={self.filter_criteria},
+            sids={self.sids},
             student_count={self.student_count},
             alert_count={self.alert_count},
             updated_at={self.updated_at},
             created_at={self.created_at}>"""
 
     @classmethod
-    def create(cls, uid, name, filter_criteria, student_count=None):
+    def create(cls, uid, name, filter_criteria, **kwargs):
         if all(not isinstance(value, bool) and not value for value in filter_criteria.values()):
             raise InternalServerError('Cohort creation requires at least one filter specification.')
-        cohort = CohortFilter(name=name, filter_criteria=filter_criteria)
-        cohort.student_count = student_count
+        cohort = cls(name=name, filter_criteria=filter_criteria)
         user = AuthorizedUser.find_by_uid(uid)
         user.cohort_filters.append(cohort)
         db.session.flush()
         std_commit()
-        return cohort
+        return cohort.to_api_json(**kwargs)
 
     @classmethod
-    def update(cls, cohort_id, name=None, filter_criteria=None, student_count=None, alert_count=None):
-        cohort = CohortFilter.query.filter_by(id=cohort_id).first()
+    def update(cls, cohort_id, name=None, filter_criteria=None, alert_count=None, **kwargs):
+        cohort = cls.query.filter_by(id=cohort_id).first()
         cohort.name = name
         cohort.filter_criteria = filter_criteria
-        if student_count is not None:
-            cohort.student_count = student_count
+        cohort.sids = None
+        cohort.student_count = None
         if alert_count is not None:
             cohort.alert_count = alert_count
+        else:
+            # Alert count will be refreshed
+            cohort.update_alert_count(None)
         std_commit()
-        return cohort
+        return cohort.to_api_json(**kwargs)
 
-    def update_student_count(self, count):
-        self.student_count = count
+    @classmethod
+    def get_sids(cls, cohort_id):
+        query = db.session.query(cls).options(undefer('sids'))
+        cohort = query.filter_by(id=cohort_id).first()
+        return cohort and cohort.sids
+
+    def update_sids_and_student_count(self, sids, student_count):
+        self.sids = sids
+        self.student_count = student_count
         std_commit()
         return self
 
@@ -99,27 +114,30 @@ class CohortFilter(Base, UserMixin):
 
     @classmethod
     def share(cls, cohort_id, user_id):
-        cohort = CohortFilter.query.filter_by(id=cohort_id).first()
+        cohort = cls.query.filter_by(id=cohort_id).first()
         user = AuthorizedUser.find_by_uid(user_id)
         user.cohort_filters.append(cohort)
         std_commit()
-        return cohort
 
     @classmethod
     def all_cohorts(cls):
-        return CohortFilter.query.all()
+        return [c.to_api_json(include_students=False) for c in cls.query.all()]
 
     @classmethod
     def all_owned_by(cls, uid):
-        return CohortFilter.query.filter(CohortFilter.owners.any(uid=uid)).order_by(CohortFilter.name).all()
+        cohorts = []
+        for cohort in cls.query.filter(cls.owners.any(uid=uid)).order_by(cls.name).all():
+            cohorts.append(cohort.to_api_json())
+        return cohorts
 
     @classmethod
-    def find_by_id(cls, cohort_id):
-        return CohortFilter.query.filter_by(id=cohort_id).first()
+    def find_by_id(cls, cohort_id, **kwargs):
+        cohort = cls.query.filter_by(id=cohort_id).first()
+        return cohort and cohort.to_api_json(**kwargs)
 
     @classmethod
     def delete(cls, cohort_id):
-        cohort_filter = CohortFilter.query.filter_by(id=cohort_id).first()
+        cohort_filter = cls.query.filter_by(id=cohort_id).first()
         db.session.delete(cohort_filter)
         std_commit()
 
@@ -136,11 +154,37 @@ class CohortFilter(Base, UserMixin):
             return {
                 'id': row['id'],
                 'name': row['name'],
-                'filterCriteria': row['filter_criteria'],
+                'criteria': row['filter_criteria'],
                 'alertCount': row['alert_count'],
                 'totalStudentCount': row['student_count'],
             }
         return [transform(row) for row in results]
+
+    @classmethod
+    def construct_phantom_cohort(cls, filters, **kwargs):
+        # A "phantom" cohort is one that we do not save to the db.
+        # On the front-end, a "phantom" cohort is an unsaved search.
+        cohort = cls(
+            name=f'phantom_cohort_{datetime.now().timestamp()}',
+            filter_criteria=cls.translate_filters_to_cohort_criteria(filters),
+        )
+        return cohort.to_api_json(**kwargs)
+
+    @classmethod
+    def translate_filters_to_cohort_criteria(cls, filters):
+        criteria = {}
+        for filter_ in filters:
+            key = filter_['key']
+            type_ = filter_['type']
+            value = filter_['value']
+            if type_ == 'boolean':
+                criteria[key] = to_bool(value)
+            elif type_ == 'array':
+                criteria[key] = criteria.get(key) or []
+                criteria[key].append(value)
+            elif type_ == 'range':
+                criteria[key] = value
+        return criteria
 
     def to_api_json(
         self,
@@ -161,9 +205,14 @@ class CohortFilter(Base, UserMixin):
             'id': self.id,
             'code': self.id,
             'name': cohort_name,
-            'owners': [user.uid for user in self.owners],
+            'owners': [],
             'alertCount': self.alert_count,
         }
+        for owner in self.owners:
+            cohort_json['owners'].append({
+                'uid': owner.uid,
+                'deptCodes': [m.university_dept.dept_code for m in owner.department_memberships],
+            })
         coe_prep_statuses = c.get('coePrepStatuses')
         coe_probation = util.to_bool_or_none(c.get('coeProbation'))
         ethnicities = c.get('ethnicities')
@@ -180,7 +229,7 @@ class CohortFilter(Base, UserMixin):
         underrepresented = util.to_bool_or_none(c.get('underrepresented'))
         unit_ranges = c.get('unitRanges')
         cohort_json.update({
-            'filterCriteria': {
+            'criteria': {
                 'advisorLdapUids': advisor_ldap_uids,
                 'coePrepStatuses': coe_prep_statuses,
                 'coeProbation': coe_probation,
@@ -235,13 +284,13 @@ class CohortFilter(Base, UserMixin):
             unit_ranges=unit_ranges,
         )
         if results:
-            # If the cohort is newly created or a cache refresh is underway, store the student count in the database
-            # to save future queries.
-            if self.student_count is None:
-                self.update_student_count(results['totalStudentCount'])
+            # We deliberately keep SIDs out of the feed. For now, it is only used server-side in bulk note creation.
             cohort_json.update({
                 'totalStudentCount': results['totalStudentCount'],
             })
+            # If the cohort is new or cache refresh is underway then store student_count and sids in the db.
+            if self.student_count is None:
+                self.update_sids_and_student_count(results['sids'], results['totalStudentCount'])
             if include_students:
                 cohort_json.update({
                     'students': results['students'],

--- a/scripts/db/migrate/20190606-BOAC-2271/pre_deploy_01_create_sids_column.sql
+++ b/scripts/db/migrate/20190606-BOAC-2271/pre_deploy_01_create_sids_column.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+    ALTER TABLE cohort_filters ADD COLUMN sids VARCHAR(80)[];
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -122,6 +122,7 @@ CREATE TABLE cohort_filters (
     id integer NOT NULL,
     name character varying(255) NOT NULL,
     filter_criteria jsonb NOT NULL,
+    sids VARCHAR(80)[],
     student_count integer,
     alert_count integer,
     created_at timestamp with time zone NOT NULL,

--- a/src/api/cohort.ts
+++ b/src/api/cohort.ts
@@ -3,16 +3,11 @@ import store from '@/store';
 
 export function createCohort(
   name: string,
-  filters: any[],
-  studentCount: number
+  filters: any[]
 ) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
-    .post(`${apiBaseUrl}/api/cohort/create`, {
-      name,
-      filters,
-      studentCount
-    })
+    .post(`${apiBaseUrl}/api/cohort/create`, {name, filters})
     .then(response => {
       const cohort = response.data;
       store.dispatch('cohort/addCohort', cohort);
@@ -87,16 +82,14 @@ export function getUsersWithCohorts() {
 export function saveCohort(
   id: number,
   name: string,
-  filters?: any,
-  studentCount?: number
+  filters?: any
 ) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
     .post(`${apiBaseUrl}/api/cohort/update`, {
       id,
       name,
-      filters,
-      studentCount
+      filters
     })
     .then(response => {
       const cohort = response.data;

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -1,12 +1,10 @@
 import axios from 'axios';
 import store from '@/store';
 
-export function translateToMenu(filterCriteria: any) {
+export function translateToMenu(criteria: any) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
-    .post(`${apiBaseUrl}/api/menu/cohort/translate_filter_criteria_to_menu`, {
-      filterCriteria: filterCriteria
-    })
+    .post(`${apiBaseUrl}/api/menu/cohort/translate_filter_criteria_to_menu`, { criteria: criteria })
     .then(response => response.data, () => null);
 }
 

--- a/src/store/modules/cohort-edit-session.ts
+++ b/src/store/modules/cohort-edit-session.ts
@@ -178,7 +178,7 @@ const actions = {
   },
   createCohort: ({ commit, state }, name: string) => {
     return new Promise(resolve => {
-      createCohort(name, state.filters, state.totalStudentCount).then(
+      createCohort(name, state.filters).then(
         cohort => {
           commit('resetSession', {
             cohort,
@@ -197,7 +197,7 @@ const actions = {
     return new Promise(resolve => {
       getCohort(id, true, orderBy).then(cohort => {
         if (cohort) {
-          translateToMenu(cohort.filterCriteria).then(filters => {
+          translateToMenu(cohort.criteria).then(filters => {
             commit('resetSession', {
               cohort,
               filters: filters,
@@ -222,8 +222,7 @@ const actions = {
       saveCohort(
         state.cohortId,
         state.cohortName,
-        state.filters,
-        state.totalStudentCount
+        state.filters
       ).then(resolve);
     });
   },
@@ -267,8 +266,7 @@ const actions = {
       saveCohort(
         state.cohortId,
         state.cohortName,
-        state.filters,
-        state.totalStudentCount
+        state.filters
       ).then(() => {
         commit('setModifiedSinceLastSearch', null);
         resolve();

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -73,7 +73,7 @@ class TestCacheUtils:
         cohorts = CohortFilter.all_owned_by(uid)
         assert len(cohorts)
         for cohort in cohorts:
-            assert cohort.alert_count is None
+            assert cohort['alertCount'] is None
         load_filtered_cohort_counts()
         for cohort in CohortFilter.all_owned_by('2040'):
-            assert cohort.alert_count >= 0
+            assert cohort['alertCount'] >= 0

--- a/tests/test_api/test_menu_controller.py
+++ b/tests/test_api/test_menu_controller.py
@@ -208,15 +208,15 @@ class TestCohortFilterTranslate:
         )
 
     def test_translate_criteria_when_empty(self, client, coe_advisor_session):
-        """Empty filterCriteria translates to zero rows."""
-        response = self._post(client, {'filterCriteria': {}})
+        """Empty criteria translates to zero rows."""
+        response = self._post(client, {'criteria': {}})
         assert response.status_code == 200
         assert json.loads(response.data) == []
 
     def test_translate_criteria_with_boolean(self, client, coe_advisor_session):
         """Filter-criteria with boolean is properly translated."""
         key = 'isInactiveCoe'
-        response = self._post(client, {'filterCriteria': {key: False}})
+        response = self._post(client, {'criteria': {key: False}})
         assert response.status_code == 200
         rows = json.loads(response.data)
         assert len(rows) == 1
@@ -229,7 +229,7 @@ class TestCohortFilterTranslate:
         """Filter-criteria with array is properly translated."""
         key = 'levels'
         selected_options = ['Freshman', 'Sophomore']
-        response = self._post(client, {'filterCriteria': {key: selected_options}})
+        response = self._post(client, {'criteria': {key: selected_options}})
         assert response.status_code == 200
         rows = json.loads(response.data)
         assert len(rows) == 2
@@ -242,7 +242,7 @@ class TestCohortFilterTranslate:
         """Filter-criteria with range is properly translated."""
         key = 'lastNameRange'
         selected_options = ['M', 'Z']
-        response = self._post(client, {'filterCriteria': {key: selected_options}})
+        response = self._post(client, {'criteria': {key: selected_options}})
         assert response.status_code == 200
         rows = json.loads(response.data)
         assert len(rows) == 1

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -27,7 +27,6 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from boac.lib import berkeley
 from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME, BERKELEY_DEPT_NAME_TO_CODE
 from boac.models.authorized_user import AuthorizedUser
-from boac.models.cohort_filter import CohortFilter
 import pytest
 
 
@@ -106,13 +105,6 @@ class TestBerkeleyAuthorization:
     def test_asc_dept_codes(self, asc_advisor, coe_advisor):
         assert berkeley.get_dept_codes(asc_advisor) == ['UWASC']
         assert berkeley.get_dept_codes(coe_advisor) == ['COENG']
-
-    def test_can_view_cohort(self, admin_user, asc_advisor, coe_advisor):
-        coe_cohorts = CohortFilter.all_owned_by('1133399')
-        assert len(coe_cohorts)
-        assert berkeley.can_view_cohort(admin_user, coe_cohorts[0])
-        assert not berkeley.can_view_cohort(asc_advisor, coe_cohorts[0])
-        assert berkeley.can_view_cohort(coe_advisor, coe_cohorts[0])
 
 
 class TestAlertRules:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2271

For batch note creation, we must quickly convert a list of cohort ids to proper list o’ SIDs. This new column provides that fast access and is maintained same way of ‘student_count’.  We use SQLAlchemy's `deferred(db.Column)` so `sids` array is only loaded if `undefer(...)` is used.

Other noteworthy changes:
* `to_api_json()` is invoked under-the-hood (i.e., the model's CRUD methods) because it enforces vital biz logic (e.g., update student_count and sids when `update()` is invoked.) IMO, this change makes code more readable.
* The front-end no longer posts 'studentCount'. The value only changes when `/update` and the back-end has it covered.
