### PR TITLE
BOAC-2377, cache user_session json by user_id; flush on login, demoMode toggle

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -36,8 +36,7 @@ from flask_login import current_user, login_required
 
 @app.route('/api/profile/my')
 def my_profile():
-    api_json = current_user.to_api_json()
-    return tolerant_jsonify(api_json)
+    return tolerant_jsonify(current_user.to_api_json())
 
 
 @app.route('/api/profile/<uid>')
@@ -96,6 +95,7 @@ def set_demo_mode():
             raise errors.BadRequestError('Parameter \'demoMode\' not found')
         user = AuthorizedUser.find_by_id(current_user.get_id())
         user.in_demo_mode = bool(in_demo_mode)
+        current_user.flush_cached()
         app.login_manager.reload_user()
         return tolerant_jsonify(current_user.to_api_json())
     else:

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -27,7 +27,6 @@ from functools import wraps
 import json
 
 from boac.externals.data_loch import get_sis_holds
-from boac.lib.berkeley import get_dept_codes
 from boac.merged import calnet
 from boac.merged.advising_note import get_advising_notes
 from boac.models.alert import Alert
@@ -210,22 +209,14 @@ def get_my_curated_groups():
     return curated_groups
 
 
-def is_asc_authorized():
-    return current_user.is_admin or 'UWASC' in get_dept_codes(current_user)
-
-
-def is_coe_authorized():
-    return current_user.is_admin or 'COENG' in get_dept_codes(current_user)
-
-
 def is_unauthorized_search(filter_keys, order_by):
     filter_key_set = set(filter_keys)
     asc_keys = {'inIntensiveCohort', 'isInactiveAsc', 'groupCodes'}
     if list(filter_key_set & asc_keys) or order_by in ['group_name']:
-        if not is_asc_authorized():
+        if not current_user.is_asc_authorized:
             return True
     coe_keys = {'advisorLdapUids', 'coePrepStatuses', 'coeProbation', 'ethnicities', 'genders', 'isInactiveCoe'}
     if list(filter_key_set & coe_keys):
-        if not is_coe_authorized():
+        if not current_user.is_coe_authorized:
             return True
     return False

--- a/boac/lib/cohort_filter_definition.py
+++ b/boac/lib/cohort_filter_definition.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 
 from boac.api.util import authorized_users_api_feed
 from boac.externals import data_loch
-from boac.lib.berkeley import BERKELEY_DEPT_NAME_TO_CODE, COE_ETHNICITIES_PER_CODE, get_dept_codes, term_name_for_sis_id
+from boac.lib.berkeley import BERKELEY_DEPT_NAME_TO_CODE, COE_ETHNICITIES_PER_CODE, term_name_for_sis_id
 from boac.merged import athletics
 from boac.merged.student import get_student_query_scope
 from boac.models.authorized_user import AuthorizedUser
@@ -301,7 +301,7 @@ def _selections_of_type(filter_type, existing_filters):
 
 
 def _get_coe_profiles():
-    users = list(filter(lambda user: 'COENG' in get_dept_codes(user), AuthorizedUser.query.all()))
+    users = list(filter(lambda _user: 'COENG' in _get_dept_codes(_user), AuthorizedUser.query.all()))
     profiles = []
     for user in authorized_users_api_feed(users):
         uid = user['uid']
@@ -380,3 +380,7 @@ def _team_groups():
 def _majors():
     relevant_majors = [row['major'] for row in data_loch.get_majors(get_student_query_scope())]
     return [{'name': major, 'value': major} for major in relevant_majors]
+
+
+def _get_dept_codes(user):
+    return [m.university_dept.dept_code for m in user.department_memberships] if user else None

--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -441,6 +441,8 @@ def get_student_query_scope(user=None):
         return []
     elif user.is_admin:
         return ['ADMIN']
+    elif hasattr(user, 'dept_codes'):
+        return user.dept_codes
     else:
         return [m.university_dept.dept_code for m in user.department_memberships]
 

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -23,10 +23,10 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from boac import db
 from boac.models.base import Base
 from boac.models.db_relationships import cohort_filter_owners
+from sqlalchemy import text
 
 
 class AuthorizedUser(Base):
@@ -65,6 +65,12 @@ class AuthorizedUser(Base):
                     updated={self.updated_at},
                     created={self.created_at}>
                 """
+
+    @classmethod
+    def get_id_per_uid(cls, uid):
+        query = text(f'SELECT id FROM authorized_users WHERE uid = :uid')
+        result = db.session.execute(query, {'uid': uid}).first()
+        return result and result['id']
 
     @classmethod
     def find_by_id(cls, db_id):

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -24,22 +24,19 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.merged.user_session import UserSession
-from boac.models.authorized_user import AuthorizedUser
 from flask import jsonify, make_response, redirect, request
 from flask_login import LoginManager
 
 
 def register_routes(app):
     """Register app routes."""
-    def _user_loader(obj):
-        # User can be loaded by (1) id primary-key, an integer, of AuthorizedUser table or (2) UID
-        user = AuthorizedUser.find_by_id(obj) if isinstance(obj, int) else AuthorizedUser.find_by_uid(obj)
-        return UserSession(user)
+    def _user_loader(user_id=None, flush_cached=False):
+        return UserSession(user_id, flush_cached)
 
     login_manager = LoginManager()
     login_manager.init_app(app)
     login_manager.user_loader(_user_loader)
-    login_manager.anonymous_user = UserSession
+    login_manager.anonymous_user = _user_loader
 
     # Register API routes.
     import boac.api.admin_controller

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -205,7 +205,6 @@ class TestCohortDetail:
         response = client.get(f'/api/cohort/{cohort_id}?orderBy=firstName')
         assert response.status_code == 200
         athlete = next(m for m in response.json['students'] if m['firstName'] == 'Deborah')
-
         term = athlete['term']
         assert term['termName'] == 'Fall 2017'
         assert term['enrolledUnits'] == 12.5
@@ -216,6 +215,7 @@ class TestCohortDetail:
     def test_includes_cohort_member_term_gpa(self, asc_advisor_session, asc_owned_cohort, client):
         cohort_id = asc_owned_cohort['id']
         response = client.get(f'/api/cohort/{cohort_id}?orderBy=firstName')
+        assert response.status_code == 200
         deborah = next(m for m in response.json['students'] if m['firstName'] == 'Deborah')
         assert len(deborah['termGpa']) == 4
         assert deborah['termGpa'][0] == {'termName': 'Spring 2018', 'gpa': 2.9}
@@ -225,6 +225,7 @@ class TestCohortDetail:
         """Includes athletic data custom cohort members for ASC advisors."""
         cohort_id = asc_owned_cohort['id']
         response = client.get(f'/api/cohort/{cohort_id}')
+        assert response.status_code == 200
         athlete = next(m for m in response.json['students'] if m['firstName'] == 'Deborah')
         assert len(athlete['athleticsProfile']['athletics']) == 2
         assert athlete['athleticsProfile']['inIntensiveCohort'] is not None
@@ -243,6 +244,7 @@ class TestCohortDetail:
         """Omits athletic data for non-ASC advisors."""
         cohort_id = coe_owned_cohort['id']
         response = client.get(f'/api/cohort/{cohort_id}')
+        assert response.status_code == 200
         secretly_an_athlete = next(m for m in response.json['students'] if m['firstName'] == 'Deborah')
         assert 'athletics' not in secretly_an_athlete
         assert 'inIntensiveCohort' not in secretly_an_athlete
@@ -253,6 +255,7 @@ class TestCohortDetail:
         """Includes athletic data for admins."""
         cohort_id = coe_owned_cohort['id']
         response = client.get(f'/api/cohort/{cohort_id}')
+        assert response.status_code == 200
         athlete = next(m for m in response.json['students'] if m['firstName'] == 'Deborah')
         assert len(athlete['athleticsProfile']['athletics']) == 2
         assert athlete['athleticsProfile']['inIntensiveCohort'] is not None
@@ -271,6 +274,7 @@ class TestCohortDetail:
         api_path = f'/api/cohort/{cohort_id}'
         # First, offset is zero
         response = client.get(f'{api_path}?offset={0}&limit={1}')
+        assert response.status_code == 200
         data_0 = json.loads(response.data)
         assert data_0['totalStudentCount'] == 4
         assert len(data_0['students']) == 1


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2377

In flask-login we `login_user(..., remember=True)` so this cached user-session-json will persist across browser restarts. This cuts `/api/my/profile`time in half which is one of the main offenders in blocking the "painting" if initial page load. (Cache is refreshed when user logs in again or toggles demo-mode.)