### PR TITLE
BOAC-2541, note_template/topic/attachment tables and SQLAlchemy models

### DIFF
--- a/boac/api/note_templates_controller.py
+++ b/boac/api/note_templates_controller.py
@@ -1,0 +1,41 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.api.errors import ForbiddenRequestError, ResourceNotFoundError
+from boac.lib.http import tolerant_jsonify
+from boac.models.note_template import NoteTemplate
+from flask import current_app as app
+from flask_login import current_user, login_required
+
+
+@app.route('/api/note_template/<note_template_id>')
+@login_required
+def get_note_template(note_template_id):
+    note_template = NoteTemplate.find_by_id(note_template_id=note_template_id)
+    if not note_template:
+        raise ResourceNotFoundError('Template not found')
+    if note_template.creator_id != current_user.get_id():
+        raise ForbiddenRequestError(f'Template not available')
+    return tolerant_jsonify(note_template.to_api_json())

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -163,3 +163,25 @@ def vacuum_whitespace(_str):
     if not _str:
         return None
     return ' '.join(_str.split())
+
+
+def get_attachment_filename(attachment_id, path_to_attachment):
+    raw_filename = path_to_attachment.rsplit('/', 1)[-1]
+    match = re.match(r'\A\d{8}_\d{6}_(.+)\Z', raw_filename)
+    if match:
+        return match[1]
+    else:
+        app.logger.warn(
+            f'Note attachment S3 filename did not match expected format: ID = {attachment_id}, filename = {raw_filename}')
+        return raw_filename
+
+
+def note_attachment_to_api_json(attachment):
+    filename = get_attachment_filename(attachment.id, attachment.path_to_attachment)
+    return {
+        'id': attachment.id,
+        'displayName': filename,
+        'filename': filename,
+        'noteId': attachment.note_id,
+        'uploadedBy': attachment.uploaded_by_uid,
+    }

--- a/boac/models/note_template.py
+++ b/boac/models/note_template.py
@@ -1,0 +1,108 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac import db, std_commit
+from boac.lib.util import titleize, vacuum_whitespace
+from boac.models.authorized_user import AuthorizedUser
+from boac.models.base import Base
+from boac.models.note_template_attachment import NoteTemplateAttachment
+from boac.models.note_template_topic import NoteTemplateTopic
+from dateutil.tz import tzutc
+from sqlalchemy import and_
+
+
+class NoteTemplate(Base):
+    __tablename__ = 'note_templates'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    creator_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False)
+    title = db.Column(db.String(255), nullable=False)
+    subject = db.Column(db.String(255), nullable=False)
+    body = db.Column(db.Text, nullable=False)
+    deleted_at = db.Column(db.DateTime, nullable=True)
+    topics = db.relationship(
+        'NoteTemplateTopic',
+        primaryjoin='and_(NoteTemplate.id==NoteTemplateTopic.note_template_id)',
+        back_populates='note_template',
+        lazy=True,
+    )
+    attachments = db.relationship(
+        'NoteTemplateAttachment',
+        primaryjoin='and_(NoteTemplate.id==NoteTemplateAttachment.note_template_id, NoteTemplateAttachment.deleted_at==None)',
+        back_populates='note_template',
+        lazy=True,
+    )
+
+    __table_args__ = (db.UniqueConstraint(
+        'creator_id',
+        'title',
+        name='student_groups_owner_id_name_unique_constraint',
+    ),)
+
+    def __init__(self, creator_id, title, subject, body):
+        self.creator_id = creator_id
+        self.title = title
+        self.subject = subject
+        self.body = body
+
+    @classmethod
+    def create(cls, creator_id, title, subject, body='', topics=(), attachments=()):
+        creator = AuthorizedUser.find_by_id(creator_id)
+        if creator:
+            note_template = cls(creator_id, title, subject, body)
+            for topic in topics:
+                note_template.topics.append(
+                    NoteTemplateTopic.create(note_template.id, titleize(vacuum_whitespace(topic))),
+                )
+            for byte_stream_bundle in attachments:
+                note_template.attachments.append(
+                    NoteTemplateAttachment.create(
+                        note_template_id=note_template.id,
+                        name=byte_stream_bundle['name'],
+                        byte_stream=byte_stream_bundle['byte_stream'],
+                        uploaded_by=creator.uid,
+                    ),
+                )
+            db.session.add(note_template)
+            std_commit()
+            return note_template
+
+    @classmethod
+    def find_by_id(cls, note_template_id):
+        return cls.query.filter(and_(cls.id == note_template_id, cls.deleted_at == None)).first()  # noqa: E711
+
+    def to_api_json(self):
+        attachments = [a.to_api_json() for a in self.attachments if not a.deleted_at]
+        topics = [t.to_api_json() for t in self.topics if not t.deleted_at]
+        return {
+            'id': self.id,
+            'attachments': attachments,
+            'title': self.title,
+            'subject': self.subject,
+            'body': self.body,
+            'topics': topics,
+            'createdAt': self.created_at.astimezone(tzutc()).isoformat(),
+            'updatedAt': self.updated_at.astimezone(tzutc()).isoformat(),
+        }

--- a/boac/models/note_template_topic.py
+++ b/boac/models/note_template_topic.py
@@ -1,0 +1,43 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac import db
+
+
+class NoteTemplateTopic(db.Model):
+    __tablename__ = 'note_template_topics'
+
+    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    note_template_id = db.Column(db.Integer, db.ForeignKey('note_templates.id'), nullable=False)
+    topic = db.Column(db.String(50), nullable=False)
+    note_template = db.relationship('NoteTemplate', back_populates='topics')
+
+    def __init__(self, note_template_id, topic):
+        self.note_template_id = note_template_id
+        self.topic = topic
+
+    @classmethod
+    def create_note_topic(cls, note_template_id, topic):
+        return cls(note_template_id=note_template_id, topic=topic)

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -48,6 +48,7 @@ def register_routes(app):
     import boac.api.config_controller
     import boac.api.course_controller
     import boac.api.curated_group_controller
+    import boac.api.note_templates_controller
     import boac.api.notes_controller
     import boac.api.search_controller
     import boac.api.student_controller

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -34,20 +34,23 @@ SET row_security = off;
 
 --
 
-ALTER TABLE IF EXISTS ONLY public.notes DROP CONSTRAINT IF EXISTS notes_author_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_alert_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_viewer_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_sid_fkey;
+ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_cohort_filter_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_user_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_note_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_note_id_path_to_attachment_unique_constraint;
-ALTER TABLE IF EXISTS ONLY public.note_topics DROP CONSTRAINT IF EXISTS note_topics_note_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.note_template_attachments DROP CONSTRAINT IF EXISTS note_template_attachments_note_template_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.note_template_topics DROP CONSTRAINT IF EXISTS note_template_topics_note_template_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.note_templates DROP CONSTRAINT IF EXISTS note_templates_creator_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.note_topics DROP CONSTRAINT IF EXISTS note_topics_author_uid_fkey;
+ALTER TABLE IF EXISTS ONLY public.note_topics DROP CONSTRAINT IF EXISTS note_topics_note_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.note_topics DROP CONSTRAINT IF EXISTS note_topics_note_id_topic_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.notes DROP CONSTRAINT IF EXISTS notes_author_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.notes_read DROP CONSTRAINT IF EXISTS notes_read_viewer_id_fkey;
-ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_user_id_fkey;
-ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_cohort_filter_id_fkey;
-ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_sid_fkey;
-ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_viewer_id_fkey;
-ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_alert_id_fkey;
-ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_student_group_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_sid_fkey;
+ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_student_group_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_owner_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_owner_id_name_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.university_dept_members DROP CONSTRAINT IF EXISTS university_dept_members_authorized_user_id_fkey;
@@ -56,49 +59,55 @@ ALTER TABLE IF EXISTS ONLY public.user_logins DROP CONSTRAINT IF EXISTS user_log
 
 --
 
-DROP INDEX IF EXISTS public.notes_author_id_idx;
-DROP INDEX IF EXISTS public.notes_sid_idx;
-DROP INDEX IF EXISTS public.note_attachments_note_id_idx;
-DROP INDEX IF EXISTS public.note_topics_topic_idx;
-DROP INDEX IF EXISTS public.note_topics_note_id_idx;
-DROP INDEX IF EXISTS public.notes_read_viewer_id_idx;
-DROP INDEX IF EXISTS public.notes_read_note_id_idx;
-DROP INDEX IF EXISTS public.alerts_sid_idx;
-DROP INDEX IF EXISTS public.alert_views_viewer_id_idx;
 DROP INDEX IF EXISTS public.alert_views_alert_id_idx;
+DROP INDEX IF EXISTS public.alert_views_viewer_id_idx;
+DROP INDEX IF EXISTS public.alerts_sid_idx;
+DROP INDEX IF EXISTS public.idx_notes_fts_index;
+DROP INDEX IF EXISTS public.note_attachments_note_id_idx;
+DROP INDEX IF EXISTS public.note_template_attachments_note_template_id_idx;
+DROP INDEX IF EXISTS public.note_template_topics_note_template_id_idx;
+DROP INDEX IF EXISTS public.note_templates_creator_id_idx;
+DROP INDEX IF EXISTS public.note_topics_note_id_idx;
+DROP INDEX IF EXISTS public.note_topics_topic_idx;
+DROP INDEX IF EXISTS public.notes_author_id_idx;
+DROP INDEX IF EXISTS public.notes_read_note_id_idx;
+DROP INDEX IF EXISTS public.notes_read_viewer_id_idx;
+DROP INDEX IF EXISTS public.notes_sid_idx;
 DROP INDEX IF EXISTS public.student_groups_owner_id_idx;
 DROP INDEX IF EXISTS public.tool_settings_key_idx;
-DROP INDEX IF EXISTS public.idx_notes_fts_index;
 DROP INDEX IF EXISTS public.user_logins_uid_idx;
 
 --
 
-ALTER TABLE IF EXISTS ONLY public.notes DROP CONSTRAINT IF EXISTS notes_pkey;
-ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_pkey;
-ALTER TABLE IF EXISTS ONLY public.note_topics DROP CONSTRAINT IF EXISTS note_topics_pkey;
-ALTER TABLE IF EXISTS ONLY public.notes_read DROP CONSTRAINT IF EXISTS notes_read_pkey;
-ALTER TABLE IF EXISTS ONLY public.json_cache DROP CONSTRAINT IF EXISTS json_cache_pkey;
-ALTER TABLE IF EXISTS ONLY public.json_cache DROP CONSTRAINT IF EXISTS json_cache_key_key;
-ALTER TABLE IF EXISTS ONLY public.cohort_filters DROP CONSTRAINT IF EXISTS cohort_filters_pkey;
-ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_pkey;
-ALTER TABLE IF EXISTS ONLY public.authorized_users DROP CONSTRAINT IF EXISTS authorized_users_uid_key;
-ALTER TABLE IF EXISTS ONLY public.authorized_users DROP CONSTRAINT IF EXISTS authorized_users_pkey;
-ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_sid_alert_type_key_unique_constraint;
-ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_pkey;
-ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_pkey;
 ALTER TABLE IF EXISTS ONLY public.alembic_version DROP CONSTRAINT IF EXISTS alembic_version_pkc;
+ALTER TABLE IF EXISTS ONLY public.alert_views DROP CONSTRAINT IF EXISTS alert_views_pkey;
+ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_pkey;
+ALTER TABLE IF EXISTS ONLY public.alerts DROP CONSTRAINT IF EXISTS alerts_sid_alert_type_key_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.authorized_users DROP CONSTRAINT IF EXISTS authorized_users_pkey;
+ALTER TABLE IF EXISTS ONLY public.authorized_users DROP CONSTRAINT IF EXISTS authorized_users_uid_key;
+ALTER TABLE IF EXISTS ONLY public.cohort_filter_owners DROP CONSTRAINT IF EXISTS cohort_filter_owners_pkey;
+ALTER TABLE IF EXISTS ONLY public.cohort_filters DROP CONSTRAINT IF EXISTS cohort_filters_pkey;
+ALTER TABLE IF EXISTS ONLY public.json_cache DROP CONSTRAINT IF EXISTS json_cache_key_key;
+ALTER TABLE IF EXISTS ONLY public.json_cache DROP CONSTRAINT IF EXISTS json_cache_pkey;
+ALTER TABLE IF EXISTS ONLY public.note_attachments DROP CONSTRAINT IF EXISTS note_attachments_pkey;
+ALTER TABLE IF EXISTS ONLY public.note_template_attachments DROP CONSTRAINT IF EXISTS note_template_attachments_pkey;
+ALTER TABLE IF EXISTS ONLY public.note_template_topics DROP CONSTRAINT IF EXISTS note_template_topics_pkey;
+ALTER TABLE IF EXISTS ONLY public.note_templates DROP CONSTRAINT IF EXISTS note_templates_pkey;
+ALTER TABLE IF EXISTS ONLY public.note_topics DROP CONSTRAINT IF EXISTS note_topics_pkey;
+ALTER TABLE IF EXISTS ONLY public.notes DROP CONSTRAINT IF EXISTS notes_pkey;
+ALTER TABLE IF EXISTS ONLY public.notes_read DROP CONSTRAINT IF EXISTS notes_read_pkey;
 ALTER TABLE IF EXISTS ONLY public.student_group_members DROP CONSTRAINT IF EXISTS student_group_members_pkey;
 ALTER TABLE IF EXISTS ONLY public.student_groups DROP CONSTRAINT IF EXISTS student_groups_pkey;
+ALTER TABLE IF EXISTS ONLY public.tool_settings DROP CONSTRAINT IF EXISTS tool_settings_key_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.topics DROP CONSTRAINT IF EXISTS topics_id_pkey;
 ALTER TABLE IF EXISTS ONLY public.topics DROP CONSTRAINT IF EXISTS topics_topic_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.university_dept_members DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
 ALTER TABLE IF EXISTS ONLY public.university_depts DROP CONSTRAINT IF EXISTS university_dept_members_pkey;
-ALTER TABLE IF EXISTS ONLY public.tool_settings DROP CONSTRAINT IF EXISTS tool_settings_key_unique_constraint;
 ALTER TABLE IF EXISTS ONLY public.user_logins DROP CONSTRAINT IF EXISTS user_logins_pkey;
-ALTER TABLE IF EXISTS public.json_cache ALTER COLUMN id DROP DEFAULT;
-ALTER TABLE IF EXISTS public.cohort_filters ALTER COLUMN id DROP DEFAULT;
-ALTER TABLE IF EXISTS public.authorized_users ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE IF EXISTS public.alerts ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE IF EXISTS public.authorized_users ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE IF EXISTS public.cohort_filters ALTER COLUMN id DROP DEFAULT;
+ALTER TABLE IF EXISTS public.json_cache ALTER COLUMN id DROP DEFAULT;
 
 --
 
@@ -106,6 +115,12 @@ DROP MATERIALIZED VIEW IF EXISTS public.notes_fts_index;
 DROP TABLE IF EXISTS public.notes;
 DROP TABLE IF EXISTS public.note_attachments;
 DROP SEQUENCE IF EXISTS public.note_attachments_id_seq;
+DROP TABLE IF EXISTS public.note_template_attachments;
+DROP SEQUENCE IF EXISTS public.note_template_attachments_id_seq;
+DROP TABLE IF EXISTS public.note_template_topics;
+DROP SEQUENCE IF EXISTS public.note_template_topics_id_seq;
+DROP TABLE IF EXISTS public.note_templates;
+DROP SEQUENCE IF EXISTS public.note_templates_id_seq;
 DROP TABLE IF EXISTS public.note_topics;
 DROP SEQUENCE IF EXISTS public.note_topics_id_seq;
 DROP TABLE IF EXISTS public.notes_read;

--- a/scripts/db/migrate/20190814-BOAC-2541/pre_deploy_01_create_note_templates_table.sql
+++ b/scripts/db/migrate/20190814-BOAC-2541/pre_deploy_01_create_note_templates_table.sql
@@ -1,0 +1,60 @@
+BEGIN;
+
+CREATE TABLE note_templates (
+    id SERIAL PRIMARY KEY,
+    creator_id INTEGER NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    body text NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX note_templates_creator_id_idx ON note_templates USING btree (creator_id);
+
+ALTER TABLE ONLY note_templates
+    ADD CONSTRAINT note_templates_creator_id_title_unique_constraint UNIQUE (creator_id, title);
+
+ALTER TABLE ONLY note_templates
+    ADD CONSTRAINT note_templates_creator_id_fkey FOREIGN KEY (creator_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
+
+--
+
+CREATE TABLE note_template_attachments (
+    id SERIAL PRIMARY KEY,
+    note_template_id INTEGER NOT NULL,
+    path_to_attachment character varying(255) NOT NULL,
+    uploaded_by_uid character varying(255) NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    deleted_at timestamp with time zone
+);
+
+-- Constraint name length is limited to 63 bytes in Postgres so we abbreviate the prefix.
+ALTER TABLE ONLY note_template_attachments
+    ADD CONSTRAINT nta_note_template_id_path_to_attachment_unique_constraint UNIQUE (note_template_id, path_to_attachment);
+
+CREATE INDEX note_template_attachments_note_template_id_idx ON note_template_attachments USING btree (note_template_id);
+
+ALTER TABLE ONLY note_template_attachments
+    ADD CONSTRAINT note_template_attachments_note_template_id_fkey FOREIGN KEY (note_template_id) REFERENCES note_templates(id) ON DELETE CASCADE;
+
+--
+
+CREATE TABLE note_template_topics (
+    id SERIAL PRIMARY KEY,
+    note_template_id INTEGER NOT NULL,
+    topic VARCHAR(50) NOT NULL
+);
+
+ALTER TABLE ONLY note_template_topics
+    ADD CONSTRAINT note_template_topics_note_template_id_topic_unique_constraint UNIQUE (note_template_id, topic);
+
+CREATE INDEX note_template_topics_note_template_id_idx ON note_template_topics (note_template_id);
+
+ALTER TABLE ONLY note_template_topics
+    ADD CONSTRAINT note_template_topics_note_template_id_fkey FOREIGN KEY (note_template_id) REFERENCES note_templates(id) ON DELETE CASCADE;
+
+-- Done
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -223,6 +223,82 @@ CREATE INDEX note_attachments_note_id_idx ON note_attachments USING btree (note_
 
 --
 
+CREATE TABLE note_templates (
+    id INTEGER NOT NULL,
+    creator_id INTEGER NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    body text NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    deleted_at TIMESTAMP WITH TIME ZONE
+);
+ALTER TABLE note_templates OWNER TO boac;
+CREATE SEQUENCE note_templates_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE note_templates_id_seq OWNER TO boac;
+ALTER SEQUENCE note_templates_id_seq OWNED BY note_templates.id;
+ALTER TABLE ONLY note_templates ALTER COLUMN id SET DEFAULT nextval('note_templates_id_seq'::regclass);
+ALTER TABLE ONLY note_templates ADD CONSTRAINT note_templates_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY note_templates
+    ADD CONSTRAINT note_templates_creator_id_title_unique_constraint UNIQUE (creator_id, title);
+CREATE INDEX note_templates_creator_id_idx ON note_templates USING btree (creator_id);
+
+--
+
+CREATE TABLE note_template_attachments (
+    id integer NOT NULL,
+    note_template_id INTEGER NOT NULL,
+    path_to_attachment character varying(255) NOT NULL,
+    uploaded_by_uid character varying(255) NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    deleted_at timestamp with time zone
+);
+ALTER TABLE note_template_attachments OWNER TO boac;
+CREATE SEQUENCE note_template_attachments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE note_template_attachments_id_seq OWNER TO boac;
+ALTER SEQUENCE note_template_attachments_id_seq OWNED BY note_template_attachments.id;
+ALTER TABLE ONLY note_template_attachments ALTER COLUMN id SET DEFAULT nextval('note_template_attachments_id_seq'::regclass);
+ALTER TABLE ONLY note_template_attachments
+    ADD CONSTRAINT note_template_attachments_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY note_template_attachments
+    ADD CONSTRAINT nta_note_template_id_path_to_attachment_unique_constraint UNIQUE (note_template_id, path_to_attachment);
+CREATE INDEX note_template_attachments_note_template_id_idx ON note_template_attachments USING btree (note_template_id);
+
+--
+
+CREATE TABLE note_template_topics (
+    id INTEGER NOT NULL,
+    note_template_id INTEGER NOT NULL,
+    topic VARCHAR(50) NOT NULL
+);
+ALTER TABLE note_template_topics OWNER TO boac;
+CREATE SEQUENCE note_template_topics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER TABLE note_template_topics_id_seq OWNER TO boac;
+ALTER SEQUENCE note_template_topics_id_seq OWNED BY note_template_topics.id;
+ALTER TABLE ONLY note_template_topics ALTER COLUMN id SET DEFAULT nextval('note_template_topics_id_seq'::regclass);
+ALTER TABLE ONLY note_template_topics
+    ADD CONSTRAINT note_template_topics_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY note_template_topics
+    ADD CONSTRAINT note_template_topics_note_template_id_topic_unique_constraint UNIQUE (note_template_id, topic);
+CREATE INDEX note_template_topics_note_template_id_idx ON note_template_topics (note_template_id);
+
+--
+
 CREATE TABLE note_topics (
     id INTEGER NOT NULL,
     note_id INTEGER NOT NULL,
@@ -461,6 +537,21 @@ ALTER TABLE ONLY notes_read
 
 ALTER TABLE ONLY note_attachments
     ADD CONSTRAINT note_attachments_note_id_fkey FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE;
+
+--
+
+ALTER TABLE ONLY note_templates
+    ADD CONSTRAINT note_templates_creator_id_fkey FOREIGN KEY (creator_id) REFERENCES authorized_users(id) ON DELETE CASCADE;
+
+--
+
+ALTER TABLE ONLY note_template_attachments
+    ADD CONSTRAINT note_template_attachments_note_template_id_fkey FOREIGN KEY (note_template_id) REFERENCES note_templates(id) ON DELETE CASCADE;
+
+--
+
+ALTER TABLE ONLY note_template_topics
+    ADD CONSTRAINT note_template_topics_note_template_id_fkey FOREIGN KEY (note_template_id) REFERENCES note_templates(id) ON DELETE CASCADE;
 
 --
 

--- a/tests/test_api/test_note_templates_controller.py
+++ b/tests/test_api/test_note_templates_controller.py
@@ -1,0 +1,65 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.models.authorized_user import AuthorizedUser
+from boac.models.note_template import NoteTemplate
+
+advisor_uid = '242881'
+
+
+class TestGetNoteTemplate:
+
+    @classmethod
+    def _api_note_template(cls, client, note_template_id, expected_status_code=200):
+        response = client.get(f'/api/note_template/{note_template_id}')
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_not_authenticated(self, app, client):
+        """Returns 401 if not authenticated."""
+        creator_id = AuthorizedUser.get_id_per_uid(advisor_uid)
+        note_template = NoteTemplate.create(creator_id=creator_id, title='Lost cause', subject='Expect 401')
+        self._api_note_template(client=client, note_template_id=note_template.id, expected_status_code=401)
+
+    def test_unauthorized(self, app, client, fake_auth):
+        """Returns 403 if user did not create the requested note template."""
+        creator_id = AuthorizedUser.get_id_per_uid(advisor_uid)
+        note_template = NoteTemplate.create(creator_id=creator_id, title='Leggo my eggo', subject='I, me, mine.')
+        fake_auth.login('2040')
+        self._api_note_template(client=client, note_template_id=note_template.id, expected_status_code=403)
+
+    def test_get_note_template_by_id(self, app, client, fake_auth):
+        """Returns note template in JSON."""
+        creator_id = AuthorizedUser.get_id_per_uid(advisor_uid)
+        fake_auth.login(advisor_uid)
+        title = 'Template for success'
+        subject = 'Winning!'
+        note_template = NoteTemplate.create(creator_id=creator_id, title=title, subject=subject)
+        api_json = self._api_note_template(client=client, note_template_id=note_template.id)
+        assert api_json.get('id') == note_template.id
+        assert api_json.get('title') == title
+        assert api_json.get('subject') == subject
+        for key in ('attachments', 'body', 'topics', 'createdAt', 'updatedAt'):
+            assert key in api_json


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2541

Note:
* Soft-delete for `note_template_attachments` (see `deleted_at` column) because file uploads might be audited.
* `note_template_topics` table has neither `author_uid` nor `deleted_at`.  Those attributes will be tracked in the actual notes.
* If an authorized_user is deleted then we `DELETE CASCADE` per `note_templates.creator_id`
* The initial tests in `test_note_templates_controller` are for basic verification of the models.
