### PR TITLE
BOAC-2379 All advisors can see all students, but not all per-student data

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -30,7 +30,6 @@ from boac.externals import data_loch
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import is_int, process_input_from_rich_text_editor
 from boac.merged.advising_note import get_boa_attachment_stream, get_legacy_attachment_stream, note_to_compatible_json
-from boac.merged.student import is_current_user_authorized_to_view_student
 from boac.models.cohort_filter import CohortFilter
 from boac.models.curated_group import CuratedGroup
 from boac.models.note import Note
@@ -43,12 +42,8 @@ from flask_login import current_user, login_required
 @app.route('/api/note/<note_id>')
 @login_required
 def get_note(note_id):
-    def _current_user_is_authorized(_note):
-        # TODO: Remove this when we've de-silo'ed advisor access to students
-        return current_user.is_admin or is_current_user_authorized_to_view_student(_note.sid)
-
     note = Note.find_by_id(note_id=note_id)
-    if not note or not _current_user_is_authorized(note):
+    if not note:
         raise ResourceNotFoundError('Note not found')
     note_read = NoteRead.when_user_read_note(current_user.get_id(), str(note.id))
     return tolerant_jsonify(_boa_note_to_compatible_json(note=note, note_read=note_read))

--- a/boac/api/student_controller.py
+++ b/boac/api/student_controller.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
 from boac.api.util import add_alert_counts, is_unauthorized_search, put_notifications
-from boac.externals.data_loch import extract_valid_sids, match_students_by_name_or_sid
+from boac.externals.data_loch import match_students_by_name_or_sid
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
 from boac.merged.student import get_student_and_terms_by_sid, get_student_and_terms_by_uid, query_students
@@ -127,13 +127,10 @@ def validate_sids():
         else:
             summary = []
             available_sids = query_students(sids=sids, sids_only=True)['sids']
-            unavailable_sids = list(filter(lambda sid: sid not in available_sids, sids))
-            # TODO: Remove the following when all advisors have access to all students
-            valid_yet_unavailable_sids = [row['sid'] for row in extract_valid_sids(unavailable_sids)]
             for sid in sids:
                 summary.append({
                     'sid': sid,
-                    'status': 200 if sid in available_sids else (401 if sid in valid_yet_unavailable_sids else 404),
+                    'status': 200 if sid in available_sids else 404,
                 })
             return tolerant_jsonify(summary)
     else:

--- a/boac/lib/cohort_filter_definition.py
+++ b/boac/lib/cohort_filter_definition.py
@@ -350,7 +350,7 @@ def _genders():
 
 
 def _grad_terms():
-    term_ids = [r['expected_grad_term'] for r in data_loch.get_expected_graduation_terms(get_student_query_scope())]
+    term_ids = [r['expected_grad_term'] for r in data_loch.get_expected_graduation_terms()]
     return [{'name': term_name_for_sis_id(term_id), 'value': term_id} for term_id in term_ids]
 
 
@@ -380,8 +380,8 @@ def _team_groups():
 
 
 def _majors():
-    relevant_majors = [row['major'] for row in data_loch.get_majors(get_student_query_scope())]
-    return [{'name': major, 'value': major} for major in relevant_majors]
+    major_results = [row['major'] for row in data_loch.get_majors()]
+    return [{'name': major, 'value': major} for major in major_results]
 
 
 def _get_dept_codes(user):

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -130,10 +130,9 @@ class Note(Base):
         return note_ids_per_sid
 
     @classmethod
-    def search(cls, search_phrase, sid_filter, author_csid, topic, datetime_from, datetime_to):
+    def search(cls, search_phrase, author_csid, student_csid, topic, datetime_from, datetime_to):
         params = {
             'search_phrase': search_phrase,
-            'sid_filter': sid_filter,
         }
         author_uid = get_uid_for_csid(app, author_csid) if author_csid else None
         if author_uid:
@@ -141,6 +140,12 @@ class Note(Base):
             params.update({'author_uid': author_uid})
         else:
             author_filter = ''
+
+        if student_csid:
+            student_filter = 'AND notes.sid = :student_csid'
+            params.update({'student_csid': student_csid})
+        else:
+            student_filter = ''
 
         date_filter = ''
         if datetime_from:
@@ -163,8 +168,8 @@ class Note(Base):
             ) AS fts
             JOIN notes
                 ON fts.id = notes.id
-                AND notes.sid = ANY(:sid_filter)
                 {author_filter}
+                {student_filter}
                 {date_filter}
             {topic_join}
             ORDER BY fts.rank DESC, notes.id

--- a/src/mixins/StudentMetadata.vue
+++ b/src/mixins/StudentMetadata.vue
@@ -12,8 +12,8 @@ export default {
       return (
         user &&
         (
-          (user.isAsc && !_.get(student, 'athleticsProfile.isActiveAsc')) ||
-          (user.isCoe && !_.get(student, 'coeProfile.isActiveCoe'))
+          (user.isAsc && _.get(student, 'athleticsProfile') && !_.get(student, 'athleticsProfile.isActiveAsc')) ||
+          (user.isCoe && _.get(student, 'coeProfile') && !_.get(student, 'coeProfile.isActiveCoe'))
         )
       );
     },

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -394,31 +394,6 @@ class TestCohortCreate:
         api_json = self._post_cohort_create(client, data)
         assert len(api_json['students']) == 2
 
-    def test_cohorts_respect_creators(self, client, fake_auth):
-        """Even under an admin view, cohorts constrain their membership by who created them."""
-        def _create_cohort(uid):
-            fake_auth.login(uid)
-            return self._post_cohort_create(
-                client,
-                {
-                    'name': 'Sophomores',
-                    'filters': [
-                        {'key': 'levels', 'type': 'array', 'value': 'Sophomore'},
-                    ],
-                },
-            )
-        asc_cohort_id = _create_cohort(asc_advisor_uid)['id']
-        coe_cohort_id = _create_cohort(coe_advisor_uid)['id']
-        admin_cohort_id = _create_cohort(admin_uid)['id']
-
-        def _count_students(cohort_id):
-            api_json = self._api_cohort(client, cohort_id)
-            return len(api_json['students'])
-
-        assert _count_students(asc_cohort_id) == 1
-        assert _count_students(coe_cohort_id) == 2
-        assert _count_students(admin_cohort_id) == 3
-
     def test_create_complex_cohort(self, client, coe_advisor_session):
         """Creates custom cohort, with many non-empty filter_criteria."""
         data = {

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -70,11 +70,6 @@ class TestGetNote:
         """Returns 401 if not authenticated."""
         self._api_note_by_id(client=client, note_id=new_coe_note.id, expected_status_code=401)
 
-    def test_not_authorized(self, app, client, fake_auth, new_coe_note):
-        """Returns 404 if not authorized."""
-        fake_auth.login(asc_advisor_uid)
-        self._api_note_by_id(client=client, note_id=new_coe_note.id, expected_status_code=404)
-
     def test_get_note_by_id(self, app, client, fake_auth, new_coe_note):
         """Returns note in JSON compatible with BOA front-end."""
         fake_auth.login(coe_advisor_uid)
@@ -599,13 +594,6 @@ class TestStreamNoteAttachments:
             assert response.headers['Content-Type'] == 'application/octet-stream'
             assert response.headers['Content-Disposition'] == "attachment; filename*=UTF-8''dog_eaten_homework.pdf"
             assert response.data == b'When in the course of human events, it becomes necessarf arf woof woof woof'
-
-    def test_stream_attachment_reports_unauthorized_files_not_found(self, app, client, fake_auth):
-        with mock_legacy_note_attachment(app):
-            fake_auth.login(asc_advisor_uid)
-            response = client.get('/api/notes/attachment/9000000000_00002_1.pdf')
-            assert response.status_code == 404
-            assert response.data == b'Sorry, attachment not available.'
 
     def test_stream_attachment_reports_missing_files_not_found(self, app, client, fake_auth):
         with mock_legacy_note_attachment(app):

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -334,7 +334,7 @@ class TestMergedAdvisingNote:
             )
         fake_auth.login(coe_advisor)
         wide_response = search_advising_notes(search_phrase='student')
-        assert len(wide_response) == 4
+        assert len(wide_response) == 5
         narrow_response = search_advising_notes(search_phrase='student', student_csid='9100000000')
         assert len(narrow_response) == 2
         new_note, legacy_note = narrow_response[0], narrow_response[1]
@@ -420,11 +420,6 @@ class TestMergedAdvisingNote:
             for chunk in stream:
                 body += chunk
             assert body == b'When in the course of human events, it becomes necessarf arf woof woof woof'
-
-    def test_stream_attachment_respects_scope_constraints(self, app, fake_auth):
-        with mock_legacy_note_attachment(app):
-            fake_auth.login(asc_advisor)
-            assert get_legacy_attachment_stream('9000000000_00002_1.pdf') is None
 
     def test_stream_attachment_handles_malformed_filename(self, app):
         with mock_legacy_note_attachment(app):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2379

Our concept of "scope" doesn't go away, but it now has less to do. A search for students via name or cohort filter now pulls in all students that BOA knows about, with their profiles and advising notes accessible, no matter who you are.

Restrictions that remain in place:
 - Advisors can't view cohorts belonging to other departments.
 - Advisors can't perform cohort searches with data from other departments as a criterion.
 - Advisors don't see data from other departments in student feeds.