### PR TITLE
BOAC-2452: Sets inactivity lifespan on session cookie

### DIFF
--- a/boac/api/auth_controller.py
+++ b/boac/api/auth_controller.py
@@ -67,7 +67,7 @@ def cas_login():
         """)
         redirect_url = add_param_to_url('/', param)
     else:
-        login_user(user, remember=True)
+        login_user(user)
         flash('Logged in successfully.')
         # Check if url is safe for redirects per https://flask-login.readthedocs.io/en/latest/
         if not _is_safe_url(request.args.get('next')):

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -23,8 +23,10 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+import datetime
+
 from boac.merged.user_session import UserSession
-from flask import jsonify, make_response, redirect, request
+from flask import jsonify, make_response, redirect, request, session
 from flask_login import LoginManager
 
 
@@ -73,6 +75,12 @@ def register_routes(app):
     def front_end_route(**kwargs):
         vue_base_url = app.config['VUE_LOCALHOST_BASE_URL']
         return redirect(vue_base_url + request.full_path) if vue_base_url else make_response(index_html)
+
+    @app.before_request
+    def before_request():
+        session.permanent = True
+        app.permanent_session_lifetime = datetime.timedelta(minutes=app.config['INACTIVE_SESSION_LIFETIME'])
+        session.modified = True
 
     @app.after_request
     def after_api_request(response):

--- a/config/default.py
+++ b/config/default.py
@@ -60,6 +60,8 @@ CSRF_ENABLED = True
 CSRF_SESSION_KEY = 'secret'
 # Used to encrypt session cookie.
 SECRET_KEY = 'secret'
+# Minutes of inactivity before session cookie is destroyed
+INACTIVE_SESSION_LIFETIME = 60
 
 TIMEZONE = 'America/Los_Angeles'
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2452

The goal is to log a user out after they close the browser - this will also log them out if the browser hasn't made any requests for 60 minutes.

This will likely be annoying for developers; I recommend overriding `INACTIVE_SESSION_LIFETIME` in your local config.