### PR TITLE
BOAC-2279, refresh student in /student if note created per sid

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -27,7 +27,7 @@ import urllib.parse
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
 from boac.lib.http import tolerant_jsonify
-from boac.lib.util import is_int, process_input_from_rich_text_editor
+from boac.lib.util import is_int, process_input_from_rich_text_editor, to_bool_or_none
 from boac.merged.advising_note import get_boa_attachment_stream, get_legacy_attachment_stream, note_to_compatible_json
 from boac.models.cohort_filter import CohortFilter
 from boac.models.curated_group import CuratedGroup
@@ -52,7 +52,7 @@ def mark_read(note_id):
 def create_note():
     params = request.form
     sids = _get_sids_for_note_creation()
-    is_batch_create = len(sids) > 1
+    is_batch_create = to_bool_or_none(params.get('isBatchMode'))
     subject = params.get('subject', None)
     body = params.get('body', None)
     topics = _get_topics(params)
@@ -78,7 +78,7 @@ def create_note():
                 sids=sids,
                 attachments=attachments,
             )
-            return tolerant_jsonify({'message': f'Note created for {len(sids)} students'}), 200
+            return tolerant_jsonify({'sids': sids})
         else:
             raise ResourceNotFoundError('API path not found')
     else:

--- a/boac/api/student_controller.py
+++ b/boac/api/student_controller.py
@@ -29,16 +29,26 @@ from boac.externals.cal1card_photo_api import get_cal1card_photo
 from boac.externals.data_loch import extract_valid_sids
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
-from boac.merged.student import get_student_and_terms, query_students
+from boac.merged.student import get_student_and_terms_by_sid, get_student_and_terms_by_uid, query_students
 from boac.models.alert import Alert
 from flask import current_app as app, request, Response
 from flask_login import current_user, login_required
 
 
-@app.route('/api/student/<uid>')
+@app.route('/api/student/by_sid/<sid>')
 @login_required
-def get_student(uid):
-    student = get_student_and_terms(uid)
+def get_student_by_sid(sid):
+    student = get_student_and_terms_by_sid(sid)
+    if not student:
+        raise ResourceNotFoundError('Unknown student')
+    put_notifications(student)
+    return tolerant_jsonify(student)
+
+
+@app.route('/api/student/by_uid/<uid>')
+@login_required
+def get_student_by_uid(uid):
+    student = get_student_and_terms_by_uid(uid)
     if not student:
         raise ResourceNotFoundError('Unknown student')
     put_notifications(student)

--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -286,7 +286,18 @@ def get_coe_profiles(sids):
     return safe_execute_rds(sql, sids=sids)
 
 
-def get_student_for_uid_and_scope(uid, scope):
+def get_student_by_sid(sid, scope):
+    query_tables = _student_query_tables_for_scope(scope)
+    if not query_tables:
+        return None
+    sql = f"""SELECT sas.*
+        {query_tables}
+        WHERE sas.sid = :sid"""
+    rows = safe_execute_rds(sql, sid=sid)
+    return None if not rows or (len(rows) == 0) else rows[0]
+
+
+def get_student_by_uid(uid, scope):
     query_tables = _student_query_tables_for_scope(scope)
     if not query_tables:
         return None

--- a/src/api/student.ts
+++ b/src/api/student.ts
@@ -1,22 +1,27 @@
 import axios from 'axios';
 import store from '@/store';
 
+const apiBaseUrl = store.getters['context/apiBaseUrl'];
+
 export function dismissStudentAlert(alertId: string) {
-  let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
     .get(`${apiBaseUrl}/api/alerts/${alertId}/dismiss`)
     .then(response => response.data, () => null);
 }
 
-export function getStudent(uid: string) {
-  let apiBaseUrl = store.getters['context/apiBaseUrl'];
+export function getStudentByUid(uid: string) {
   return axios
-    .get(`${apiBaseUrl}/api/student/${uid}`)
+    .get(`${apiBaseUrl}/api/student/by_uid/${uid}`)
+    .then(response => response.data, () => null);
+}
+
+export function getStudentBySid(sid: string) {
+  return axios
+    .get(`${apiBaseUrl}/api/student/by_sid/${sid}`)
     .then(response => response.data, () => null);
 }
 
 export function validateSids(sids: string[]) {
-  let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios
     .post(`${apiBaseUrl}/api/students/validate_sids`, { sids: sids })
     .then(response => response.data, () => null);

--- a/src/components/note/AdvisingNoteTopics.vue
+++ b/src/components/note/AdvisingNoteTopics.vue
@@ -66,12 +66,12 @@
 
 <script>
 import Context from '@/mixins/Context';
-import NoteEditSession from "@/mixins/NoteEditSession";
+import StudentEditSession from "@/mixins/StudentEditSession";
 import Util from '@/mixins/Util';
 
 export default {
   name: 'AdvisingNoteTopics',
-  mixins: [Context, NoteEditSession, Util],
+  mixins: [Context, StudentEditSession, Util],
   props: {
     functionAdd: {
       type: Function,

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -89,7 +89,7 @@ import AdvisingNoteTopics from '@/components/note/AdvisingNoteTopics';
 import AreYouSureModal from '@/components/util/AreYouSureModal';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Context from '@/mixins/Context';
-import NoteEditSession from "@/mixins/NoteEditSession";
+import StudentEditSession from "@/mixins/StudentEditSession";
 import Util from '@/mixins/Util';
 import { updateNote } from '@/api/notes';
 
@@ -98,7 +98,7 @@ require('@/assets/styles/ckeditor-custom.css');
 export default {
   name: 'EditAdvisingNote',
   components: { AdvisingNoteTopics, AreYouSureModal },
-  mixins: [Context, NoteEditSession, Util],
+  mixins: [Context, StudentEditSession, Util],
   props: {
     afterCancelled: Function,
     afterSaved: Function,

--- a/src/components/note/NewNoteModal.vue
+++ b/src/components/note/NewNoteModal.vue
@@ -263,8 +263,8 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Context from '@/mixins/Context';
 import CreateNoteCohortDropdown from '@/components/note/CreateNoteCohortDropdown';
 import FocusLock from 'vue-focus-lock';
-import NoteEditSession from '@/mixins/NoteEditSession';
 import NoteUtil from '@/components/note/NoteUtil';
+import StudentEditSession from '@/mixins/StudentEditSession';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
 import { createNote } from '@/api/notes';
@@ -274,7 +274,7 @@ require('@/assets/styles/ckeditor-custom.css');
 export default {
   name: 'NewNoteModal',
   components: {AdvisingNoteTopics, AreYouSureModal, CreateNoteCohortDropdown, FocusLock},
-  mixins: [Context, NoteEditSession, NoteUtil, UserMetadata, Util],
+  mixins: [Context, NoteUtil, StudentEditSession, UserMetadata, Util],
   props: {
     disable: Boolean,
     initialMode: {
@@ -290,7 +290,7 @@ export default {
       required: true,
       type: Function
     },
-    student: {
+    sid: {
       required: false,
       type: Object
     }
@@ -337,7 +337,7 @@ export default {
   },
   created() {
     this.initFileDropPrevention();
-    this.sids = this.student ? [ this.student.sid ] : [];
+    this.sids = this.sid ? [ this.sid ] : [];
     this.reset();
   },
   methods: {
@@ -368,6 +368,7 @@ export default {
       this.showErrorPopover = false;
     },
     create() {
+      const isBatchMode = this.newNoteMode === 'batch';
       this.subject = this.trim(this.subject);
       if (this.subject && this.targetStudentCount) {
         this.body = this.trim(this.body);
@@ -376,6 +377,7 @@ export default {
         const addedCohortIds = this.map(this.addedCohorts, 'id');
         const addedCuratedGroupIds = this.map(this.addedCuratedGroups, 'id');
         createNote(
+          isBatchMode,
           this.sids,
           this.subject,
           this.body,

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -33,9 +33,9 @@
 import Cohorts from '@/components/sidebar/Cohorts.vue';
 import Context from '@/mixins/Context';
 import CuratedGroups from '@/components/sidebar/CuratedGroups.vue';
-import NoteEditSession from "@/mixins/NoteEditSession";
 import NewNoteModal from '@/components/note/NewNoteModal.vue';
 import SearchForm from '@/components/sidebar/SearchForm.vue';
+import StudentEditSession from "@/mixins/StudentEditSession";
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
 
@@ -47,7 +47,7 @@ export default {
     NewNoteModal,
     SearchForm
   },
-  mixins: [Context, NoteEditSession, UserMetadata, Util]
+  mixins: [Context, StudentEditSession, UserMetadata, Util]
 };
 </script>
 

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -228,8 +228,8 @@ import Context from '@/mixins/Context';
 import EditAdvisingNote from '@/components/note/EditAdvisingNote';
 import GoogleAnalytics from '@/mixins/GoogleAnalytics';
 import NewNoteModal from "@/components/note/NewNoteModal";
-import NoteEditSession from "@/mixins/NoteEditSession";
 import Scrollable from '@/mixins/Scrollable';
+import StudentEditSession from "@/mixins/StudentEditSession";
 import TimelineDate from '@/components/student/profile/TimelineDate';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
@@ -239,7 +239,7 @@ import { deleteNote, markRead } from '@/api/notes';
 export default {
   name: 'AcademicTimeline',
   components: {AdvisingNote, AreYouSureModal, EditAdvisingNote, NewNoteModal, TimelineDate},
-  mixins: [Context, GoogleAnalytics, NoteEditSession, Scrollable, UserMetadata, Util],
+  mixins: [Context, GoogleAnalytics, Scrollable, StudentEditSession, UserMetadata, Util],
   props: {
     student: Object
   },

--- a/src/mixins/StudentEditSession.vue
+++ b/src/mixins/StudentEditSession.vue
@@ -2,18 +2,21 @@
 import { mapActions, mapGetters } from 'vuex';
 
 export default {
-  name: 'NoteEditSession',
+  name: 'StudentEditSession',
   computed: {
-    ...mapGetters('noteEditSession', [
+    ...mapGetters('studentEditSession', [
       'editingNoteId',
       'newNoteMode',
       'suggestedTopics'
     ])
   },
   methods: {
-    ...mapActions('noteEditSession', [
+    ...mapActions('studentEditSession', [
       'editExistingNoteId',
-      'setNewNoteMode'
+      'endSession',
+      'setNewNoteMode',
+      'setReloadStudentBySidFunction',
+      'setSid'
     ])
   }
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@ import cohort from '@/store/modules/cohort';
 import cohortEditSession from '@/store/modules/cohort-edit-session';
 import context from '@/store/modules/context';
 import curated from '@/store/modules/curated';
-import noteEditSession from '@/store/modules/note-edit-session';
+import studentEditSession from '@/store/modules/student-edit-session';
 import user from '@/store/modules/user';
 import Vue from 'vue';
 import Vuex from 'vuex';
@@ -15,7 +15,7 @@ export default new Vuex.Store({
     cohortEditSession,
     context,
     curated,
-    noteEditSession,
+    studentEditSession,
     user
   },
   strict: process.env.NODE_ENV !== 'production'

--- a/src/store/modules/student-edit-session.ts
+++ b/src/store/modules/student-edit-session.ts
@@ -6,17 +6,22 @@ const VALID_MODES = ['advanced', 'batch', 'docked', 'minimized', 'saving'];
 const state = {
   editingNoteId: undefined,
   newNoteMode: undefined,
+  reloadStudentBySidFunction: undefined,
+  sid: undefined,
   suggestedTopics: undefined
 };
 
 const getters = {
   editingNoteId: (state: any): number => state.editingNoteId,
   newNoteMode: (state: any): string => state.newNoteMode,
+  reloadStudentBySidFunction: (state: any): Function => state.reloadStudentBySidFunction,
+  sid: (state: any): string => state.sid,
   suggestedTopics: (state: any): any[] => state.suggestedTopics
 };
 
 const mutations = {
   editExistingNoteId: (state: any, id: number) => (state.editingNoteId = id),
+  endSession: (state: any) => _.each(_.keys(state), key => state[key] = undefined),
   setNewNoteMode: (state: any, mode: string) => {
     if (_.isNil(mode)) {
       state.newNoteMode = null;
@@ -26,11 +31,14 @@ const mutations = {
       throw new TypeError('Invalid mode: ' + mode);
     }
   },
-  setSuggestedTopics: (state: any, topics: any[]) => (state.suggestedTopics = topics),
+  setReloadStudentBySidFunction: (state: any, fct: Function) => (state.reloadStudentBySidFunction = fct),
+  setSid: (state: any, sid: string) => (state.sid = sid),
+  setSuggestedTopics: (state: any, topics: any[]) => (state.suggestedTopics = topics)
 };
 
 const actions = {
   editExistingNoteId: ({ commit }, id: number) => commit('editExistingNoteId', id),
+  endSession: ({ commit }) => commit('endSession'),
   setNewNoteMode: ({ commit }, mode: string) => {
     if (_.isUndefined(state.suggestedTopics)) {
       // Lazy-load topics
@@ -41,7 +49,9 @@ const actions = {
     } else {
       commit('setNewNoteMode', mode);
     }
-  }
+  },
+  setReloadStudentBySidFunction: ({ commit }, fct: Function) => commit('setReloadStudentBySidFunction', fct),
+  setSid: ({ commit }, sid: string) => commit('setSid', sid)
 };
 
 export default {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ def create_alerts(client, db_session):
         message='Week 5 homework in BOSCRSR 27B is late.',
     )
     # Load our usual student of interest into the cache and generate midterm alerts from fixture data.
-    client.get('/api/student/61889')
+    client.get('/api/student/by_uid/61889')
     Alert.update_all_for_term(2178)
 
 

--- a/tests/test_api/test_alerts_controller.py
+++ b/tests/test_api/test_alerts_controller.py
@@ -33,7 +33,7 @@ class TestAlertsController:
 
     @classmethod
     def _get_alerts(cls, client, uid):
-        response = client.get(f'/api/student/{uid}')
+        response = client.get(f'/api/student/by_uid/{uid}')
         assert response.status_code == 200
         return response.json['notifications']['alert']
 

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -81,8 +81,8 @@ class TestCohortDetail:
         """Pre-load students into cache for consistent alert data."""
         from boac.models.alert import Alert
 
-        assert client.get('/api/student/61889').status_code == 200
-        assert client.get('/api/student/98765').status_code == 200
+        assert client.get('/api/student/by_uid/61889').status_code == 200
+        assert client.get('/api/student/by_uid/98765').status_code == 200
 
         Alert.update_all_for_term(2178)
         cohorts = all_cohorts_owned_by(asc_advisor_uid)
@@ -114,9 +114,9 @@ class TestCohortDetail:
         assert dave_doolittle['alertCount'] == 1
 
         def _get_alerts(uid):
-            response = client.get(f'/api/student/{uid}')
-            assert response.status_code == 200
-            return response.json['notifications']['alert']
+            _response = client.get(f'/api/student/by_uid/{uid}')
+            assert _response.status_code == 200
+            return _response.json['notifications']['alert']
 
         alert_to_dismiss = _get_alerts(61889)[0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -173,7 +173,7 @@ class TestGetCuratedGroup:
         assert api_json[0]['alertCount'] == 3
         assert api_json[1]['alertCount'] == 1
 
-        student = client.get('/api/student/61889').json
+        student = client.get('/api/student/by_uid/61889').json
         alert_to_dismiss = student['notifications']['alert'][0]['id']
         client.get('/api/alerts/' + str(alert_to_dismiss) + '/dismiss')
         students_with_alerts = client.get(f'/api/curated_group/{asc_curated_groups[0].id}/students_with_alerts').json

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -584,7 +584,7 @@ class TestStreamNoteAttachments:
 
 
 def _get_notes(client, uid):
-    response = client.get(f'/api/student/{uid}')
+    response = client.get(f'/api/student/by_uid/{uid}')
     assert response.status_code == 200
     return response.json['notifications']['note']
 
@@ -633,6 +633,7 @@ def _api_batch_note_create(
     with mock_advising_note_s3_bucket(app):
         data = {
             'authorId': author_id,
+            'isBatchMode': sids and len(sids) > 1,
             'sids': sids or [],
             'cohortIds': cohort_ids or [],
             'curatedGroupIds': curated_group_ids or [],

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -34,12 +34,12 @@ def admin_login(fake_auth):
 
 
 @pytest.fixture()
-def asc_advisor(fake_auth):
+def asc_advisor_login(fake_auth):
     fake_auth.login('1081940')
 
 
 @pytest.fixture()
-def coe_advisor(fake_auth):
+def coe_advisor_login(fake_auth):
     fake_auth.login('1133399')
 
 
@@ -55,7 +55,7 @@ def asc_inactive_students():
 class TestFindStudents:
     """Generic student API calls."""
 
-    def test_all_students(self, asc_advisor, asc_inactive_students, client):
+    def test_all_students(self, asc_advisor_login, asc_inactive_students, client):
         """Returns a list of students."""
         data = {
             'levels': ['Freshmen', 'Sophomore', 'Junior', 'Senior'],
@@ -88,11 +88,11 @@ class TestCollegeOfEngineering:
             content_type='application/json',
         )
 
-    def test_unauthorized_request_for_coe_data(self, client, asc_advisor):
+    def test_unauthorized_request_for_coe_data(self, client, asc_advisor_login):
         """In order to access PREP, etc. the user must be either COE or Admin."""
         assert 403 == self._api_students(client, {'coePrepStatuses': ['did_prep']}).status_code
 
-    def test_authorized_request_for_coe_data(self, client, coe_advisor):
+    def test_authorized_request_for_coe_data(self, client, coe_advisor_login):
         """In order to access PREP, etc. the user must be either COE or Admin."""
         response = self._api_students(client, {'coePrepStatuses': ['did_prep']})
         assert response.status_code == 200
@@ -100,7 +100,7 @@ class TestCollegeOfEngineering:
         assert len(students) == 1
         assert students[0]['sid'] == '11667051'
 
-    def test_authorized_request_for_gender(self, client, coe_advisor):
+    def test_authorized_request_for_gender(self, client, coe_advisor_login):
         """For now, only COE users can access gender data."""
         response = self._api_students(client, {'genders': ['F']})
         assert response.status_code == 200
@@ -113,7 +113,7 @@ class TestCollegeOfEngineering:
         assert students[1]['coeProfile']['gender'] == 'F'
         assert students[1]['coeProfile']['isActiveCoe'] is False
 
-    def test_authorized_request_for_coe_inactive_gender(self, client, coe_advisor):
+    def test_authorized_request_for_coe_inactive_gender(self, client, coe_advisor_login):
         response = self._api_students(
             client,
             {
@@ -126,7 +126,7 @@ class TestCollegeOfEngineering:
         assert len(students) == 1
         assert students[0]['sid'] == '9000000000'
 
-    def test_authorized_request_for_ethnicity(self, client, coe_advisor):
+    def test_authorized_request_for_ethnicity(self, client, coe_advisor_login):
         """For now, only COE users can access ethnicity data."""
         response = self._api_students(client, {'ethnicities': ['B', 'H']})
         assert response.status_code == 200
@@ -164,7 +164,7 @@ class TestCollegeOfEngineering:
 
 
 class TestAthleticsStudyCenter:
-    """ASC-specific API calls."""
+    """Student API, Athletics Study Center."""
 
     @classmethod
     def _api_students(cls, client, json_data=()):
@@ -174,7 +174,7 @@ class TestAthleticsStudyCenter:
             content_type='application/json',
         )
 
-    def test_multiple_teams(self, asc_advisor, asc_inactive_students, client):
+    def test_multiple_teams(self, asc_advisor_login, asc_inactive_students, client):
         """Includes multiple team memberships."""
         response = self._api_students(client, {'groupCodes': ['MFB-DB', 'MFB-DL']})
         assert response.status_code == 200
@@ -186,7 +186,7 @@ class TestAthleticsStudyCenter:
         assert 'MFB-DB' in group_codes
         assert 'MFB-DL' in group_codes
 
-    def test_get_intensive_cohort(self, asc_advisor, asc_inactive_students, client):
+    def test_get_intensive_cohort(self, asc_advisor_login, asc_inactive_students, client):
         """Returns the canned 'intensive' cohort, available to all authenticated users."""
         response = self._api_students(client, {'inIntensiveCohort': True})
         assert response.status_code == 200
@@ -207,7 +207,7 @@ class TestAthleticsStudyCenter:
         response = self._api_students(client, {'inIntensiveCohort': True})
         assert response.status_code == 403
 
-    def test_order_by_with_intensive_cohort(self, asc_advisor, client):
+    def test_order_by_with_intensive_cohort(self, asc_advisor_login, client):
         """Returns students marked as 'intensive' by ASC."""
         all_expected_order = {
             'first_name': ['61889', '123456', '1049291', '242881', '211159'],
@@ -232,7 +232,7 @@ class TestAthleticsStudyCenter:
             uid_list = [s['uid'] for s in cohort['students']]
             assert uid_list == expected_uid_list, f'Unmet expectation where order_by={order_by}'
 
-    def test_forbidden_order_by(self, client, coe_advisor):
+    def test_forbidden_order_by(self, client, coe_advisor_login):
         """COE advisor cannot order results by ASC criteria."""
         assert 403 == self._api_students(
             client,
@@ -242,7 +242,7 @@ class TestAthleticsStudyCenter:
             },
         ).status_code
 
-    def test_get_inactive_cohort(self, asc_advisor, client):
+    def test_get_inactive_cohort(self, asc_advisor_login, client):
         response = self._api_students(client, {'isInactiveAsc': True})
         assert response.status_code == 200
         cohort = json.loads(response.data)
@@ -281,7 +281,7 @@ class TestStudentResultsForFilter:
     sample_filter['levels'] = []
     coe_filter = json.dumps(sample_filter)
 
-    def test_get_students(self, asc_advisor, asc_inactive_students, client):
+    def test_get_students(self, asc_advisor_login, asc_inactive_students, client):
         response = client.post('/api/students', data=self.asc_filter, content_type='application/json')
         assert response.status_code == 200
         assert 'students' in response.json
@@ -291,7 +291,7 @@ class TestStudentResultsForFilter:
         # Offset of 1, ordered by lastName
         assert ['9933311', '242881'] == [student['uid'] for student in students]
 
-    def test_get_students_includes_athletics_asc(self, asc_advisor, client):
+    def test_get_students_includes_athletics_asc(self, asc_advisor_login, client):
         response = client.post('/api/students', data=self.asc_filter, content_type='application/json')
         students = response.json['students']
         group_codes_1133399 = [a['groupCode'] for a in students[0]['athleticsProfile']['athletics']]
@@ -302,11 +302,11 @@ class TestStudentResultsForFilter:
         group_codes_242881 = [a['groupCode'] for a in students[1]['athleticsProfile']['athletics']]
         assert group_codes_242881 == ['MFB-DL']
 
-    def test_coe_unauthorized_request_for_asc_data(self, coe_advisor, client):
+    def test_coe_unauthorized_request_for_asc_data(self, coe_advisor_login, client):
         response = client.post('/api/students', data=self.coe_filter, content_type='application/json')
         assert 403 == response.status_code
 
-    def test_get_active_asc_students(self, asc_advisor, asc_inactive_students, client):
+    def test_get_active_asc_students(self, asc_advisor_login, asc_inactive_students, client):
         """An ASC cohort search finds ASC sophomores."""
         args = {'levels': ['Sophomore']}
         response = client.post('/api/students', data=json.dumps(args), content_type='application/json')
@@ -315,7 +315,7 @@ class TestStudentResultsForFilter:
         assert _get_common_sids(students, asc_inactive_students)
         assert len(students) == 1
 
-    def test_get_inactive_asc_students(self, asc_advisor, asc_inactive_students, client):
+    def test_get_inactive_asc_students(self, asc_advisor_login, asc_inactive_students, client):
         """ASC cohort results include ASC sophomores."""
         args = {
             'levels': ['Sophomore'],
@@ -328,7 +328,7 @@ class TestStudentResultsForFilter:
         assert len(_get_common_sids(students, asc_inactive_students)) == 1
         assert next(s for s in students if s['name'] == 'Siegfried Schlemiel')
 
-    def test_get_students_coe_limited(self, coe_advisor, client):
+    def test_get_students_coe_limited(self, coe_advisor_login, client):
         """COE cohort results include active COE sophomores."""
         response = client.post('/api/students', data='{"levels": ["Sophomore"]}', content_type='application/json')
         students = response.json['students']
@@ -349,88 +349,87 @@ class TestStudentResultsForFilter:
 class TestStudent:
     """Student API."""
 
-    coe_student = '/api/student/1049291'
-    dave = '/api/student/98765'
-    deborah = '/api/student/61889'
-    non_student = '/api/student/2040'
-    unknown = '/api/student/9999999'
+    @classmethod
+    def _api_student_by_sid(cls, client, sid, expected_status_code=200):
+        response = client.get(f'/api/student/by_sid/{sid}')
+        assert response.status_code == expected_status_code
+        return response.json
 
-    @pytest.fixture()
-    def coe_advisor(self, fake_auth):
-        fake_auth.login('1133399')
+    @classmethod
+    def _api_student_by_uid(cls, client, uid, expected_status_code=200):
+        response = client.get(f'/api/student/by_uid/{uid}')
+        assert response.status_code == expected_status_code
+        return response.json
 
-    @pytest.fixture()
-    def authenticated_response(self, coe_advisor, client):
-        response = client.get(self.deborah)
-        assert response.status_code == 200
-        return response
-
-    @pytest.fixture()
-    def asc_advisor(self, fake_auth):
-        fake_auth.login('1081940')
-
-    @pytest.fixture()
-    def asc_authenticated_response(self, asc_advisor, client):
-        response = client.get(self.deborah)
-        assert response.status_code == 200
-        return response
-
-    @pytest.fixture()
-    def coe_authenticated_response(self, coe_advisor, client):
-        response = client.get(self.coe_student)
-        assert response.status_code == 200
-        return response
+    asc_student = {
+        'sid': '2345678901',
+        'uid': '98765',
+    }
+    coe_student = {
+        'sid': '7890123456',
+        'uid': '1049291',
+    }
+    asc_student_in_coe = {
+        'sid': '11667051',
+        'uid': '61889',
+    }
+    unrecognized_student = {
+        'sid': '9999999',
+        'uid': '9999999',
+    }
 
     @pytest.fixture()
     def admin_auth(self, fake_auth):
         fake_auth.login('2040')
 
-    @pytest.fixture()
-    def admin_authenticated_response(self, admin_auth, client):
-        response = client.get(self.deborah)
-        assert response.status_code == 200
-        return response
-
     @staticmethod
-    def get_course_for_code(response, term_id, code):
-        term = next((term for term in response.json['enrollmentTerms'] if term['termId'] == term_id), None)
+    def get_course_for_code(student, term_id, code):
+        term = next((term for term in student['enrollmentTerms'] if term['termId'] == term_id), None)
         if term:
             return next((course for course in term['enrollments'] if course['displayName'] == code), None)
 
     def test_user_analytics_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
-        response = client.get(self.deborah)
-        assert response.status_code == 401
+        self._api_student_by_sid(client=client, sid=self.asc_student['sid'], expected_status_code=401)
+        self._api_student_by_uid(client=client, uid=self.asc_student['uid'], expected_status_code=401)
 
-    def test_user_with_no_enrollments_in_current_term(self, asc_advisor, client):
+    def test_user_with_no_enrollments_in_current_term(self, asc_advisor_login, client):
         """Identifies user with no enrollments in current term."""
-        response = client.get(self.dave)
-        assert response.status_code == 200
-        enrollment_terms = response.json['enrollmentTerms']
-        assert len(enrollment_terms) == 1
-        assert enrollment_terms[0]['termName'] == 'Spring 2017'
-        assert response.json['hasCurrentTermEnrollments'] is False
+        sid = self.asc_student['sid']
+        uid = self.asc_student['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            enrollment_terms = student['enrollmentTerms']
+            assert len(enrollment_terms) == 1
+            assert enrollment_terms[0]['termName'] == 'Spring 2017'
+            assert student['hasCurrentTermEnrollments'] is False
 
-    def test_user_analytics_authenticated(self, authenticated_response):
+    def test_user_analytics_authenticated(self, client, coe_advisor_login):
         """Returns a well-formed response if authenticated."""
-        assert authenticated_response.status_code == 200
-        assert authenticated_response.json['uid'] == '61889'
-        assert authenticated_response.json['canvasUserId'] == '9000100'
-        assert authenticated_response.json['hasCurrentTermEnrollments'] is True
-        assert len(authenticated_response.json['enrollmentTerms']) > 0
-        for term in authenticated_response.json['enrollmentTerms']:
-            assert len(term['enrollments']) > 0
-            for course in term['enrollments']:
-                for canvas_site in course['canvasSites']:
-                    assert canvas_site['canvasCourseId']
-                    assert canvas_site['courseCode']
-                    assert canvas_site['courseTerm']
-                    assert canvas_site['courseCode']
-                    assert canvas_site['analytics']
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            assert student['sid'] == sid
+            assert student['uid'] == uid
+            assert student['canvasUserId'] == '9000100'
+            assert student['hasCurrentTermEnrollments'] is True
+            assert len(student['enrollmentTerms']) > 0
+            for term in student['enrollmentTerms']:
+                assert len(term['enrollments']) > 0
+                for course in term['enrollments']:
+                    for canvas_site in course['canvasSites']:
+                        assert canvas_site['canvasCourseId']
+                        assert canvas_site['courseCode']
+                        assert canvas_site['courseTerm']
+                        assert canvas_site['courseCode']
+                        assert canvas_site['analytics']
 
-    def test_user_analytics_holds(self, asc_advisor, client):
+    def test_user_analytics_holds(self, asc_advisor_login, client):
         """Returns holds if any."""
-        response = client.get('/api/student/9933311')
+        response = client.get('/api/student/by_uid/9933311')
         assert response.status_code == 200
         holds = response.json['notifications']['hold']
         assert len(holds) == 2
@@ -439,270 +438,361 @@ class TestStudent:
         assert holds[1]['reason']['description'] == 'Semester Out'
         assert holds[1]['reason']['formalDescription'].startswith('You are not eligible to register')
 
-    def test_user_analytics_multiple_terms(self, authenticated_response):
+    def test_user_analytics_multiple_terms(self, client, coe_advisor_login):
         """Returns all terms with enrollment data in reverse order."""
-        assert len(authenticated_response.json['enrollmentTerms']) == 3
-        assert authenticated_response.json['enrollmentTerms'][0]['termName'] == 'Spring 2018'
-        assert authenticated_response.json['enrollmentTerms'][0]['enrolledUnits'] == 3
-        assert len(authenticated_response.json['enrollmentTerms'][0]['enrollments']) == 1
-        assert authenticated_response.json['enrollmentTerms'][1]['termName'] == 'Fall 2017'
-        assert authenticated_response.json['enrollmentTerms'][1]['enrolledUnits'] == 12.5
-        assert len(authenticated_response.json['enrollmentTerms'][1]['enrollments']) == 5
-        assert authenticated_response.json['enrollmentTerms'][2]['termName'] == 'Spring 2017'
-        assert authenticated_response.json['enrollmentTerms'][2]['enrolledUnits'] == 10
-        assert len(authenticated_response.json['enrollmentTerms'][2]['enrollments']) == 3
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            assert len(student['enrollmentTerms']) == 3
+            assert student['enrollmentTerms'][0]['termName'] == 'Spring 2018'
+            assert student['enrollmentTerms'][0]['enrolledUnits'] == 3
+            assert len(student['enrollmentTerms'][0]['enrollments']) == 1
+            assert student['enrollmentTerms'][1]['termName'] == 'Fall 2017'
+            assert student['enrollmentTerms'][1]['enrolledUnits'] == 12.5
+            assert len(student['enrollmentTerms'][1]['enrollments']) == 5
+            assert student['enrollmentTerms'][2]['termName'] == 'Spring 2017'
+            assert student['enrollmentTerms'][2]['enrolledUnits'] == 10
+            assert len(student['enrollmentTerms'][2]['enrollments']) == 3
 
-    def test_user_analytics_earliest_term_cutoff(self, authenticated_response):
+    def test_user_analytics_earliest_term_cutoff(self, client, coe_advisor_login):
         """Ignores terms before the configured earliest term."""
-        for term in authenticated_response.json['enrollmentTerms']:
-            assert term['termName'] != 'Spring 2016'
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            for term in student['enrollmentTerms']:
+                assert term['termName'] != 'Spring 2016'
 
-    def test_user_analytics_future_term_cutoff(self, authenticated_response):
+    def test_user_analytics_future_term_cutoff(self, client, coe_advisor_login):
         """Ignores terms after the configured future term."""
-        for term in authenticated_response.json['enrollmentTerms']:
-            assert term['termName'] != 'Summer 2018'
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            for term in student['enrollmentTerms']:
+                assert term['termName'] != 'Summer 2018'
 
-    def test_enrollment_without_course_site(self, authenticated_response):
+    def test_enrollment_without_course_site(self, client, coe_advisor_login):
         """Returns enrollments with no associated course sites."""
-        enrollment_without_site = self.get_course_for_code(authenticated_response, '2172', 'MUSIC 41C')
-        assert enrollment_without_site['title'] == 'Private Carillon Lessons for Advanced Students'
-        assert enrollment_without_site['canvasSites'] == []
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            enrollment_without_site = self.get_course_for_code(student, '2172', 'MUSIC 41C')
+            assert enrollment_without_site['title'] == 'Private Carillon Lessons for Advanced Students'
+            assert enrollment_without_site['canvasSites'] == []
 
-    def test_enrollment_with_multiple_course_sites(self, authenticated_response):
+    def test_enrollment_with_multiple_course_sites(self, client, coe_advisor_login):
         """Returns multiple course sites associated with an enrollment, sorted by site id."""
-        enrollment_with_multiple_sites = self.get_course_for_code(authenticated_response, '2178', 'NUC ENG 124')
-        canvas_sites = enrollment_with_multiple_sites['canvasSites']
-        assert len(canvas_sites) == 2
-        assert canvas_sites[0]['courseName'] == 'Radioactive Waste Management'
-        assert canvas_sites[1]['courseName'] == 'Optional Friday Night Radioactivity Group'
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            enrollment_with_multiple_sites = self.get_course_for_code(student, '2178', 'NUC ENG 124')
+            canvas_sites = enrollment_with_multiple_sites['canvasSites']
+            assert len(canvas_sites) == 2
+            assert canvas_sites[0]['courseName'] == 'Radioactive Waste Management'
+            assert canvas_sites[1]['courseName'] == 'Optional Friday Night Radioactivity Group'
 
-    def test_multiple_primary_section_enrollments(self, authenticated_response):
+    def test_multiple_primary_section_enrollments(self, client, coe_advisor_login):
         """Disambiguates multiple primary sections under a single course display name."""
-        classics_first = self.get_course_for_code(authenticated_response, '2172', 'CLASSIC 130 LEC 001')
-        classics_second = self.get_course_for_code(authenticated_response, '2172', 'CLASSIC 130 LEC 002')
-        assert len(classics_first['sections']) == 1
-        assert classics_first['sections'][0]['units'] == 4
-        assert classics_first['sections'][0]['gradingBasis'] == 'P/NP'
-        assert classics_first['sections'][0]['grade'] == 'P'
-        assert classics_first['units'] == 4
-        assert classics_first['gradingBasis'] == 'P/NP'
-        assert classics_first['grade'] == 'P'
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            classics_first = self.get_course_for_code(student, '2172', 'CLASSIC 130 LEC 001')
+            classics_second = self.get_course_for_code(student, '2172', 'CLASSIC 130 LEC 002')
+            assert len(classics_first['sections']) == 1
+            assert classics_first['sections'][0]['units'] == 4
+            assert classics_first['sections'][0]['gradingBasis'] == 'P/NP'
+            assert classics_first['sections'][0]['grade'] == 'P'
+            assert classics_first['units'] == 4
+            assert classics_first['gradingBasis'] == 'P/NP'
+            assert classics_first['grade'] == 'P'
 
-        assert len(classics_second['sections']) == 1
-        assert classics_second['sections'][0]['units'] == 4
-        assert classics_second['sections'][0]['gradingBasis'] == 'Letter'
-        assert classics_second['sections'][0]['grade'] == 'B-'
-        assert classics_second['units'] == 4
-        assert classics_second['gradingBasis'] == 'Letter'
-        assert classics_second['grade'] == 'B-'
+            assert len(classics_second['sections']) == 1
+            assert classics_second['sections'][0]['units'] == 4
+            assert classics_second['sections'][0]['gradingBasis'] == 'Letter'
+            assert classics_second['sections'][0]['grade'] == 'B-'
+            assert classics_second['units'] == 4
+            assert classics_second['gradingBasis'] == 'Letter'
+            assert classics_second['grade'] == 'B-'
 
-    def test_enrollments_sorted(self, authenticated_response):
+    def test_enrollments_sorted(self, client, coe_advisor_login):
         """Sorts enrollments by course display name."""
-        spring_2017_enrollments = authenticated_response.json['enrollmentTerms'][2]['enrollments']
-        assert(spring_2017_enrollments[0]['displayName'] == 'CLASSIC 130 LEC 001')
-        assert(spring_2017_enrollments[1]['displayName'] == 'CLASSIC 130 LEC 002')
-        assert(spring_2017_enrollments[2]['displayName'] == 'MUSIC 41C')
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            spring_2017_enrollments = student['enrollmentTerms'][2]['enrollments']
+            assert(spring_2017_enrollments[0]['displayName'] == 'CLASSIC 130 LEC 001')
+            assert(spring_2017_enrollments[1]['displayName'] == 'CLASSIC 130 LEC 002')
+            assert(spring_2017_enrollments[2]['displayName'] == 'MUSIC 41C')
 
-    def test_course_site_without_enrollment(self, authenticated_response):
+    def test_course_site_without_enrollment(self, client, coe_advisor_login):
         """Returns course sites with no associated enrollments."""
-        assert len(authenticated_response.json['enrollmentTerms'][0]['unmatchedCanvasSites']) == 0
-        assert len(authenticated_response.json['enrollmentTerms'][1]['unmatchedCanvasSites']) == 0
-        assert len(authenticated_response.json['enrollmentTerms'][2]['unmatchedCanvasSites']) == 1
-        unmatched_site = authenticated_response.json['enrollmentTerms'][2]['unmatchedCanvasSites'][0]
-        assert unmatched_site['courseCode'] == 'STAT 154'
-        assert unmatched_site['courseName'] == 'Modern Statistical Prediction and Machine Learning'
-        assert unmatched_site['analytics']
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            assert len(student['enrollmentTerms'][0]['unmatchedCanvasSites']) == 0
+            assert len(student['enrollmentTerms'][1]['unmatchedCanvasSites']) == 0
+            assert len(student['enrollmentTerms'][2]['unmatchedCanvasSites']) == 1
+            unmatched_site = student['enrollmentTerms'][2]['unmatchedCanvasSites'][0]
+            assert unmatched_site['courseCode'] == 'STAT 154'
+            assert unmatched_site['courseName'] == 'Modern Statistical Prediction and Machine Learning'
+            assert unmatched_site['analytics']
 
-    def test_course_site_without_membership(self, authenticated_response):
+    def test_course_site_without_membership(self, client, coe_advisor_login):
         """Returns a graceful error if the expected membership is not found in the course site."""
-        course_without_membership = self.get_course_for_code(authenticated_response, '2178', 'BURMESE 1A')
-        for metric in ['assignmentsSubmitted', 'currentScore', 'lastActivity']:
-            assert course_without_membership['canvasSites'][0]['analytics'][metric]['error']
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            course_without_membership = self.get_course_for_code(student, '2178', 'BURMESE 1A')
+            for metric in ['assignmentsSubmitted', 'currentScore', 'lastActivity']:
+                assert course_without_membership['canvasSites'][0]['analytics'][metric]['error']
 
-    def test_course_site_with_enrollment(self, authenticated_response):
+    def test_course_site_with_enrollment(self, client, coe_advisor_login):
         """Returns sensible data if the expected enrollment is found in the course site."""
-        course_with_enrollment = self.get_course_for_code(authenticated_response, '2178', 'MED ST 205')
-        analytics = course_with_enrollment['canvasSites'][0]['analytics']
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            course_with_enrollment = self.get_course_for_code(student, '2178', 'MED ST 205')
+            analytics = course_with_enrollment['canvasSites'][0]['analytics']
 
-        assert analytics['assignmentsSubmitted']['student']['raw'] == 8
-        assert analytics['assignmentsSubmitted']['student']['percentile'] == 64
-        assert analytics['assignmentsSubmitted']['courseDeciles'][0] == 0
-        assert analytics['assignmentsSubmitted']['courseDeciles'][9] == 10
-        assert analytics['assignmentsSubmitted']['courseDeciles'][10] == 17
+            assert analytics['assignmentsSubmitted']['student']['raw'] == 8
+            assert analytics['assignmentsSubmitted']['student']['percentile'] == 64
+            assert analytics['assignmentsSubmitted']['courseDeciles'][0] == 0
+            assert analytics['assignmentsSubmitted']['courseDeciles'][9] == 10
+            assert analytics['assignmentsSubmitted']['courseDeciles'][10] == 17
 
-        assert analytics['currentScore']['student']['raw'] == 84
+            assert analytics['currentScore']['student']['raw'] == 84
 
-        assert analytics['lastActivity']['boxPlottable'] is True
-        assert analytics['lastActivity']['student']['raw'] == 1535275620
-        assert analytics['lastActivity']['student']['percentile'] == 93
-        assert analytics['lastActivity']['displayPercentile'] == '90th'
+            assert analytics['lastActivity']['boxPlottable'] is True
+            assert analytics['lastActivity']['student']['raw'] == 1535275620
+            assert analytics['lastActivity']['student']['percentile'] == 93
+            assert analytics['lastActivity']['displayPercentile'] == '90th'
 
-    def test_student_not_found(self, coe_advisor, client):
+    def test_student_not_found(self, coe_advisor_login, client):
         """Returns 404 if no viewable student."""
-        response = client.get(self.unknown)
-        assert response.status_code == 404
-        assert response.json['message'] == 'Unknown student'
+        sid = self.unrecognized_student['sid']
+        uid = self.unrecognized_student['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid, expected_status_code=404)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid, expected_status_code=404)
+        for response in [student_by_sid, student_by_uid]:
+            assert response['message'] == 'Unknown student'
 
-    def test_user_analytics_not_department_authorized(self, coe_advisor, client):
+    def test_user_analytics_not_department_authorized(self, coe_advisor_login, client):
         """Returns 404 if attempting to view a user outside one's own department."""
-        response = client.get(self.dave)
-        assert response.status_code == 404
+        self._api_student_by_sid(client=client, sid=self.asc_student['sid'], expected_status_code=404)
+        self._api_student_by_uid(client=client, uid=self.asc_student['uid'], expected_status_code=404)
 
-    def test_sis_enrollment_merge(self, authenticated_response):
+    def test_sis_enrollment_merge(self, client, coe_advisor_login):
         """Merges sorted SIS enrollment data."""
-        burmese = self.get_course_for_code(authenticated_response, '2178', 'BURMESE 1A')
-        assert burmese['displayName'] == 'BURMESE 1A'
-        assert burmese['title'] == 'Introductory Burmese'
-        assert len(burmese['sections']) == 1
-        assert burmese['sections'][0]['ccn'] == 90100
-        assert burmese['sections'][0]['sectionNumber'] == '001'
-        assert burmese['sections'][0]['enrollmentStatus'] == 'E'
-        assert burmese['sections'][0]['units'] == 4
-        assert burmese['sections'][0]['gradingBasis'] == 'Letter'
-        assert burmese['sections'][0]['midtermGrade'] == 'D+'
-        assert burmese['sections'][0]['primary'] is True
-        assert not burmese['sections'][0]['grade']
-        assert burmese['units'] == 4
-        assert burmese['gradingBasis'] == 'Letter'
-        assert burmese['midtermGrade'] == 'D+'
-        assert not burmese['grade']
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            burmese = self.get_course_for_code(student, '2178', 'BURMESE 1A')
+            assert burmese['displayName'] == 'BURMESE 1A'
+            assert burmese['title'] == 'Introductory Burmese'
+            assert len(burmese['sections']) == 1
+            assert burmese['sections'][0]['ccn'] == 90100
+            assert burmese['sections'][0]['sectionNumber'] == '001'
+            assert burmese['sections'][0]['enrollmentStatus'] == 'E'
+            assert burmese['sections'][0]['units'] == 4
+            assert burmese['sections'][0]['gradingBasis'] == 'Letter'
+            assert burmese['sections'][0]['midtermGrade'] == 'D+'
+            assert burmese['sections'][0]['primary'] is True
+            assert not burmese['sections'][0]['grade']
+            assert burmese['units'] == 4
+            assert burmese['gradingBasis'] == 'Letter'
+            assert burmese['midtermGrade'] == 'D+'
+            assert not burmese['grade']
 
-        medieval = self.get_course_for_code(authenticated_response, '2178', 'MED ST 205')
-        assert medieval['displayName'] == 'MED ST 205'
-        assert medieval['title'] == 'Medieval Manuscripts as Primary Sources'
-        assert len(medieval['sections']) == 1
-        assert medieval['sections'][0]['ccn'] == 90200
-        assert medieval['sections'][0]['sectionNumber'] == '001'
-        assert medieval['sections'][0]['enrollmentStatus'] == 'E'
-        assert medieval['sections'][0]['units'] == 5
-        assert medieval['sections'][0]['gradingBasis'] == 'Letter'
-        assert medieval['sections'][0]['primary'] is True
-        assert not medieval['sections'][0]['grade']
+            medieval = self.get_course_for_code(student, '2178', 'MED ST 205')
+            assert medieval['displayName'] == 'MED ST 205'
+            assert medieval['title'] == 'Medieval Manuscripts as Primary Sources'
+            assert len(medieval['sections']) == 1
+            assert medieval['sections'][0]['ccn'] == 90200
+            assert medieval['sections'][0]['sectionNumber'] == '001'
+            assert medieval['sections'][0]['enrollmentStatus'] == 'E'
+            assert medieval['sections'][0]['units'] == 5
+            assert medieval['sections'][0]['gradingBasis'] == 'Letter'
+            assert medieval['sections'][0]['primary'] is True
+            assert not medieval['sections'][0]['grade']
 
-        nuclear = self.get_course_for_code(authenticated_response, '2178', 'NUC ENG 124')
-        assert nuclear['displayName'] == 'NUC ENG 124'
-        assert nuclear['title'] == 'Radioactive Waste Management'
-        assert len(nuclear['sections']) == 2
-        assert nuclear['sections'][0]['ccn'] == 90300
-        assert nuclear['sections'][0]['sectionNumber'] == '002'
-        assert nuclear['sections'][0]['enrollmentStatus'] == 'E'
-        assert nuclear['sections'][0]['units'] == 3
-        assert nuclear['sections'][0]['gradingBasis'] == 'P/NP'
-        assert nuclear['sections'][0]['grade'] == 'P'
-        assert nuclear['sections'][0]['primary'] is True
-        assert nuclear['sections'][1]['ccn'] == 90301
-        assert nuclear['sections'][1]['sectionNumber'] == '201'
-        assert nuclear['sections'][1]['enrollmentStatus'] == 'E'
-        assert nuclear['sections'][1]['units'] == 0
-        assert nuclear['sections'][1]['gradingBasis'] == 'NON'
-        assert nuclear['sections'][1]['primary'] is False
-        assert not nuclear['sections'][1]['grade']
+            nuclear = self.get_course_for_code(student, '2178', 'NUC ENG 124')
+            assert nuclear['displayName'] == 'NUC ENG 124'
+            assert nuclear['title'] == 'Radioactive Waste Management'
+            assert len(nuclear['sections']) == 2
+            assert nuclear['sections'][0]['ccn'] == 90300
+            assert nuclear['sections'][0]['sectionNumber'] == '002'
+            assert nuclear['sections'][0]['enrollmentStatus'] == 'E'
+            assert nuclear['sections'][0]['units'] == 3
+            assert nuclear['sections'][0]['gradingBasis'] == 'P/NP'
+            assert nuclear['sections'][0]['grade'] == 'P'
+            assert nuclear['sections'][0]['primary'] is True
+            assert nuclear['sections'][1]['ccn'] == 90301
+            assert nuclear['sections'][1]['sectionNumber'] == '201'
+            assert nuclear['sections'][1]['enrollmentStatus'] == 'E'
+            assert nuclear['sections'][1]['units'] == 0
+            assert nuclear['sections'][1]['gradingBasis'] == 'NON'
+            assert nuclear['sections'][1]['primary'] is False
+            assert not nuclear['sections'][1]['grade']
 
-        music = self.get_course_for_code(authenticated_response, '2172', 'MUSIC 41C')
-        assert music['displayName'] == 'MUSIC 41C'
-        assert music['title'] == 'Private Carillon Lessons for Advanced Students'
-        assert len(music['sections']) == 1
-        assert music['sections'][0]['ccn'] == 80100
-        assert music['sections'][0]['sectionNumber'] == '001'
-        assert music['sections'][0]['enrollmentStatus'] == 'E'
-        assert music['sections'][0]['units'] == 2
-        assert music['sections'][0]['gradingBasis'] == 'Letter'
-        assert music['sections'][0]['grade'] == 'A-'
-        assert music['sections'][0]['primary'] is True
-        assert music['units'] == 2
-        assert music['gradingBasis'] == 'Letter'
-        assert music['grade'] == 'A-'
+            music = self.get_course_for_code(student, '2172', 'MUSIC 41C')
+            assert music['displayName'] == 'MUSIC 41C'
+            assert music['title'] == 'Private Carillon Lessons for Advanced Students'
+            assert len(music['sections']) == 1
+            assert music['sections'][0]['ccn'] == 80100
+            assert music['sections'][0]['sectionNumber'] == '001'
+            assert music['sections'][0]['enrollmentStatus'] == 'E'
+            assert music['sections'][0]['units'] == 2
+            assert music['sections'][0]['gradingBasis'] == 'Letter'
+            assert music['sections'][0]['grade'] == 'A-'
+            assert music['sections'][0]['primary'] is True
+            assert music['units'] == 2
+            assert music['gradingBasis'] == 'Letter'
+            assert music['grade'] == 'A-'
 
-    def test_dropped_sections(self, authenticated_response):
+    def test_dropped_sections(self, client, coe_advisor_login):
         """Collects dropped sections in a separate feed."""
-        dropped_sections = authenticated_response.json['enrollmentTerms'][1]['droppedSections']
-        assert len(dropped_sections) == 1
-        assert dropped_sections[0]['displayName'] == 'MUSIC 41C'
-        assert dropped_sections[0]['component'] == 'TUT'
-        assert dropped_sections[0]['sectionNumber'] == '002'
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            dropped_sections = student['enrollmentTerms'][1]['droppedSections']
+            assert len(dropped_sections) == 1
+            assert dropped_sections[0]['displayName'] == 'MUSIC 41C'
+            assert dropped_sections[0]['component'] == 'TUT'
+            assert dropped_sections[0]['sectionNumber'] == '002'
 
-    def test_sis_profile(self, authenticated_response):
+    def test_sis_profile(self, client, coe_advisor_login):
         """Provides SIS profile data."""
-        sis_profile = authenticated_response.json['sisProfile']
-        assert sis_profile['academicCareer'] == 'UGRD'
-        assert sis_profile['cumulativeGPA'] == 3.8
-        assert sis_profile['cumulativeUnits'] == 101.3
-        assert sis_profile['degreeProgress']['requirements']['americanCultures']['status'] == 'In Progress'
-        assert sis_profile['degreeProgress']['requirements']['americanHistory']['status'] == 'Not Satisfied'
-        assert sis_profile['degreeProgress']['requirements']['americanInstitutions']['status'] == 'Not Satisfied'
-        assert sis_profile['degreeProgress']['requirements']['entryLevelWriting']['status'] == 'Satisfied'
-        assert sis_profile['emailAddress'] == 'oski@berkeley.edu'
-        assert sis_profile['level']['code'] == '30'
-        assert sis_profile['level']['description'] == 'Junior'
-        assert sis_profile['phoneNumber'] == '415/123-4567'
-        assert len(sis_profile['plans']) == 2
-        assert sis_profile['plans'][0]['description'] == 'English BA'
-        assert sis_profile['plans'][0]['program'] == 'Undergrad Letters & Science'
-        assert sis_profile['plans'][0]['degreeProgramUrl'] == 'http://guide.berkeley.edu/undergraduate/degree-programs/english/'
-        assert sis_profile['plans'][1]['description'] == 'Nuclear Engineering BS'
-        assert sis_profile['plans'][1]['program'] == 'Engineering'
-        assert sis_profile['plans'][1]['degreeProgramUrl'] == 'http://guide.berkeley.edu/undergraduate/degree-programs/nuclear-engineering/'
-        assert sis_profile['preferredName'] == 'Osk Bear'
-        assert sis_profile['primaryName'] == 'Oski Bear'
-        assert sis_profile['termsInAttendance'] == 5
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            sis_profile = student['sisProfile']
+            assert sis_profile['academicCareer'] == 'UGRD'
+            assert sis_profile['cumulativeGPA'] == 3.8
+            assert sis_profile['cumulativeUnits'] == 101.3
+            assert sis_profile['degreeProgress']['requirements']['americanCultures']['status'] == 'In Progress'
+            assert sis_profile['degreeProgress']['requirements']['americanHistory']['status'] == 'Not Satisfied'
+            assert sis_profile['degreeProgress']['requirements']['americanInstitutions']['status'] == 'Not Satisfied'
+            assert sis_profile['degreeProgress']['requirements']['entryLevelWriting']['status'] == 'Satisfied'
+            assert sis_profile['emailAddress'] == 'oski@berkeley.edu'
+            assert sis_profile['level']['code'] == '30'
+            assert sis_profile['level']['description'] == 'Junior'
+            assert sis_profile['phoneNumber'] == '415/123-4567'
+            assert len(sis_profile['plans']) == 2
+            assert sis_profile['plans'][0]['description'] == 'English BA'
+            assert sis_profile['plans'][0]['program'] == 'Undergrad Letters & Science'
+            assert sis_profile['plans'][0]['degreeProgramUrl'] == 'http://guide.berkeley.edu/undergraduate/degree-programs/english/'
+            assert sis_profile['plans'][1]['description'] == 'Nuclear Engineering BS'
+            assert sis_profile['plans'][1]['program'] == 'Engineering'
+            assert sis_profile['plans'][1]['degreeProgramUrl'] == 'http://guide.berkeley.edu/undergraduate/degree-programs/nuclear-engineering/'
+            assert sis_profile['preferredName'] == 'Osk Bear'
+            assert sis_profile['primaryName'] == 'Oski Bear'
+            assert sis_profile['termsInAttendance'] == 5
 
-    def test_sis_profile_expected_graduation_term(self, authenticated_response):
+    def test_sis_profile_expected_graduation_term(self, client, coe_advisor_login):
         """Provides the last of any expected graduation terms listed in SIS profile."""
-        sis_profile = authenticated_response.json['sisProfile']
-        assert sis_profile['expectedGraduationTerm']['id'] == '2198'
-        assert sis_profile['expectedGraduationTerm']['name'] == 'Fall 2019'
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            sis_profile = student['sisProfile']
+            assert sis_profile['expectedGraduationTerm']['id'] == '2198'
+            assert sis_profile['expectedGraduationTerm']['name'] == 'Fall 2019'
 
-    def test_athletics_profile_non_asc(self, authenticated_response):
+    def test_athletics_profile_non_asc(self, client, coe_advisor_login):
         """Does not include athletics profile for non-ASC users."""
-        assert 'athleticsProfile' not in authenticated_response.json
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            assert 'athleticsProfile' not in student
 
-    def test_athletics_profile_asc(self, asc_authenticated_response):
+    def test_athletics_profile_asc(self, asc_advisor_login, client):
         """Includes athletics profile for ASC users."""
-        response = asc_authenticated_response.json
-        assert 'coeProfile' not in response
-        athletics_profile = response['athleticsProfile']
-        assert athletics_profile['inIntensiveCohort'] is True
-        assert len(athletics_profile['athletics']) == 2
-        hockey = next(a for a in athletics_profile['athletics'] if a['groupCode'] == 'WFH')
-        assert hockey['groupName'] == 'Women\'s Field Hockey'
-        assert hockey['teamCode'] == 'FHW'
-        assert hockey['teamName'] == 'Women\'s Field Hockey'
-        tennis = next(a for a in athletics_profile['athletics'] if a['groupCode'] == 'WTE')
-        assert tennis['groupName'] == 'Women\'s Tennis'
-        assert tennis['teamCode'] == 'TNW'
-        assert tennis['teamName'] == 'Women\'s Tennis'
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            assert 'coeProfile' not in student
+            athletics_profile = student['athleticsProfile']
+            assert athletics_profile['inIntensiveCohort'] is True
+            assert len(athletics_profile['athletics']) == 2
+            hockey = next(a for a in athletics_profile['athletics'] if a['groupCode'] == 'WFH')
+            assert hockey['groupName'] == 'Women\'s Field Hockey'
+            assert hockey['teamCode'] == 'FHW'
+            assert hockey['teamName'] == 'Women\'s Field Hockey'
+            tennis = next(a for a in athletics_profile['athletics'] if a['groupCode'] == 'WTE')
+            assert tennis['groupName'] == 'Women\'s Tennis'
+            assert tennis['teamCode'] == 'TNW'
+            assert tennis['teamName'] == 'Women\'s Tennis'
 
-    def test_college_of_engineering_profile(self, coe_advisor, coe_authenticated_response):
+    def test_college_of_engineering_profile(self, client, coe_advisor_login):
         """Includes COE profile (eg, PREP) for COE students."""
-        response = coe_authenticated_response.json
-        assert 'athleticsProfile' not in response
-        assert 'coeProfile' in response
-        coe_profile = response['coeProfile']
-        assert coe_profile == {
-            'advisorUid': '1133399',
-            'gender': 'F',
-            'ethnicity': 'B',
-            'minority': True,
-            'didPrep': False,
-            'prepEligible': True,
-            'didTprep': False,
-            'tprepEligible': False,
-            'sat1read': 510,
-            'sat2read': 520,
-            'sat2math': 620,
-            'inMet': False,
-            'gradTerm': 'sp',
-            'gradYear': '2020',
-            'probation': False,
-            'status': 'C',
-            'isActiveCoe': True,
-        }
+        sid = self.coe_student['sid']
+        uid = self.coe_student['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            assert 'athleticsProfile' not in student
+            assert 'coeProfile' in student
+            coe_profile = student['coeProfile']
+            assert coe_profile == {
+                'advisorUid': '1133399',
+                'gender': 'F',
+                'ethnicity': 'B',
+                'minority': True,
+                'didPrep': False,
+                'prepEligible': True,
+                'didTprep': False,
+                'tprepEligible': False,
+                'sat1read': 510,
+                'sat2read': 520,
+                'sat2math': 620,
+                'inMet': False,
+                'gradTerm': 'sp',
+                'gradYear': '2020',
+                'probation': False,
+                'status': 'C',
+                'isActiveCoe': True,
+            }
 
-    def test_athletics_profile_admin(self, admin_authenticated_response):
+    def test_athletics_profile_admin(self, admin_login, client):
         """Includes athletics profile for admins."""
-        athletics_profile = admin_authenticated_response.json['athleticsProfile']
-        assert athletics_profile['inIntensiveCohort'] is True
-        assert len(athletics_profile['athletics']) == 2
+        sid = self.asc_student_in_coe['sid']
+        uid = self.asc_student_in_coe['uid']
+        student_by_sid = self._api_student_by_sid(client=client, sid=sid)
+        student_by_uid = self._api_student_by_uid(client=client, uid=uid)
+        for student in [student_by_sid, student_by_uid]:
+            athletics_profile = student['athleticsProfile']
+            assert athletics_profile['inIntensiveCohort'] is True
+            assert len(athletics_profile['athletics']) == 2
 
 
 class TestAlerts:
@@ -711,7 +801,7 @@ class TestAlerts:
 
     @classmethod
     def _get_alerts(cls, client, uid):
-        response = client.get(f'/api/student/{uid}')
+        response = client.get(f'/api/student/by_uid/{uid}')
         assert response.status_code == 200
         return response.json['notifications']['alert']
 
@@ -741,7 +831,7 @@ class TestNotes:
         """Returns a BOAC-created note."""
         author_uid = coe_advising_note_with_attachment.author_uid
         fake_auth.login(author_uid)
-        response = client.get('/api/student/61889')
+        response = client.get('/api/student/by_uid/61889')
         assert response.status_code == 200
         notes = response.json.get('notifications', {}).get('note')
         assert len(notes)
@@ -759,7 +849,7 @@ class TestNotes:
         """Returns a legacy note."""
         coe_advisor_uid = '1133399'
         fake_auth.login(coe_advisor_uid)
-        response = client.get('/api/student/61889')
+        response = client.get('/api/student/by_uid/61889')
         assert response.status_code == 200
         notes = response.json.get('notifications', {}).get('note')
         assert len(notes)
@@ -828,11 +918,11 @@ class TestValidateSids:
         """Requires authentication."""
         self._api_validate_sids(client, expected_status_code=401)
 
-    def test_validate_sids_with_invalid_sid(self, client, coe_advisor):
+    def test_validate_sids_with_invalid_sid(self, client, coe_advisor_login):
         """Complains about non-numeric SID."""
         self._api_validate_sids(client, sids=['7890123456', 'ABC'], expected_status_code=400)
 
-    def test_validate_sids_with_some_invalid(self, client, coe_advisor):
+    def test_validate_sids_with_some_invalid(self, client, coe_advisor_login):
         """SID status is 401 if advisor is not authorized to view student's profile."""
         api_json = self._api_validate_sids(
             client,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2279

On front-end, our vue mixin `EditNoteSession` is now `StudentEditSession`, lending itself to a nice code pattern whereby student profile can be refreshed when, for example, a note is created via batch-create. Using `$eventHub` to emit events was not a good solution here.

In order to make this work we needed two small BOA API changes: (1) `/api/student` takes SID instead of UID and (2) if create note is  "batch-mode" then server always return an array of SIDs.

IMO, it's a fairly intuitive arrangement.