### PR TITLE
BOAC-2658, move 'Create Template' to top-right 'Templates' menu

### DIFF
--- a/src/assets/styles/boac-global.css
+++ b/src/assets/styles/boac-global.css
@@ -83,6 +83,21 @@
   display: flex;
   flex-direction: row;
 }
+.font-size-14 {
+  font-size: 14px;
+}
+.font-size-16 {
+  font-size: 16px;
+}
+.font-size-18 {
+  font-size: 18px;
+}
+.font-size-20 {
+  font-size: 20px;
+}
+.font-size-24 {
+  font-size: 24px;
+}
 .form-control {
   height: 38px;
   padding: 8px 12px;
@@ -162,19 +177,6 @@ select.form-control {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.font-size-14 {
-  font-size: 14px;
-}
-.font-size-16 {
-  font-size: 16px;
-}
-.font-size-20 {
-  font-size: 20px;
-}
-.font-size-24 {
-  font-size: 24px;
-}
-
 #content {
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }

--- a/src/assets/styles/bootstrap-overrides.css
+++ b/src/assets/styles/bootstrap-overrides.css
@@ -10,6 +10,9 @@ legend {
   background-color: #337ab7;
   border-color: #337ab7;
 }
+.alert-dismissible .close {
+  padding: 8px 18px 0 0;
+}
 .b-dd-item-override {
   color: #212529 !important;
 }

--- a/src/components/note/NewNoteModalButtons.vue
+++ b/src/components/note/NewNoteModalButtons.vue
@@ -1,14 +1,5 @@
 <template>
   <div class="d-flex flex-wrap-reverse mt-1 mr-3 mb-0 ml-3">
-    <div v-if="undocked && mode !== 'editTemplate'" class="flex-grow-1">
-      <b-btn
-        id="btn-to-save-note-as-template"
-        variant="link"
-        :disabled="!trim(model.subject)"
-        @click.prevent="saveAsTemplate()">
-        Save note as template
-      </b-btn>
-    </div>
     <div class="flex-grow-1">
       <b-btn
         v-if="!undocked"
@@ -16,6 +7,17 @@
         variant="link"
         @click.prevent="setMode('advanced')">
         Advanced note options
+      </b-btn>
+    </div>
+    <div v-if="mode === 'createTemplate'">
+      <b-btn
+        id="create-template-button"
+        class="btn-primary-color-override"
+        :disabled="!model.subject"
+        aria-label="Create note template"
+        variant="primary"
+        @click.prevent="createTemplate()">
+        Create Template
       </b-btn>
     </div>
     <div v-if="mode === 'editTemplate'">
@@ -29,12 +31,12 @@
         Update Template
       </b-btn>
     </div>
-    <div v-if="mode !== 'editTemplate'">
+    <div v-if="!includes(['createTemplate', 'editTemplate'], mode)">
       <b-btn
         id="create-note-button"
         class="btn-primary-color-override"
         :disabled="!targetStudentCount || !trim(model.subject)"
-        aria-label="Create new note"
+        aria-label="Create note"
         variant="primary"
         @click.prevent="createNote()">
         Save
@@ -70,15 +72,15 @@ export default {
       required: true,
       type: Function
     },
+    createTemplate: {
+      required: true,
+      type: Function
+    },
     deleteTemplate: {
       required: true,
       type: Function
     },
     minimize: {
-      required: true,
-      type: Function
-    },
-    saveAsTemplate: {
       required: true,
       type: Function
     },

--- a/src/components/note/NewNotePageHeader.vue
+++ b/src/components/note/NewNotePageHeader.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="d-flex flex-wrap align-items-end pt-2 mb-1" :class="{'mt-2': undocked}">
     <div class="flex-grow-1 new-note-header font-weight-bolder">
+      <span v-if="mode === 'createTemplate'">Create Template</span>
       <span v-if="mode === 'editTemplate'">Edit Template</span>
-      <span v-if="mode !== 'editTemplate'">New Note</span>
+      <span v-if="!includes(['createTemplate', 'editTemplate'], mode)">New Note</span>
     </div>
     <div v-if="undocked" class="mr-4">
       <b-dropdown
@@ -16,7 +17,9 @@
         <b-dropdown-header v-if="!size(noteTemplates)" id="no-templates-header" class="templates-dropdown-header">
           <div class="font-weight-bolder">Templates</div>
           <div class="templates-dropdown-instructions">
-            You have no saved templates. To begin, create a new note and select, "Save note as template," to build your first note template.
+            You have no saved templates.
+            <b-link v-if="mode !== 'createTemplate'" @click="createTemplate()">Create a template.</b-link>
+            <span v-if="mode === 'createTemplate'">Fill in fields below then click 'Create Template'.</span>
           </div>
         </b-dropdown-header>
         <b-dropdown-item
@@ -25,7 +28,7 @@
           :key="template.id">
           <div class="align-items-center d-flex justify-content-between">
             <div>
-              <b-btn variant="link" class="dropdown-item pl-1" @click="loadTemplate(template)">{{ truncate(template.title) }}</b-btn>
+              <b-link class="font-size-18 text-muted" @click="loadTemplate(template)">{{ truncate(template.title) }}</b-link>
             </div>
             <div class="align-items-center d-flex ml-2 no-wrap">
               <div class="pl-2">
@@ -39,6 +42,10 @@
               </div>
             </div>
           </div>
+        </b-dropdown-item>
+        <b-dropdown-divider></b-dropdown-divider>
+        <b-dropdown-item v-if="size(noteTemplates)">
+          <b-link v-if="mode !== 'createTemplate'" @click="createTemplate()">Create new template</b-link>
         </b-dropdown-item>
       </b-dropdown>
     </div>
@@ -104,6 +111,11 @@ export default {
     undocked: {
       required: true,
       type: Boolean
+    }
+  },
+  methods: {
+    createTemplate() {
+      this.setMode('createTemplate');
     }
   }
 }

--- a/src/store/modules/note-edit-session.ts
+++ b/src/store/modules/note-edit-session.ts
@@ -1,6 +1,8 @@
 import _ from 'lodash';
 import {createNote, createNoteBatch, getDistinctStudentCount} from '@/api/notes';
 
+const VALID_MODES = ['advanced', 'batch', 'docked', 'createTemplate', 'edit', 'editTemplate', 'minimized', 'saving'];
+
 const $_getDefaultModel = () => {
   return {
     id: undefined,
@@ -24,8 +26,6 @@ const $_recalculateStudentCount = ({ commit, state }) => {
     commit('setTargetStudentCount', sids.length);
   }
 };
-
-const VALID_MODES = ['advanced', 'batch', 'docked', 'edit', 'editTemplate', 'minimized', 'saving'];
 
 const state = {
   addedCohorts: [],


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2658

Plus:
* after clicking 'create template', the modal stays open and resets the form
* fade-after-five-seconds, dismissible alert when create/cancel new template
