### PR TITLE
NOJIRA, null check in 'Status  > Version' section of /admin page

### DIFF
--- a/src/components/util/Status.vue
+++ b/src/components/util/Status.vue
@@ -27,7 +27,7 @@
       <div>
         <ul>
           <li>Version: {{ version.version }}</li>
-          <li>
+          <li v-if="version.build">
             Build
             <ul>
               <li>Artifact: {{ version.build.artifact || '--' }}</li>


### PR DESCRIPTION
Only noticeable in local env, where no build-information file exists and `version.build` is nil. No need for QA PR.