### PR TITLE
BOAC-2639 Loosen match criteria for note ID permalinks

### DIFF
--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -387,7 +387,7 @@ export default {
   },
   mounted() {
     if (this.anchor) {
-      const match = this.anchor.match(/#([0-9-]+)/);
+      const match = this.anchor.match(/#(\d[0-9A-Z-]+\d)/);
       if (match) {
         const messageId = match[1];
         const note = this.find(this.messages, function(m) {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2639

Note IDs should start with a digit and end with a digit, but things get crazy in the middle.