### PR TITLE
BOAC-2547, create note when attachments come from note template

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import urllib.parse
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import get_note_attachments_from_http_post, get_note_topics_from_http_post
+from boac.api.util import get_note_attachments_from_http_post, get_note_topics_from_http_post, get_template_attachment_ids_from_http_post
 from boac.externals import data_loch
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param, is_int, process_input_from_rich_text_editor, to_bool_or_none
@@ -83,6 +83,7 @@ def create_note():
         topics=topics,
         sid=sid,
         attachments=attachments,
+        template_attachment_ids=get_template_attachment_ids_from_http_post(),
     )
     note_read = NoteRead.find_or_create(current_user.get_id(), note.id)
     return tolerant_jsonify(_boa_note_to_compatible_json(note=note, note_read=note_read))
@@ -112,6 +113,7 @@ def batch_create_notes():
         topics=topics,
         sids=sids,
         attachments=attachments,
+        template_attachment_ids=get_template_attachment_ids_from_http_post(),
     )
     return tolerant_jsonify(note_ids_per_sid)
 

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -219,6 +219,11 @@ def get_note_attachments_from_http_post(tolerate_none=False):
     return byte_stream_bundle
 
 
+def get_template_attachment_ids_from_http_post():
+    ids = request.form.get('templateAttachmentIds', [])
+    return ids if isinstance(ids, list) else list(filter(None, str(ids).split(',')))
+
+
 def get_note_topics_from_http_post():
     topics = request.form.get('topics', ())
     return topics if isinstance(topics, list) else list(filter(None, str(topics).split(',')))

--- a/boac/models/note_attachment.py
+++ b/boac/models/note_attachment.py
@@ -55,6 +55,14 @@ class NoteAttachment(db.Model):
         )
 
     @classmethod
+    def create_using_template_attachment(cls, note_id, template_attachment, uploaded_by):
+        return NoteAttachment(
+            note_id=note_id,
+            path_to_attachment=template_attachment.path_to_attachment,
+            uploaded_by_uid=uploaded_by,
+        )
+
+    @classmethod
     def find_by_id(cls, attachment_id):
         return cls.query.filter(and_(cls.id == attachment_id, cls.deleted_at == None)).first()  # noqa: E711
 

--- a/boac/models/note_template_attachment.py
+++ b/boac/models/note_template_attachment.py
@@ -61,6 +61,10 @@ class NoteTemplateAttachment(db.Model):
         return cls.query.filter(and_(cls.id == attachment_id, cls.deleted_at == None)).first()  # noqa: E711
 
     @classmethod
+    def get_attachments(cls, attachment_ids):
+        return cls.query.filter(and_(cls.id.in_(attachment_ids), cls.deleted_at == None)).all()  # noqa: E711
+
+    @classmethod
     def create(cls, note_template_id, name, byte_stream, uploaded_by):
         return NoteTemplateAttachment(
             note_template_id=note_template_id,

--- a/fixtures/mock_note_template_attachment_1.txt
+++ b/fixtures/mock_note_template_attachment_1.txt
@@ -1,0 +1,1 @@
+I am a mock template attachment.

--- a/src/api/note-templates.ts
+++ b/src/api/note-templates.ts
@@ -9,6 +9,12 @@ export function getMyNoteTemplates() {
     .then(response => response.data, () => null);
 }
 
+export function getNoteTemplate(templateId: number) {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/note_template/${templateId}`)
+    .then(response => response.data, () => null);
+}
+
 export function createNoteTemplate(
     title: string,
     subject: string,

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -34,9 +34,10 @@ export function createNote(
     subject: string,
     body: string,
     topics: string[],
-    attachments: any[]
+    attachments: any[],
+    templateAttachmentIds: []
 ) {
-  const data = {sid, subject, body, topics};
+  const data = {sid, subject, body, topics, templateAttachmentIds};
   _.each(attachments || [], (attachment, index) => data[`attachment[${index}]`] = attachment);
   return utils.postMultipartFormData('/api/notes/create', data).then(data => {
     Vue.prototype.$eventHub.$emit('advising-note-created', data);
@@ -55,10 +56,11 @@ export function createNoteBatch(
     body: string,
     topics: string[],
     attachments: any[],
+    templateAttachmentIds: [],
     cohortIds: number[],
     curatedGroupIds: number[]
 ) {
-  const data = {sids, subject, body, topics, cohortIds, curatedGroupIds};
+  const data = {sids, subject, body, topics, templateAttachmentIds, cohortIds, curatedGroupIds};
   _.each(attachments || [], (attachment, index) => data[`attachment[${index}]`] = attachment);
   return utils.postMultipartFormData('/api/notes/batch/create', data).then(data => {
     Vue.prototype.$eventHub.$emit('batch-of-notes-created', data);

--- a/src/components/note/AdvisingNoteAttachments.vue
+++ b/src/components/note/AdvisingNoteAttachments.vue
@@ -99,8 +99,8 @@ export default {
   },
   methods: {
     removeAttachmentByIndex(index) {
+      this.alertScreenReader(`Attachment '${this.existingAttachments[index].name}' removed`);
       this.removeAttachment(index);
-      this.alertScreenReader(`Attachment '${this.attachments[index].name}' removed`);
     }
   }
 }

--- a/src/components/note/NewNoteModal.vue
+++ b/src/components/note/NewNoteModal.vue
@@ -291,7 +291,7 @@ export default {
       this.beginEditSession({
         mode: 'editTemplate',
         model: template,
-        sid: undefined
+        sid: this.get(this.student, 'sid')
       });
     },
     getTemplateTitle(templateId) {
@@ -301,8 +301,8 @@ export default {
     loadTemplate(template) {
       this.beginEditSession({
         mode: this.mode,
-        model: template,
-        sid: undefined
+        model: this.cloneDeep(template),
+        sid: this.get(this.student, 'sid')
       });
       this.alertScreenReader(`Template ${template.title} loaded`);
     },
@@ -327,7 +327,15 @@ export default {
       this.putFocusNextTick('template-title-input');
     },
     updateTemplate() {
-      updateNoteTemplate(this.model.id, this.model.subject, this.model.body, this.model.topics, this.model.attachments, []).then(template => {
+      const newAttachments = this.filterList(this.model.attachments, a => !a.id);
+      updateNoteTemplate(
+        this.model.id,
+        this.model.subject,
+        this.model.body,
+        this.model.topics,
+        newAttachments,
+        this.model.deleteAttachmentIds
+      ).then(template => {
         this.terminate();
         this.isModalOpen = false;
         this.alertScreenReader(`Template ${template.label} updated`);

--- a/src/components/note/NewNotePageHeader.vue
+++ b/src/components/note/NewNotePageHeader.vue
@@ -25,7 +25,7 @@
           :key="template.id">
           <div class="align-items-center d-flex justify-content-between">
             <div>
-              <b-btn variant="link" class="dropdown-item p-0" @click="loadTemplate(template)">{{ truncate(template.title) }}</b-btn>
+              <b-btn variant="link" class="dropdown-item pl-1" @click="loadTemplate(template)">{{ truncate(template.title) }}</b-btn>
             </div>
             <div class="align-items-center d-flex ml-2 no-wrap">
               <div class="pl-2">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,7 +219,7 @@ def mock_note_template(app, db):
     """Create advising note template with attachment (mock s3)."""
     with mock_advising_note_s3_bucket(app):
         base_dir = app.config['BASE_DIR']
-        path_to_file = f'{base_dir}/fixtures/mock_advising_note_attachment_1.txt'
+        path_to_file = f'{base_dir}/fixtures/mock_note_template_attachment_1.txt'
         timestamp = datetime.now().timestamp()
         with open(path_to_file, 'r') as file:
             note_template = NoteTemplate.create(


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2547

A template-attachment is not a file upload and must be handled differently. This PR includes a few other minor fixes.