### PR TITLE
BOAC-2491, configurable redirect port for Google client

### DIFF
--- a/boac/externals/google_calendar_client.py
+++ b/boac/externals/google_calendar_client.py
@@ -99,7 +99,8 @@ def _get_credentials():
                     client_secrets_file,
                     SCOPES,
                 )
-                credentials = flow.run_local_server()
+                port = app.config['GOOGLE_CLIENT_REDIRECT_PORT']
+                credentials = flow.run_local_server(port=port)
             # TODO: Save the credentials in database?
             with open(token_pickle_path, 'wb') as token:
                 pickle.dump(credentials, token)

--- a/config/default.py
+++ b/config/default.py
@@ -45,6 +45,7 @@ FIXTURES_PATH = None
 
 # The following JSON is generated at https://console.developers.google.com/apis/credentials
 GOOGLE_CLIENT_SECRETS_JSON = 'config/google-client-secrets.json'
+GOOGLE_CLIENT_REDIRECT_PORT = 8088
 
 # Save DB changes at the end of a request.
 SQLALCHEMY_COMMIT_ON_TEARDOWN = True


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2491

See info on `run_local_server` at https://google-auth-oauthlib.readthedocs.io/en/latest/reference/google_auth_oauthlib.flow.html
