### PR TITLE
BOAC-2608 Fixes to expected graduation term filter options

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -622,18 +622,11 @@ def get_distinct_ethnicities():
     return safe_execute_rds(f'SELECT DISTINCT ethnicity FROM {student_schema()}.ethnicities ORDER BY ethnicity')
 
 
-def get_max_expected_graduation_term():
-    sql = f"""SELECT MAX(expected_grad_term) AS term FROM {student_schema()}.student_academic_status
-        WHERE expected_grad_term > '0'"""
-    rows = safe_execute_rds(sql)
-    return None if not rows or (len(rows) == 0) else rows[0]
-
-
-def get_min_expected_graduation_term():
-    sql = f"""SELECT MIN(expected_grad_term) AS term FROM {student_schema()}.student_academic_status
-        WHERE expected_grad_term > '0'"""
-    rows = safe_execute_rds(sql)
-    return None if not rows or (len(rows) == 0) else rows[0]
+def get_expected_graduation_terms():
+    sql = f"""SELECT DISTINCT expected_grad_term FROM {student_schema()}.student_academic_status
+        WHERE expected_grad_term > '0'
+        ORDER BY expected_grad_term DESC"""
+    return safe_execute_rds(sql)
 
 
 def get_majors():

--- a/boac/merged/cohort_filter_options.py
+++ b/boac/merged/cohort_filter_options.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 
 from boac.api.util import authorized_users_api_feed
 from boac.externals import data_loch
-from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME, COE_ETHNICITIES_PER_CODE, term_ids_range, term_name_for_sis_id
+from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME, COE_ETHNICITIES_PER_CODE, current_term_id, term_name_for_sis_id
 from boac.merged import athletics
 from boac.merged.calnet import get_csid_for_uid
 from boac.merged.student import get_student_query_scope
@@ -394,10 +394,11 @@ def _genders():
 
 
 def _grad_terms():
-    earliest_term_id = data_loch.get_min_expected_graduation_term()['term']
-    latest_term_id = data_loch.get_max_expected_graduation_term()['term']
-    term_ids = term_ids_range(earliest_term_id, latest_term_id)
-    return [{'name': ' '.join(term_name_for_sis_id(term_id).split()[::-1]), 'value': term_id} for term_id in term_ids]
+    term_ids = [r['expected_grad_term'] for r in data_loch.get_expected_graduation_terms()]
+    terms = [{'name': ' '.join(term_name_for_sis_id(term_id).split()[::-1]), 'value': term_id} for term_id in term_ids]
+    first_previous_term_index = next((i for i, term in enumerate(terms) if term['value'] < current_term_id()), None)
+    terms.insert(first_previous_term_index, {'name': 'divider', 'value': 'divider'})
+    return terms
 
 
 def _gpa_ranges():

--- a/src/components/cohort/FilterRow.vue
+++ b/src/components/cohort/FilterRow.vue
@@ -78,22 +78,24 @@
               </div>
             </div>
           </template>
-          <b-dropdown-item
-            v-for="option in filter.options"
-            :id="`${filter.name}-${option.value}`"
-            :key="option.key"
-            class="dropdown-item"
-            :aria-disabled="option.disabled"
-            :disabled="option.disabled"
-            @click="typeArrayUpdateValue(option)"
-            @mouseover.prevent.stop>
-            <span
-              class="font-size-16"
-              :class="{
-                'font-weight-light pointer-default text-muted': option.disabled,
-                'font-weight-normal text-dark': !option.disabled
-              }">{{ option.name }}</span>
-          </b-dropdown-item>
+          <div v-for="option in filter.options" :key="option.key">
+            <b-dropdown-item
+              v-if="option.value !== 'divider'"
+              :id="`${filter.name}-${option.value}`"
+              class="dropdown-item"
+              :aria-disabled="option.disabled"
+              :disabled="option.disabled"
+              @click="typeArrayUpdateValue(option)"
+              @mouseover.prevent.stop>
+              <span
+                class="font-size-16"
+                :class="{
+                  'font-weight-light pointer-default text-muted': option.disabled,
+                  'font-weight-normal text-dark': !option.disabled
+                }">{{ option.name }}</span>
+            </b-dropdown-item>
+            <b-dropdown-divider v-if="option.value === 'divider'"></b-dropdown-divider>
+          </div>
         </b-dropdown>
       </div>
       <div v-if="filter.type === 'range'" class="filter-range-container">

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -1158,8 +1158,9 @@ class TestCohortFilterOptions:
         assert len(api_json)
         assert len(api_json[0])
         filter_options = api_json[0][0].get('options')
-        assert filter_options[0].get('name') == '1997 Fall'
-        assert filter_options[1].get('name') == '1998 Spring'
+        assert filter_options[-1].get('name') == '1997 Fall'
+        assert filter_options[-2].get('name') == 'divider'
+        assert filter_options[-3].get('name') == '2019 Spring'
 
 
 class TestTranslateToFilterOptions:

--- a/tests/test_externals/test_data_loch.py
+++ b/tests/test_externals/test_data_loch.py
@@ -151,6 +151,3 @@ class TestDataLoch:
         no_db = data_loch.get_sis_section_enrollments(0, 0)
         # TODO Real data_loch queries will return an empty list if the course is not found.
         assert no_db is None
-
-    def test_get_min_expected_graduation_term(self):
-        assert data_loch.get_min_expected_graduation_term()['term'] == '1978'


### PR DESCRIPTION
Like the customer ordered in https://jira.ets.berkeley.edu/jira/browse/BOAC-2608:
- Revert term interpolation (#1788);
- Order latest to earliest;
- Insert a divider between present term and past terms.

I don't love the 'divider' convention but I didn't want to further redo the filter framework for the sake of putting one divider in one dropdown.