### PR TITLE
BOAC-2279, efficient use of eventHub.emit to update AcademicTimeline with new note

### DIFF
--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -227,6 +227,11 @@ def get_summary_student_profiles(sids, term_id=None):
     return profiles
 
 
+def is_current_user_authorized_to_view_student(sid):
+    # TODO: Remove this when we've de-silo'ed advisor access to students
+    return data_loch.get_student_by_sid(sid, get_student_query_scope()) is not None
+
+
 def get_student_and_terms_by_sid(sid):
     student = data_loch.get_student_by_sid(sid, get_student_query_scope())
     return _construct_student_profile(student)

--- a/boac/models/note_read.py
+++ b/boac/models/note_read.py
@@ -58,3 +58,8 @@ class NoteRead(db.Model):
     @classmethod
     def get_notes_read_by_user(cls, viewer_id, note_ids):
         return cls.query.filter(NoteRead.viewer_id == viewer_id, NoteRead.note_id.in_(note_ids)).all()
+
+    @classmethod
+    def when_user_read_note(cls, viewer_id, note_id):
+        note_read = cls.query.filter(NoteRead.viewer_id == viewer_id, NoteRead.note_id == note_id).first()
+        return note_read and note_read.created_at

--- a/src/api/api-utils.ts
+++ b/src/api/api-utils.ts
@@ -3,6 +3,7 @@ import store from "@/store";
 import axios from "axios";
 
 export default {
+  apiBaseUrl: () => store.getters['context/apiBaseUrl'],
   postMultipartFormData: (
     path: string,
     data: object

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -315,6 +315,19 @@ export default {
     this.sortMessages();
     this.alertScreenReader('Academic Timeline has loaded');
     this.isTimelineLoading = false;
+    this.$eventHub.$on('advising-note-created', note => {
+      if (note.sid === this.student.sid) {
+        const currentNoteIds = this.map(this.filterList(this.messages, ['type', 'note']), 'id');
+        const isNotInView = !this.includes(currentNoteIds, note.id);
+        if (isNotInView) {
+          note.transientId = new Date().getTime();
+          this.messages.push(note);
+          this.countsPerType.note++;
+          this.sortMessages();
+          this.alertScreenReader(`New advising note created for student ${this.student.sid}.`);
+        }
+      }
+    });
   },
   mounted() {
     if (this.anchor) {
@@ -424,16 +437,8 @@ export default {
         ? this.filterList(this.messages, ['type', type])
         : this.messages;
     },
-    onCreateAdvisingNote(note) {
+    onCreateAdvisingNote() {
       this.creatingNewNote = false;
-      note.type = 'note';
-      note.message = note.body;
-      note.transientId = new Date().getTime();
-      this.messages.push(note);
-      this.countsPerType.note++;
-      this.sortMessages();
-      this.openMessages.push(note.transientId);
-      this.gaNoteEvent(note.id, `Advisor ${this.user.uid} created note`, 'create');
     },
     onSubmitAdvisingNote() {
       this.creatingNewNote = true;

--- a/src/mixins/StudentEditSession.vue
+++ b/src/mixins/StudentEditSession.vue
@@ -15,7 +15,6 @@ export default {
       'editExistingNoteId',
       'endSession',
       'setNewNoteMode',
-      'setReloadStudentBySidFunction',
       'setSid'
     ])
   }

--- a/src/store/modules/student-edit-session.ts
+++ b/src/store/modules/student-edit-session.ts
@@ -6,7 +6,6 @@ const VALID_MODES = ['advanced', 'batch', 'docked', 'minimized', 'saving'];
 const state = {
   editingNoteId: undefined,
   newNoteMode: undefined,
-  reloadStudentBySidFunction: undefined,
   sid: undefined,
   suggestedTopics: undefined
 };
@@ -14,7 +13,6 @@ const state = {
 const getters = {
   editingNoteId: (state: any): number => state.editingNoteId,
   newNoteMode: (state: any): string => state.newNoteMode,
-  reloadStudentBySidFunction: (state: any): Function => state.reloadStudentBySidFunction,
   sid: (state: any): string => state.sid,
   suggestedTopics: (state: any): any[] => state.suggestedTopics
 };
@@ -31,7 +29,6 @@ const mutations = {
       throw new TypeError('Invalid mode: ' + mode);
     }
   },
-  setReloadStudentBySidFunction: (state: any, fct: Function) => (state.reloadStudentBySidFunction = fct),
   setSid: (state: any, sid: string) => (state.sid = sid),
   setSuggestedTopics: (state: any, topics: any[]) => (state.suggestedTopics = topics)
 };
@@ -50,7 +47,6 @@ const actions = {
       commit('setNewNoteMode', mode);
     }
   },
-  setReloadStudentBySidFunction: ({ commit }, fct: Function) => commit('setReloadStudentBySidFunction', fct),
   setSid: ({ commit }, sid: string) => commit('setSid', sid)
 };
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2279

Both "batch" and standard note creation use `eventHub.emit` tactic (instead of mixin) to refresh notes list in student's profile. My earlier concerns w/ listener-related memory leak were assuaged.

(I'm keeping the unused `/api/student/by_sid/<sid>` in place, for now.)