### PR TITLE
[QA] BOAC-2574 Suppress null advising note topics from Redshift

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -415,6 +415,7 @@ def get_sis_advising_note_topics(sid):
     sql = f"""SELECT advising_note_id, note_topic
         FROM {advising_notes_schema()}.advising_note_topics
         WHERE sid=:sid
+        AND note_topic IS NOT NULL
         ORDER BY advising_note_id"""
     return safe_execute_redshift(sql, sid=sid)
 


### PR DESCRIPTION
QA-first PR for https://jira.ets.berkeley.edu/jira/browse/BOAC-2574.

https://github.com/ets-berkeley-edu/nessie/pull/505 cleared out null topics from RDS, but turns out BOA is still querying Redshift for notes. The right fix is to have BOA start querying RDS (and maybe keep null topics out of our internal Redshift as well). But rather than make an architectural change the day before release, this should plug the gap.