### PR TITLE
BOAC-2365, remove expensive CohortFilter.all_owned_by call when verifying user perm to edit/view cohort

### DIFF
--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import get_my_cohorts, is_unauthorized_search
+from boac.api.util import get_cohort_owned_by, is_unauthorized_search
 from boac.lib.berkeley import get_dept_codes
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param, to_bool_or_none as to_bool
@@ -39,7 +39,11 @@ import numpy as np
 @app.route('/api/cohorts/my')
 @login_required
 def my_cohorts():
-    return tolerant_jsonify(get_my_cohorts())
+    cohorts = []
+    for cohort in CohortFilter.summarize_alert_counts_in_all_owned_by(current_user.id):
+        cohort['isOwnedByCurrentUser'] = True
+        cohorts.append(cohort)
+    return tolerant_jsonify(cohorts)
 
 
 @app.route('/api/cohorts/all')
@@ -204,8 +208,7 @@ def update_cohort():
     filter_criteria = _filters_to_filter_criteria(params.get('filters')) if 'filters' in params else params.get('criteria')
     if not name and not filter_criteria:
         raise BadRequestError('Invalid request')
-    uid = current_user.get_id()
-    cohort = next((c for c in CohortFilter.all_owned_by(uid) if c['id'] == cohort_id), None)
+    cohort = get_cohort_owned_by(current_user.id, cohort_id)
     if not cohort:
         raise ForbiddenRequestError(f'Invalid or unauthorized request')
     name = name or cohort['name']
@@ -226,13 +229,12 @@ def update_cohort():
 def delete_cohort(cohort_id):
     if cohort_id.isdigit():
         cohort_id = int(cohort_id)
-        uid = current_user.get_id()
-        cohort = next((c for c in CohortFilter.all_owned_by(uid) if c['id'] == cohort_id), None)
+        cohort = get_cohort_owned_by(current_user.id, cohort_id)
         if cohort:
             CohortFilter.delete(cohort_id)
             return tolerant_jsonify({'message': f'Cohort deleted (id={cohort_id})'}), 200
         else:
-            raise BadRequestError(f'User {uid} does not own cohort with id={cohort_id}')
+            raise BadRequestError(f'User {current_user.get_id()} does not own cohort with id={cohort_id}')
     else:
         raise ForbiddenRequestError(f'Programmatic deletion of canned cohorts is not allowed (id={cohort_id})')
 

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -258,13 +258,11 @@ def get_my_curated_groups():
     return curated_groups
 
 
-def get_my_cohorts():
-    uid = current_user.get_id()
-    cohorts = []
-    for cohort in CohortFilter.summarize_alert_counts_in_all_owned_by(uid):
+def get_cohort_owned_by(user_id, cohort_id):
+    cohort = CohortFilter.get_cohort_owned_by(user_id, cohort_id)
+    if cohort:
         cohort['isOwnedByCurrentUser'] = True
-        cohorts.append(cohort)
-    return cohorts
+    return cohort
 
 
 def is_asc_authorized():

--- a/tests/test_api/api_test_utils.py
+++ b/tests/test_api/api_test_utils.py
@@ -1,0 +1,39 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.models.cohort_filter import CohortFilter
+
+
+def all_cohorts_owned_by(uid):
+    def transform(c):
+        return {
+            'id': c.id,
+            'name': c.name,
+            'criteria': c.filter_criteria,
+            'alertCount': c.alert_count,
+            'totalStudentCount': c.student_count,
+        }
+    cohorts = CohortFilter.query.filter(CohortFilter.owners.any(uid=uid)).order_by(CohortFilter.name).all()
+    return [transform(cohort) for cohort in cohorts]

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -26,9 +26,9 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from boac import std_commit
 from boac.models.alert import Alert
 from boac.models.authorized_user import AuthorizedUser
-from boac.models.cohort_filter import CohortFilter
 from boac.models.curated_group import CuratedGroup, CuratedGroupStudent
 import pytest
+from tests.test_api.api_test_utils import all_cohorts_owned_by
 
 
 @pytest.mark.usefixtures('db_session')
@@ -70,10 +70,10 @@ class TestCacheUtils:
     def test_load_filtered_cohort_counts(self, app):
         from boac.api.cache_utils import load_filtered_cohort_counts
         uid = '2040'
-        cohorts = CohortFilter.all_owned_by(uid)
+        cohorts = all_cohorts_owned_by(uid)
         assert len(cohorts)
         for cohort in cohorts:
             assert cohort['alertCount'] is None
         load_filtered_cohort_counts()
-        for cohort in CohortFilter.all_owned_by('2040'):
+        for cohort in all_cohorts_owned_by('2040'):
             assert cohort['alertCount'] >= 0

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -26,6 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from boac.models.cohort_filter import CohortFilter
 import pytest
 import simplejson as json
+from tests.test_api.api_test_utils import all_cohorts_owned_by
 
 admin_uid = '2040'
 asc_advisor_uid = '1081940'
@@ -49,14 +50,13 @@ def coe_advisor_session(fake_auth):
 
 @pytest.fixture()
 def asc_owned_cohort():
-    cohorts = CohortFilter.all_owned_by(asc_advisor_uid)
+    cohorts = all_cohorts_owned_by(asc_advisor_uid)
     return next((c for c in cohorts if c['name'] == 'All sports'), None)
 
 
 @pytest.fixture()
 def coe_owned_cohort():
-    cohorts = CohortFilter.all_owned_by(coe_advisor_uid)
-    assert len(cohorts)
+    cohorts = all_cohorts_owned_by(coe_advisor_uid)
     return next((c for c in cohorts if c['name'] == 'Radioactive Women and Men'), None)
 
 
@@ -83,7 +83,7 @@ class TestCohortDetail:
         client.get('/api/student/98765')
         from boac.models.alert import Alert
         Alert.update_all_for_term(2178)
-        cohorts = CohortFilter.all_owned_by(asc_advisor_uid)
+        cohorts = all_cohorts_owned_by(asc_advisor_uid)
         assert len(cohorts)
         cohort_id = cohorts[0]['id']
         students_with_alerts = client.get(f'/api/cohort/{cohort_id}/students_with_alerts').json
@@ -164,7 +164,7 @@ class TestCohortDetail:
 
     def test_undeclared_major(self, asc_advisor_session, client):
         """Returns a well-formed response with custom cohort."""
-        cohort = CohortFilter.all_owned_by(asc_advisor_uid)[-1]
+        cohort = all_cohorts_owned_by(asc_advisor_uid)[-1]
         cohort_id = cohort['id']
         response = client.get(f'/api/cohort/{cohort_id}')
         assert response.status_code == 200
@@ -590,7 +590,7 @@ class TestCohortDelete:
         cohort_id = cohort['id']
         response = client.delete(f'/api/cohort/delete/{cohort_id}')
         assert response.status_code == 200
-        cohorts = CohortFilter.all_owned_by(asc_advisor_uid)
+        cohorts = all_cohorts_owned_by(asc_advisor_uid)
         assert not next((c for c in cohorts if c['id'] == cohort_id), None)
 
 

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -31,6 +31,7 @@ from boac.models.curated_group import CuratedGroup
 from boac.models.note import Note
 from boac.models.note_attachment import NoteAttachment
 import pytest
+from tests.test_api.api_test_utils import all_cohorts_owned_by
 from tests.util import mock_advising_note_s3_bucket, mock_legacy_note_attachment, override_config
 
 asc_advisor_uid = '6446'
@@ -660,11 +661,8 @@ def _get_curated_groups_ids_and_sids(advisor):
 
 
 def _get_cohorts_ids_and_sids(advisor):
-    cohorts = CohortFilter.all_owned_by(advisor.uid)
-    cohort_ids = []
+    cohort_ids = [c['id'] for c in all_cohorts_owned_by(advisor.uid)]
     sids = []
-    for cohort in cohorts:
-        cohort_ids.append(cohort['id'])
-        for s in cohort['students']:
-            sids.append(s['sid'])
+    for cohort_id in cohort_ids:
+        sids = sids + CohortFilter.get_sids(cohort_id)
     return cohort_ids, sids

--- a/tests/test_models/test_cohort_filter.py
+++ b/tests/test_models/test_cohort_filter.py
@@ -27,6 +27,7 @@ from boac.api.errors import InternalServerError
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
 import pytest
+from tests.test_api.api_test_utils import all_cohorts_owned_by
 
 asc_advisor_uid = '2040'
 coe_advisor_uid = '1133399'
@@ -35,10 +36,6 @@ coe_advisor_uid = '1133399'
 @pytest.mark.usefixtures('db_session')
 class TestCohortFilter:
     """Cohort filter."""
-
-    def test_no_cohort(self):
-        assert not CohortFilter.find_by_id(99999999)
-        assert not CohortFilter.all_owned_by('88888888')
 
     def test_filter_criteria(self):
         gpa_ranges = [
@@ -128,4 +125,4 @@ class TestCohortFilter:
 
 
 def cohort_count(user_uid):
-    return len(CohortFilter.all_owned_by(user_uid))
+    return len(all_cohorts_owned_by(user_uid))


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2365

To verify that `current_user` has access to cohort we do not need the expensive:
 `cls.query.filter(cls.owners.any(uid=uid)).order_by(cls.name).all()`