### PR TITLE
NS-676: Removes attachment path logic

### DIFF
--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -306,10 +306,7 @@ def get_legacy_attachment_stream(filename):
         display_filename = filename
     else:
         display_filename = attachment_result[0].get('user_file_name')
-    if attachment_result[0].get('is_historical'):
-        s3_key = '/'.join([app.config['DATA_LOCH_S3_ADVISING_NOTE_ATTACHMENT_PATH'], sid, filename])
-    else:
-        s3_key = '/'.join([app.config['DATA_LOCH_S3_ADVISING_NOTE_ATTACHMENT_INCR_PATH'], filename])
+    s3_key = '/'.join([app.config['DATA_LOCH_S3_ADVISING_NOTE_ATTACHMENT_PATH'], sid, filename])
     return {
         'filename': display_filename,
         'stream': s3.stream_object(app.config['DATA_LOCH_S3_ADVISING_NOTE_BUCKET'], s3_key),


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/NS-676

This will temporarily break the ability to download attachments from recent notes until we've consolidated all attachment files in the historical folder.