### PR TITLE
BOAC-2271, notes_controller support for batch note creation

### DIFF
--- a/boac/models/note_attachment.py
+++ b/boac/models/note_attachment.py
@@ -51,6 +51,14 @@ class NoteAttachment(db.Model):
 
     @classmethod
     def create_attachment(cls, note, name, byte_stream, uploaded_by):
+        return NoteAttachment(
+            note_id=note.id,
+            path_to_attachment=cls.put_attachment_to_s3(name=name, byte_stream=byte_stream),
+            uploaded_by_uid=uploaded_by,
+        )
+
+    @classmethod
+    def put_attachment_to_s3(cls, name, byte_stream):
         bucket = app.config['DATA_LOCH_S3_ADVISING_NOTE_BUCKET']
         base_path = app.config['DATA_LOCH_S3_BOA_NOTE_ATTACHMENTS_PATH']
         key_suffix = _localize_datetime(datetime.now()).strftime(f'%Y/%m/%d/%Y%m%d_%H%M%S_{name}')
@@ -60,11 +68,7 @@ class NoteAttachment(db.Model):
             key=key,
             binary_data=byte_stream,
         )
-        return NoteAttachment(
-            note_id=note.id,
-            path_to_attachment=key,
-            uploaded_by_uid=uploaded_by,
-        )
+        return key
 
     @classmethod
     def find_by_id(cls, attachment_id):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2271

Using postgres native `json_populate_recordset` for bulk inserts seems to be faster than what's listed in https://docs.sqlalchemy.org/en/13/_modules/examples/performance/bulk_inserts.html   The use of `INSERT ... returning id` allows `db.session.execute(...)` to treat the query as SELECT, getting a list of note `ids` in result-set.

Notice the log message "...records inserted in ... seconds" – I will further profile batch creation once in `boa-dev`.