### PR TITLE
BOAC-2409, obsolete cohort filter values (eg, 'Sociology BA') should not bust front-end

### DIFF
--- a/boac/lib/cohort_filter_definition.py
+++ b/boac/lib/cohort_filter_definition.py
@@ -296,7 +296,9 @@ def _selections_of_type(filter_type, existing_filters):
         key = row['key']
         if not selections[key]:
             selections[key] = []
-        selections[key].append(row['value'])
+        value = row.get('value')
+        if value:
+            selections[key].append(value)
     return selections
 
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2409

Cohort created by COE advisor, in March, had 'Sociology BA' major selected. 'Sociology BA' is no longer in COE scope. This does not break queries but it does disrupt front-end when rendering menu options. I'm working around the problem by tolerating nulls in menu render.

This bug is unlikely to recur after we desilo-ize but if it does, we can consider a more sophisticated fix. 