### PR TITLE
BOAC-2542, note_template update API endpoint plus cleanup

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -140,9 +140,6 @@ def update_note():
     subject = params.get('subject', None)
     body = params.get('body', None)
     topics = get_note_topics_from_http_post()
-    delete_ids_ = params.get('deleteAttachmentIds') or []
-    delete_ids_ = delete_ids_ if isinstance(delete_ids_, list) else str(delete_ids_).split(',')
-    delete_attachment_ids = [int(id_) for id_ in delete_ids_]
     if not note_id or not subject:
         raise BadRequestError('Note requires \'id\' and \'subject\'')
     if Note.find_by_id(note_id=note_id).author_uid != current_user.get_uid():
@@ -152,8 +149,6 @@ def update_note():
         subject=subject,
         body=process_input_from_rich_text_editor(body),
         topics=topics,
-        attachments=get_note_attachments_from_http_post(tolerate_none=True),
-        delete_attachment_ids=delete_attachment_ids,
     )
     note_read = NoteRead.find_or_create(current_user.get_id(), note_id)
     return tolerant_jsonify(_boa_note_to_compatible_json(note=note, note_read=note_read))

--- a/boac/models/note_attachment.py
+++ b/boac/models/note_attachment.py
@@ -47,9 +47,9 @@ class NoteAttachment(db.Model):
         self.uploaded_by_uid = uploaded_by_uid
 
     @classmethod
-    def create_attachment(cls, note, name, byte_stream, uploaded_by):
+    def create(cls, note_id, name, byte_stream, uploaded_by):
         return NoteAttachment(
-            note_id=note.id,
+            note_id=note_id,
             path_to_attachment=put_attachment_to_s3(name=name, byte_stream=byte_stream),
             uploaded_by_uid=uploaded_by,
         )
@@ -57,10 +57,6 @@ class NoteAttachment(db.Model):
     @classmethod
     def find_by_id(cls, attachment_id):
         return cls.query.filter(and_(cls.id == attachment_id, cls.deleted_at == None)).first()  # noqa: E711
-
-    @classmethod
-    def find_by_note_id(cls, note_id):
-        return cls.query.filter(and_(cls.note_id == note_id, cls.deleted_at == None)).all()  # noqa: E711
 
     def get_user_filename(self):
         return get_attachment_filename(self.id, self.path_to_attachment)

--- a/boac/models/note_template_topic.py
+++ b/boac/models/note_template_topic.py
@@ -23,7 +23,8 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from boac import db
+from boac import db, std_commit
+from sqlalchemy import and_
 
 
 class NoteTemplateTopic(db.Model):
@@ -41,6 +42,16 @@ class NoteTemplateTopic(db.Model):
     @classmethod
     def create(cls, note_template_id, topic):
         return cls(note_template_id=note_template_id, topic=topic)
+
+    @classmethod
+    def find_by_note_template_id(cls, note_template_id):
+        return cls.query.filter(and_(cls.note_template_id == note_template_id)).all()
+
+    @classmethod
+    def delete(cls, topic_id):
+        topic = cls.query.filter_by(id=topic_id).first()
+        db.session.delete(topic)
+        std_commit()
 
     def to_api_json(self):
         return self.topic

--- a/boac/models/note_topic.py
+++ b/boac/models/note_topic.py
@@ -43,7 +43,7 @@ class NoteTopic(db.Model):
         self.author_uid = author_uid
 
     @classmethod
-    def create_note_topic(cls, note, topic, author_uid):
+    def create(cls, note, topic, author_uid):
         return NoteTopic(
             note_id=note.id,
             topic=topic,

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -88,18 +88,14 @@ export function updateNote(
     noteId: number,
     subject: string,
     body: string,
-    topics: string[],
-    newAttachments: any[],
-    deleteAttachmentIds: number[]
+    topics: string[]
 ) {
   const data = {
     id: noteId,
     subject: subject,
     body: body,
-    topics: topics,
-    deleteAttachmentIds: deleteAttachmentIds || []
+    topics: topics
   };
-  _.each(newAttachments || [], (attachment, index) => data[`attachment[${index}]`] = attachment);
   const api_json = utils.postMultipartFormData('/api/notes/update', data);
   store.dispatch('user/gaNoteEvent', {
     id: noteId,

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -163,7 +163,7 @@ export default {
       this.subject = this.trim(this.subject);
       if (this.subject) {
         this.body = this.trim(this.body);
-        updateNote(this.note.id, this.subject, this.body, this.topics, [], []).then(updatedNote => {
+        updateNote(this.note.id, this.subject, this.body, this.topics).then(updatedNote => {
           this.afterSaved(updatedNote);
           this.alertScreenReader('Changes to note have been saved');
         });

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -568,9 +568,9 @@ class TestPrefixSearch:
 class TestNotes:
     """Advising Notes API."""
 
-    def test_advising_note(self, client, coe_advising_note_with_attachment, fake_auth):
+    def test_advising_note(self, client, mock_advising_note, fake_auth):
         """Returns a BOAC-created note."""
-        author_uid = coe_advising_note_with_attachment.author_uid
+        author_uid = mock_advising_note.author_uid
         fake_auth.login(author_uid)
         response = client.get('/api/student/by_uid/61889')
         assert response.status_code == 200

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -39,7 +39,7 @@ coe_advisor = '1133399'
 class TestMergedAdvisingNote:
     """Advising note data, merged."""
 
-    def test_get_advising_notes(self, app, coe_advising_note_with_attachment, fake_auth):
+    def test_get_advising_notes(self, app, mock_advising_note, fake_auth):
         fake_auth.login(coe_advisor)
         notes = get_advising_notes('11667051')
 
@@ -101,9 +101,9 @@ class TestMergedAdvisingNote:
         assert notes[6]['read'] is False
 
         # Non-legacy note
-        boa_created_note = next((n for n in notes if n['id'] == coe_advising_note_with_attachment.id), None)
+        boa_created_note = next((n for n in notes if n['id'] == mock_advising_note.id), None)
         assert boa_created_note['id']
-        assert boa_created_note['author']['uid'] == coe_advising_note_with_attachment.author_uid
+        assert boa_created_note['author']['uid'] == mock_advising_note.author_uid
         assert boa_created_note['sid'] == '11667051'
         assert boa_created_note['subject'] == 'In France they kiss on main street'
         assert 'My darling dime store thief' in boa_created_note['body']
@@ -129,7 +129,7 @@ class TestMergedAdvisingNote:
             },
         ]
 
-    def test_get_advising_notes_cs_attachment(self, app, coe_advising_note_with_attachment, fake_auth):
+    def test_get_advising_notes_cs_attachment(self, app, mock_advising_note, fake_auth):
         fake_auth.login(coe_advisor)
         notes = get_advising_notes('11667051')
         assert notes[1]['attachments'] == [
@@ -139,9 +139,9 @@ class TestMergedAdvisingNote:
                 'displayName': 'brigitte_photo.jpeg',
             },
         ]
-        boa_created_note = next((n for n in notes if n['id'] == coe_advising_note_with_attachment.id), None)
+        boa_created_note = next((n for n in notes if n['id'] == mock_advising_note.id), None)
         assert boa_created_note
-        assert boa_created_note['attachments'][0]['uploadedBy'] == coe_advising_note_with_attachment.author_uid
+        assert boa_created_note['attachments'][0]['uploadedBy'] == mock_advising_note.author_uid
 
     def test_get_advising_notes_timestamp_format(self, app, fake_auth):
         fake_auth.login(coe_advisor)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2542

Per reqts, `note_template` API does not need dedicated add/remove attachment endpoints. See [latest comment in BOAC-2542](https://jira.ets.berkeley.edu/jira/browse/BOAC-2519?focusedCommentId=310693&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-310693).