### PR TITLE
Revert: BOAC-2168, 'Gender' cohort filter for all

### DIFF
--- a/boac/api/menu_controller.py
+++ b/boac/api/menu_controller.py
@@ -1,0 +1,44 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.lib.cohort_filter_definition import get_cohort_filter_options, translate_cohort_filter
+from boac.lib.http import tolerant_jsonify
+from boac.lib.util import get as get_param
+from flask import current_app as app, request
+from flask_login import login_required
+
+
+@app.route('/api/menu/cohort/all_filter_options', methods=['POST'])
+@login_required
+def all_cohort_filter_options():
+    existing_filters = get_param(request.get_json(), 'existingFilters', [])
+    return tolerant_jsonify(get_cohort_filter_options(existing_filters))
+
+
+@app.route('/api/menu/cohort/translate_filter_criteria_to_menu', methods=['POST'])
+@login_required
+def translate_cohort_filter_to_menu():
+    criteria = get_param(request.get_json(), 'criteria')
+    return tolerant_jsonify(translate_cohort_filter(criteria))

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -215,7 +215,7 @@ def is_unauthorized_search(filter_keys, order_by):
     if list(filter_key_set & asc_keys) or order_by in ['group_name']:
         if not current_user.is_asc_authorized:
             return True
-    coe_keys = {'advisorLdapUids', 'coePrepStatuses', 'coeProbation', 'ethnicities', 'isInactiveCoe'}
+    coe_keys = {'advisorLdapUids', 'coePrepStatuses', 'coeProbation', 'ethnicities', 'genders', 'isInactiveCoe'}
     if list(filter_key_set & coe_keys):
         if not current_user.is_coe_authorized:
             return True

--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -540,10 +540,6 @@ def get_ethnicity_codes(scope=()):
         """)
 
 
-def get_distinct_genders():
-    return safe_execute_rds(f'SELECT DISTINCT gender FROM {student_schema()}.demographics ORDER BY gender')
-
-
 def get_expected_graduation_terms():
     sql = f"""SELECT DISTINCT expected_grad_term FROM {student_schema()}.student_academic_status
         ORDER BY expected_grad_term"""
@@ -607,8 +603,6 @@ def get_students_query(     # noqa
                         AND n{i}.sid = sas.sid"""
                 word = ''.join(re.split('\W', word))
                 query_bindings.update({f'name_phrase_{i}': f'{word}%'})
-    if genders:
-        query_tables += f""" JOIN {student_schema()}.demographics d ON d.sid = sas.sid"""
     if sids:
         query_filter += f' AND sas.sid = ANY(:sids)'
         query_bindings.update({'sids': sids})
@@ -658,7 +652,7 @@ def get_students_query(     # noqa
         query_filter += ' AND s.ethnicity = ANY(:ethnicities)'
         query_bindings.update({'ethnicities': ethnicities})
     if genders:
-        query_filter += ' AND d.gender = ANY(:genders)'
+        query_filter += ' AND s.gender = ANY(:genders)'
         query_bindings.update({'genders': genders})
     query_filter += f' AND s.probation IS {coe_probation}' if coe_probation is not None else ''
     query_filter += f' AND s.minority IS {underrepresented}' if underrepresented is not None else ''
@@ -809,6 +803,7 @@ def _student_query_tables_for_scope(scope):
                     'did_prep',
                     'did_tprep',
                     'ethnicity',
+                    'gender',
                     'minority',
                     'prep_eligible',
                     'probation',

--- a/boac/lib/cohort_filter_definition.py
+++ b/boac/lib/cohort_filter_definition.py
@@ -33,49 +33,7 @@ from boac.merged.student import get_student_query_scope
 from boac.models.authorized_user import AuthorizedUser
 
 
-def translate_to_filter_options(criteria=None):
-    rows = []
-    if criteria:
-        for definitions in _get_filter_options(get_student_query_scope()):
-            for definition in definitions:
-                selected = criteria.get(definition['key'])
-                if selected is not None:
-                    if definition['type'] == 'array':
-                        for selection in selected:
-                            rows.append(_translate_filter_row(definition, selection))
-                    else:
-                        rows.append(_translate_filter_row(definition, selected))
-    return rows
-
-
-def get_cohort_filter_options(existing_filters):
-    # Default menu has all options available.
-    filter_categories = _get_filter_options(get_student_query_scope())
-    menus = [menu for category in filter_categories for menu in category]
-    for key in _keys_of_type_boolean(existing_filters):
-        # Disable sub_menu options if they are already in cohort criteria
-        for menu in menus:
-            if menu['key'] == key:
-                # Disable 'boolean' sub_menu (e.g., 'isInactiveCoe') if it is already in cohort criteria
-                menu['disabled'] = True
-    # Get filters of type 'range' (e.g., 'last name')
-    for key, values in _selections_of_type('range', existing_filters).items():
-        menu = next(s for s in menus if s['key'] == key)
-        menu['disabled'] = True
-    # Get filters of type 'array' (e.g., 'levels')
-    for key, values in _selections_of_type('array', existing_filters).items():
-        menu = next(s for s in menus if s['key'] == key)
-        if len(values) == len(menu['options']):
-            # If count of selected values equals number of options then disable the sub_menu
-            menu['disabled'] = True
-        for option in menu['options']:
-            if option['value'] in values:
-                # Disable sub_menu options that are already in cohort criteria
-                option['disabled'] = True
-    return filter_categories
-
-
-def _get_filter_options(scope):
+def get_cohort_filter_definitions(scope):
     all_dept_codes = list(BERKELEY_DEPT_NAME_TO_CODE.values())
     categories = [
         [
@@ -154,7 +112,7 @@ def _get_filter_options(scope):
                 'type': 'array',
             },
             {
-                'availableTo': all_dept_codes,
+                'availableTo': ['COENG'],
                 'defaultValue': None,
                 'key': 'genders',
                 'name': 'Gender',
@@ -270,6 +228,48 @@ def _get_filter_options(scope):
     return list(filter(lambda g: len(g), available_categories))
 
 
+def translate_cohort_filter(criteria=None):
+    rows = []
+    if criteria:
+        for definitions in get_cohort_filter_definitions(get_student_query_scope()):
+            for definition in definitions:
+                selected = criteria.get(definition['key'])
+                if selected is not None:
+                    if definition['type'] == 'array':
+                        for selection in selected:
+                            rows.append(_translate_filter_row(definition, selection))
+                    else:
+                        rows.append(_translate_filter_row(definition, selected))
+    return rows
+
+
+def get_cohort_filter_options(existing_filters):
+    # Default menu has all options available.
+    filter_categories = get_cohort_filter_definitions(get_student_query_scope())
+    menus = [menu for category in filter_categories for menu in category]
+    for key in _keys_of_type_boolean(existing_filters):
+        # Disable sub_menu options if they are already in cohort criteria
+        for menu in menus:
+            if menu['key'] == key:
+                # Disable 'boolean' sub_menu (e.g., 'isInactiveCoe') if it is already in cohort criteria
+                menu['disabled'] = True
+    # Get filters of type 'range' (e.g., 'last name')
+    for key, values in _selections_of_type('range', existing_filters).items():
+        menu = next(s for s in menus if s['key'] == key)
+        menu['disabled'] = True
+    # Get filters of type 'array' (e.g., 'levels')
+    for key, values in _selections_of_type('array', existing_filters).items():
+        menu = next(s for s in menus if s['key'] == key)
+        if len(values) == len(menu['options']):
+            # If count of selected values equals number of options then disable the sub_menu
+            menu['disabled'] = True
+        for option in menu['options']:
+            if option['value'] in values:
+                # Disable sub_menu options that are already in cohort criteria
+                option['disabled'] = True
+    return filter_categories
+
+
 def _translate_filter_row(definition, selection=None):
     clone = deepcopy(definition)
     row = {k: clone.get(k) for k in ['key', 'name', 'options', 'subcategoryHeader', 'type']}
@@ -343,7 +343,10 @@ def _coe_prep_statuses():
 
 
 def _genders():
-    return [{'name': row['gender'], 'value': row['gender']} for row in data_loch.get_distinct_genders()]
+    return [
+        {'name': 'Female', 'value': 'F'},
+        {'name': 'Male', 'value': 'M'},
+    ]
 
 
 def _grad_terms():

--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -251,6 +251,7 @@ def query_students(
     advisor_ldap_uids=None,
     coe_prep_statuses=None,
     coe_probation=None,
+    cohort_owner=None,
     ethnicities=None,
     expected_grad_terms=None,
     genders=None,
@@ -443,6 +444,7 @@ def scope_for_criteria(**kwargs):
             'coe_prep_statuses',
             'coe_probation',
             'ethnicities',
+            'genders',
             'underrepresented',
         ],
     }

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -294,12 +294,17 @@ class CohortFilter(Base, UserMixin):
             benchmark('end')
             return cohort_json
 
+        # Until we remove per-department siloing, cohort membership queries are constrained by the cohort owner, which
+        # is a single user per present UX.
+        cohort_owner = self.owners[0] if len(self.owners) else None
+
         benchmark('begin students query')
         sids_only = not include_students
         results = query_students(
             advisor_ldap_uids=advisor_ldap_uids,
             coe_prep_statuses=coe_prep_statuses,
             coe_probation=coe_probation,
+            cohort_owner=cohort_owner,
             ethnicities=ethnicities,
             expected_grad_terms=expected_grad_terms,
             genders=genders,

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -46,6 +46,7 @@ def register_routes(app):
     import boac.api.config_controller
     import boac.api.course_controller
     import boac.api.curated_group_controller
+    import boac.api.menu_controller
     import boac.api.notes_controller
     import boac.api.search_controller
     import boac.api.student_controller

--- a/fixtures/loch.sql
+++ b/fixtures/loch.sql
@@ -187,13 +187,6 @@ CREATE TABLE sis_data.sis_terms
     session_ends DATE NOT NULL
 );
 
-CREATE TABLE student.demographics
-(
-    sid VARCHAR NOT NULL,
-    gender VARCHAR NOT NULL,
-    minority BOOLEAN NOT NULL
-);
-
 CREATE TABLE student.student_holds
 (
     sid VARCHAR NOT NULL,
@@ -483,19 +476,6 @@ VALUES
 ('2168', '2016 Fall', 'GRAD', '2016-08-17', '2016-12-16', '1', 'Regular Academic Session', '2016-08-24', '2016-12-09'),
 ('2168', '2016 Fall', 'UCBX', '2016-08-17', '2016-12-16', '1', 'Regular Academic Session', '2016-08-24', '2016-12-09'),
 ('2168', '2016 Fall', 'UGRD', '2016-08-17', '2016-12-16', '1', 'Regular Academic Session', '2016-08-24', '2016-12-09');
-
-INSERT INTO student.demographics
-(sid, gender, minority)
-VALUES
-('11667051', 'Different Identity', FALSE),
-('2345678901', 'Decline to State', FALSE),
-('3456789012', 'Male', FALSE),
-('5678901234', 'Male', FALSE),
-('7890123456', 'Female', TRUE),
-('8901234567', 'Different Identity', FALSE),
-('890127492', 'Genderqueer/Gender Non-Conform', FALSE),
-('9000000000', 'Female', TRUE),
-('9100000000', 'Different Identity', FALSE);
 
 INSERT INTO student.student_holds
 (sid, feed)

--- a/src/api/cohort.ts
+++ b/src/api/cohort.ts
@@ -39,14 +39,6 @@ export function getCohort(
     .then(response => response.data, () => null);
 }
 
-export function getCohortFilterOptions(existingFilters: any[]) {
-  return axios
-    .post(`${utils.apiBaseUrl()}/api/cohort/filter_options`, {
-      existingFilters: existingFilters
-    })
-    .then(response => response.data, () => null);
-}
-
 export function getMyCohorts() {
   return axios
     .get(`${utils.apiBaseUrl()}/api/cohorts/my`)
@@ -97,10 +89,4 @@ export function saveCohort(
       store.dispatch('cohort/updateCohort', cohort);
       return cohort;
     }, () => null);
-}
-
-export function translateToFilterOptions(criteria: any) {
-  return axios
-    .post(`${utils.apiBaseUrl()}/api/cohort/translate_to_filter_options`, { criteria: criteria })
-    .then(response => response.data, () => null);
 }

--- a/src/api/menu.ts
+++ b/src/api/menu.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import utils from '@/api/api-utils';
+
+export function translateToMenu(criteria: any) {
+  return axios
+    .post(`${utils.apiBaseUrl()}/api/menu/cohort/translate_filter_criteria_to_menu`, { criteria: criteria })
+    .then(response => response.data, () => null);
+}
+
+export function getCohortFilterOptions(existingFilters: any[]) {
+  return axios
+    .post(`${utils.apiBaseUrl()}/api/menu/cohort/all_filter_options`, {
+      existingFilters: existingFilters
+    })
+    .then(response => response.data, () => null);
+}

--- a/src/store/modules/cohort-edit-session.ts
+++ b/src/store/modules/cohort-edit-session.ts
@@ -2,11 +2,10 @@ import _ from 'lodash';
 import {
   createCohort,
   getCohort,
-  getCohortFilterOptions,
   getStudentsPerFilters,
-  saveCohort,
-  translateToFilterOptions
+  saveCohort
 } from '@/api/cohort';
+import { getCohortFilterOptions, translateToMenu } from '@/api/menu';
 import router from '@/router';
 import store from '@/store';
 
@@ -198,7 +197,7 @@ const actions = {
     return new Promise(resolve => {
       getCohort(id, true, orderBy).then(cohort => {
         if (cohort) {
-          translateToFilterOptions(cohort.criteria).then(filters => {
+          translateToMenu(cohort.criteria).then(filters => {
             commit('resetSession', {
               cohort,
               filters: filters,

--- a/tests/test_api/test_menu_controller.py
+++ b/tests/test_api/test_menu_controller.py
@@ -1,0 +1,252 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import pytest
+import simplejson as json
+
+admin_uid = '2040'
+asc_advisor_uid = '1081940'
+coe_advisor_uid = '1133399'
+
+
+@pytest.fixture()
+def admin_session(fake_auth):
+    fake_auth.login(admin_uid)
+
+
+@pytest.fixture()
+def asc_advisor_session(fake_auth):
+    fake_auth.login(asc_advisor_uid)
+
+
+@pytest.fixture()
+def coe_advisor_session(fake_auth):
+    fake_auth.login(coe_advisor_uid)
+
+
+class TestAllCohortFilterOptions:
+    """Menu API."""
+
+    @classmethod
+    def _post(cls, client, json_data=()):
+        return client.post(
+            '/api/menu/cohort/all_filter_options',
+            data=json.dumps(json_data),
+            content_type='application/json',
+        )
+
+    @classmethod
+    def _level_option(cls, student_class_level):
+        return {
+            'key': 'levels',
+            'type': 'array',
+            'value': student_class_level,
+        }
+
+    def test_menu_api_not_authenticated(self, client):
+        """Menu API cohort-filter-options requires authentication."""
+        assert self._post(client).status_code == 401
+
+    def test_menu_with_nothing_disabled(self, client, coe_advisor_session):
+        """Menu API with all menu options available."""
+        response = self._post(
+            client,
+            {
+                'existingFilters': [],
+            },
+        )
+        assert response.status_code == 200
+        for category in response.json:
+            for menu in category:
+                assert 'disabled' not in menu
+                if menu['type'] == 'array':
+                    for option in menu['options']:
+                        assert 'disabled' not in option
+
+    def test_menu_with_category_disabled(self, client, coe_advisor_session):
+        """The coe_probation option is disabled if it is in existing-filters."""
+        response = self._post(
+            client,
+            {
+                'existingFilters':
+                    [
+                        {
+                            'key': 'coeProbation',
+                            'type': 'boolean',
+                        },
+                    ],
+            },
+        )
+        assert response.status_code == 200
+        filter_categories = response.json
+        assert len(filter_categories) == 4
+        for category in filter_categories:
+            for menu in category:
+                if menu['key'] == 'coeProbation':
+                    assert menu['disabled'] is True
+                else:
+                    assert 'disabled' not in menu
+
+    def test_menu_with_disabled_option(self, client, coe_advisor_session):
+        """The 'Freshman' sub-menu option is disabled if it is already in cohort filter set."""
+        response = self._post(
+            client,
+            {
+                'existingFilters':
+                    [
+                        self._level_option('Freshman'),
+                        self._level_option('Sophomore'),
+                        self._level_option('Junior'),
+                        {
+                            'key': 'advisorLdapUids',
+                            'type': 'array',
+                            'value': '1022796',
+                        },
+                    ],
+            },
+        )
+        assert response.status_code == 200
+        filter_categories = response.json
+        assert len(filter_categories) == 4
+        assertion_count = 0
+        for category in filter_categories:
+            for menu in category:
+                # All top-level category menus are enabled
+                assert 'disabled' not in menu
+                if menu['key'] == 'levels':
+                    for option in menu['options']:
+                        disabled = option.get('disabled')
+                        if option['value'] in ['Freshman', 'Sophomore', 'Junior']:
+                            assert disabled is True
+                            assertion_count += 1
+                        else:
+                            assert disabled is None
+                else:
+                    assert 'disabled' not in menu
+        assert assertion_count == 3
+
+    def test_all_options_in_category_disabled(self, client, coe_advisor_session):
+        """Disable the category if all its options are in existing-filters."""
+        response = self._post(
+            client,
+            {
+                'existingFilters':
+                    [
+                        self._level_option('Senior'),
+                        self._level_option('Junior'),
+                        self._level_option('Sophomore'),
+                        self._level_option('Freshman'),
+                    ],
+            },
+        )
+        assert response.status_code == 200
+        for category in response.json:
+            for menu in category:
+                if menu['key'] == 'levels':
+                    assert menu.get('disabled') is True
+                    for option in menu['options']:
+                        assert option.get('disabled') is True
+                else:
+                    assert 'disabled' not in menu
+
+    def test_disable_last_name_range(self, client, coe_advisor_session):
+        """Disable the category if all its options are in existing-filters."""
+        response = self._post(
+            client,
+            {
+                'existingFilters':
+                    [
+                        {
+                            'key': 'lastNameRange',
+                            'type': 'range',
+                            'value': ['A', 'B'],
+                        },
+                    ],
+            },
+        )
+        assert response.status_code == 200
+        for category in response.json:
+            for menu in category:
+                is_disabled = menu.get('disabled')
+                if menu['key'] == 'lastNameRange':
+                    assert is_disabled is True
+                else:
+                    assert is_disabled is None
+
+
+class TestCohortFilterTranslate:
+    """Menu API."""
+
+    @classmethod
+    def _post(cls, client, json_data=()):
+        return client.post(
+            '/api/menu/cohort/translate_filter_criteria_to_menu',
+            data=json.dumps(json_data),
+            content_type='application/json',
+        )
+
+    def test_translate_criteria_when_empty(self, client, coe_advisor_session):
+        """Empty criteria translates to zero rows."""
+        response = self._post(client, {'criteria': {}})
+        assert response.status_code == 200
+        assert json.loads(response.data) == []
+
+    def test_translate_criteria_with_boolean(self, client, coe_advisor_session):
+        """Filter-criteria with boolean is properly translated."""
+        key = 'isInactiveCoe'
+        response = self._post(client, {'criteria': {key: False}})
+        assert response.status_code == 200
+        rows = json.loads(response.data)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row['name'] == 'Inactive'
+        assert row['key'] == key
+        assert row['value'] is False
+
+    def test_translate_criteria_with_array(self, client, coe_advisor_session):
+        """Filter-criteria with array is properly translated."""
+        key = 'levels'
+        selected_options = ['Freshman', 'Sophomore']
+        response = self._post(client, {'criteria': {key: selected_options}})
+        assert response.status_code == 200
+        rows = json.loads(response.data)
+        assert len(rows) == 2
+        assert rows[0]['name'] == rows[1]['name'] == 'Level'
+        assert rows[0]['key'] == rows[1]['key'] == key
+        assert rows[0]['value'] == 'Freshman'
+        assert rows[1]['value'] == 'Sophomore'
+
+    def test_translate_criteria_with_range(self, client, coe_advisor_session):
+        """Filter-criteria with range is properly translated."""
+        key = 'lastNameRange'
+        selected_options = ['M', 'Z']
+        response = self._post(client, {'criteria': {key: selected_options}})
+        assert response.status_code == 200
+        rows = json.loads(response.data)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row['name'] == 'Last Name'
+        assert row['key'] == key
+        assert row['value'] == selected_options

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -102,13 +102,7 @@ class TestCollegeOfEngineering:
 
     def test_authorized_request_for_gender(self, client, coe_advisor_login):
         """For now, only COE users can access gender data."""
-        response = self._api_students(
-            client,
-            {
-                'genders': ['Female'],
-                'orderBy': 'firstName',
-            },
-        )
+        response = self._api_students(client, {'genders': ['F']})
         assert response.status_code == 200
         students = response.json['students']
         assert len(students) == 2
@@ -123,7 +117,7 @@ class TestCollegeOfEngineering:
         response = self._api_students(
             client,
             {
-                'genders': ['Female'],
+                'genders': ['F'],
                 'isInactiveCoe': True,
             },
         )


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2168

This reverts PR #1711 

Expectation with gender and ethnicity/URM data is that the existing CoE filters should be renamed to include "(COE)" and moved to the department-specific filter section. COE advisors will have access to multiple gender filters.