### PR TITLE
[BOAC-2659] Suppress log levels on botocore as it is too verbose in debug mode. 

### DIFF
--- a/boac/logger.py
+++ b/boac/logger.py
@@ -33,6 +33,7 @@ import ldap3.utils.log as ldap3_log
 def initialize_logger(app):
     level = app.config['LOGGING_LEVEL']
     location = app.config['LOGGING_LOCATION']
+    log_propagation_level = app.config['LOGGING_PROPAGATION_LEVEL']
 
     # Configure the root logger and library loggers as desired.
     loggers = [
@@ -62,3 +63,7 @@ def initialize_logger(app):
         for handler in handlers:
             logger.addHandler(handler)
             logger.setLevel(level)
+
+    logging.getLogger('boto3').setLevel(log_propagation_level)
+    logging.getLogger('botocore').setLevel(log_propagation_level)
+    logging.getLogger('s3transfer').setLevel(log_propagation_level)

--- a/config/default.py
+++ b/config/default.py
@@ -144,6 +144,7 @@ ALERT_WITHDRAWAL_ENABLED = True
 LOGGING_FORMAT = '[%(asctime)s] - %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'
 LOGGING_LOCATION = 'boac.log'
 LOGGING_LEVEL = logging.DEBUG
+LOGGING_PROPAGATION_LEVEL = logging.INFO
 
 # Flask-caching (number of seconds, or False to disable)
 CACHE_DEFAULT_TIMEOUT = False


### PR DESCRIPTION
Now defaults to INFO level. Log level can be overridden by setting LOGGING_PROPAGATION_LEVEL in the configs.

https://jira.ets.berkeley.edu/jira/browse/BOAC-2659