### PR TITLE
BOAC-2596, hide default sort arrows in bootstrap b-table

### DIFF
--- a/src/assets/styles/bootstrap-overrides.css
+++ b/src/assets/styles/bootstrap-overrides.css
@@ -38,6 +38,9 @@ legend {
   padding-left: 8px !important;
   position: inherit !important;
 }
+.b-table th::before {
+  content: '' !important;
+}
 .b-table th[aria-sort="none"]::after {
   color: transparent;
   content: '\25b2' !important;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2596
