### PR TITLE
BOAC-2238: Makes ASC notes searchable

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -433,24 +433,38 @@ def search_advising_notes(
     if datetime_to:
         date_filter += ' AND an.created_at < :datetime_to'
 
-    sql = f"""SELECT
-        an.sid, an.id, an.note_body, an.advisor_sid, an.created_by, an.created_at, an.updated_at,
-        sas.uid, sas.first_name, sas.last_name
+    sql = f"""WITH an AS (
+        (SELECT sis.sid, sis.id, sis.note_body, sis.advisor_sid, NULL AS advisor_uid, NULL AS advisor_first_name, NULL AS advisor_last_name,
+                sis.created_by, sis.created_at, sis.updated_at, idx.rank
+            FROM {advising_notes_schema()}.advising_notes sis
+            JOIN (
+                SELECT id, ts_rank(fts_index, plainto_tsquery('english', :search_phrase)) AS rank
+                FROM {advising_notes_schema()}.advising_notes_search_index
+                WHERE fts_index @@ plainto_tsquery('english', :search_phrase)
+            ) AS idx
+            ON idx.id = sis.id)
+        UNION
+        (SELECT ascn.sid, ascn.id, NULL AS note_body, NULL AS advisor_sid, ascn.advisor_uid, ascn.advisor_first_name, ascn.advisor_last_name,
+                NULL AS created_by, ascn.created_at, ascn.updated_at, idx.rank
+            FROM {asc_schema()}.advising_notes ascn
+            JOIN (
+                SELECT id, ts_rank(fts_index, plainto_tsquery('english', :search_phrase)) AS rank
+                FROM {asc_schema()}.advising_notes_search_index
+                WHERE fts_index @@ plainto_tsquery('english', :search_phrase)
+            ) AS idx
+            ON idx.id = ascn.id)
+        )
+        SELECT DISTINCT
+        an.sid, an.id, an.note_body, an.advisor_sid, an.advisor_uid, an.created_by, an.created_at, an.updated_at,
+        sas.uid, sas.first_name, sas.last_name, an.advisor_first_name, an.advisor_last_name, an.rank
         {student_query_tables}
-        JOIN {advising_notes_schema()}.advising_notes an
+        JOIN an
             ON an.sid = sas.sid
             {author_filter}
             {date_filter}
         {topic_join}
-        JOIN (
-          SELECT id, ts_rank(fts_index, plainto_tsquery('english', :search_phrase)) AS rank
-          FROM {advising_notes_schema()}.advising_notes_search_index
-          WHERE fts_index @@ plainto_tsquery('english', :search_phrase)
-        )
-        AS idx
-            ON idx.id = an.id
         {student_query_filter}
-        ORDER BY idx.rank DESC, an.id"""
+        ORDER BY an.rank DESC, an.id"""
     if offset is not None and offset > 0:
         sql += ' OFFSET :offset'
     if limit is not None and limit < 150:  # Sanity check large limits

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -214,18 +214,22 @@ def _get_local_notes_search_results(local_results, student_rows_by_sid, search_t
 
 def _get_loch_notes_search_results(loch_results, search_terms):
     results = []
-    calnet_advisor_feeds = get_calnet_users_for_csids(app, list(set([row.get('advisor_sid') for row in loch_results])))
+    calnet_advisor_feeds = get_calnet_users_for_csids(
+        app,
+        list(set([row.get('advisor_sid') for row in loch_results if row.get('advisor_sid') is not None])),
+    )
     for row in loch_results:
         note = {camelize(key): row[key] for key in row.keys()}
         advisor_feed = calnet_advisor_feeds.get(note.get('advisorSid'))
+        advisor_name = join_if_present(' ', [advisor_feed.get('firstName'), advisor_feed.get('lastName')]) if advisor_feed else None
         results.append({
             'id': note.get('id'),
             'studentSid': note.get('sid'),
             'studentUid': note.get('uid'),
             'studentName': join_if_present(' ', [note.get('firstName'), note.get('lastName')]),
             'advisorSid': note.get('advisorSid'),
-            'advisorName': join_if_present(' ', [advisor_feed.get('firstName'), advisor_feed.get('lastName')]) if advisor_feed else None,
-            'noteSnippet': _notes_text_snippet(note.get('noteBody'), search_terms),
+            'advisorName': advisor_name or join_if_present(' ', [note.get('advisorFirstName'), note.get('advisorLastName')]),
+            'noteSnippet': _notes_text_snippet(note.get('noteBody') or '', search_terms),
             'createdAt': _resolve_created_at(note),
             'updatedAt': _resolve_updated_at(note),
         })

--- a/fixtures/loch.sql
+++ b/fixtures/loch.sql
@@ -228,16 +228,34 @@ CREATE TABLE student.student_term_gpas
 INSERT INTO asc_advising_notes.advising_notes
 (id, asc_id, sid, student_first_name, student_last_name, meeting_date, advisor_uid, advisor_first_name, advisor_last_name, created_at, updated_at)
 VALUES
-('11667051-139362', '139362', '11667051', 'Deborah',  'Davies', '2014-01-03', '1133399', 'Lemmy', 'Kilmister', '2014-01-03 20:30:00+00', '2014-01-03 20:30:00+00'),
-('11667051-139379', '139379', '11667051', 'Deborah',  'Davies', '2014-01-16', '90412', 'Ginger', 'Baker', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00'),
-('9000000000-139379', '139379', '9000000000', 'Wolfgang',  'Pauli-O''Rourke', '2014-01-16', '90412', 'Ginger', 'Baker', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00'),
-('9100000000-139379', '139379', '9100000000', 'Nora Stanton',  'Barney', '2014-01-16', '90412', 'Ginger', 'Baker', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00');
+('11667051-139362', '139362', '11667051', 'Deborah', 'Davies', '2014-01-03', '1133399', 'Lemmy', 'Kilmister', '2014-01-03 20:30:00+00', '2014-01-03 20:30:00+00'),
+('11667051-139379', '139379', '11667051', 'Deborah', 'Davies', '2014-01-16', '90412', 'Ginger', 'Baker', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00'),
+('8901234567-139379', '139379', '8901234567', 'John David', 'Crossman', '2014-01-16', '90412', 'Ginger', 'Baker', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00'),
+('2345678901-139379', '139379', '2345678901', 'Dave', 'Doolittle', '2014-01-16', '90412', 'Ginger', 'Baker', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00');
 
 INSERT INTO asc_advising_notes.advising_note_topics
 (id, asc_id, sid, topic)
 VALUES
 ('11667051-139362', '139362', '11667051', 'Academic'),
 ('11667051-139362', '139362', '11667051', 'Other');
+
+CREATE TABLE boac_advising_asc.advising_notes AS (
+    SELECT id, asc_id, sid, student_first_name, student_last_name, meeting_date,
+        advisor_uid, advisor_first_name, advisor_last_name, created_at, updated_at
+    FROM asc_advising_notes.advising_notes
+);
+
+CREATE TABLE boac_advising_asc.advising_note_topics AS (
+    SELECT id, asc_id, sid, topic
+    FROM asc_advising_notes.advising_note_topics
+);
+
+CREATE MATERIALIZED VIEW boac_advising_asc.advising_notes_search_index AS (
+  SELECT n.id, to_tsvector('english', COALESCE(topic || ' ', '') || advisor_first_name || ' ' || advisor_last_name) AS fts_index
+  FROM asc_advising_notes.advising_notes n
+  LEFT OUTER JOIN asc_advising_notes.advising_note_topics t
+  ON n.id = t.id
+);
 
 INSERT INTO boac_advising_asc.students
 (sid, intensive, active, status_asc, group_code, group_name, team_code, team_name)

--- a/tests/test_api/test_search_controller.py
+++ b/tests/test_api/test_search_controller.py
@@ -325,6 +325,32 @@ class TestNoteSearch:
         assert notes[0].get('id') == '11667051-00001'
         assert notes[1].get('id') == '11667051-00002'
 
+    def test_search_notes_by_asc_advisor_name(self, asc_advisor, client):
+        """Includes ASC notes with advisor name match in search results."""
+        response = client.post(
+            '/api/search',
+            data=json.dumps({'notes': True, 'searchPhrase': 'ginger'}),
+            content_type='application/json',
+        )
+        assert 'notes' in response.json
+        notes = response.json['notes']
+        assert len(notes) == 3
+        assert notes[0].get('id') == '11667051-139379'
+        assert notes[1].get('id') == '2345678901-139379'
+        assert notes[2].get('id') == '8901234567-139379'
+
+    def test_search_notes_by_asc_topic(self, asc_advisor, client):
+        """Includes ASC notes with advisor name match in search results."""
+        response = client.post(
+            '/api/search',
+            data=json.dumps({'notes': True, 'searchPhrase': 'academic'}),
+            content_type='application/json',
+        )
+        assert 'notes' in response.json
+        notes = response.json['notes']
+        assert len(notes) == 1
+        assert notes[0].get('id') == '11667051-139362'
+
     def test_search_by_note_topic(self, coe_advisor, client):
         """Searches notes by topic if topics option is selected."""
         response = client.post(

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -157,6 +157,21 @@ class TestMergedAdvisingNote:
         assert parse(notes[0]['createdAt']) == parse('2017-11-05T12:00:00+00')
         assert parse(notes[0]['updatedAt']) == parse('2017-11-06T12:00:00+00')
 
+    def test_search_for_asc_advising_notes(self, app, fake_auth):
+        fake_auth.login(asc_advisor)
+        response = search_advising_notes(search_phrase='kilmister')
+        assert len(response) == 1
+        assert response[0]['noteSnippet'] == ''
+        assert response[0]['advisorName'] == 'Lemmy Kilmister'
+        assert parse(response[0]['createdAt']) == parse('2014-01-03T20:30:00+00')
+        assert parse(response[0]['updatedAt']) == parse('2014-01-03T20:30:00+00')
+        response = search_advising_notes(search_phrase='academic')
+        assert len(response) == 1
+        assert response[0]['noteSnippet'] == ''
+        assert response[0]['advisorName'] == 'Lemmy Kilmister'
+        assert parse(response[0]['createdAt']) == parse('2014-01-03T20:30:00+00')
+        assert parse(response[0]['updatedAt']) == parse('2014-01-03T20:30:00+00')
+
     def test_search_advising_notes_stemming(self, app, fake_auth):
         fake_auth.login(coe_advisor)
         response = search_advising_notes(search_phrase='spare')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2238

First attempt at squeezing ASC notes into the note search results paradigm. Since they don't have a note body, they won't have a note snippet to display - just the advisor name and date.