### PR TITLE
BOAC-2496 Ignore planless advisor-student associations

### DIFF
--- a/boac/merged/cohort_filter_options.py
+++ b/boac/merged/cohort_filter_options.py
@@ -338,10 +338,7 @@ def _academic_plans_for_cohort_owner(owner_uid):
     for row in plan_results:
         value = row['academic_plan_code']
         if value:
-            name = row['academic_plan']
-        else:
-            name = row['[No plan]']
-        plans.append({'name': name, 'value': value})
+            plans.append({'name': row['academic_plan'], 'value': value})
     return plans
 
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2496

Most advisor-student associations from our SIS source are associated with an academic plan, but a handful of them represent the plan as either null or a blank string. Cohort filters aren't playing well with this state of affairs; let's suppress blank plans in the app and look into fixing the data upstream.