### PR TITLE
BOAC-2663, RichTextEditor wraps ckeditor so we can 'correct the DOM', if necessary

### DIFF
--- a/src/components/admin/EditServiceAnnouncement.vue
+++ b/src/components/admin/EditServiceAnnouncement.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="announcement !== undefined" class="mt-3">
+  <div v-if="announcement !== undefined && originalText !== undefined" class="mt-3">
     <h2 id="edit-service-announcement" class="page-section-header-sub">Service Alert</h2>
     <div class="p-2">
       <div v-if="isTogglingPublish">
@@ -19,13 +19,12 @@
         <div v-if="error" class="mt-2 has-error w-100">
           <span aria-live="polite" role="alert">{{ error }}</span>
         </div>
-        <ckeditor
+        <RichTextEditor
           id="textarea-update-service-announcement"
-          v-model="text"
           aria-label="Service announcement input"
-          :config="editorConfig"
+          :initial-value="originalText"
           :disabled="isSaving"
-          :editor="editor"></ckeditor>
+          :on-value-update="onEditorUpdate" />
         <div>
           <b-btn
             id="button-update-service-announcement"
@@ -43,21 +42,16 @@
 </template>
 
 <script>
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Context from '@/mixins/Context';
+import RichTextEditor from '@/components/util/RichTextEditor';
 import Util from '@/mixins/Util';
 import { getServiceAnnouncement, publishAnnouncement, updateAnnouncement } from '@/api/config';
 
-require('@/assets/styles/ckeditor-custom.css');
-
 export default {
   name: 'EditServiceAnnouncement',
+  components: { RichTextEditor },
   mixins: [Context, Util],
   data: () => ({
-    editor: ClassicEditor,
-    editorConfig: {
-      toolbar: ['bold', 'italic', 'bulletedList', 'numberedList', 'link']
-    },
     error: undefined,
     isPublished: undefined,
     isTogglingPublish: false,
@@ -67,11 +61,14 @@ export default {
   }),
   created() {
     getServiceAnnouncement().then(data => {
-      this.originalText = this.text = data.text;
+      this.originalText = this.text = data.text || '';
       this.isPublished = data.isPublished;
     })
   },
   methods: {
+    onEditorUpdate(value) {
+      this.text = value;
+    },
     togglePublish() {
       const publish = !this.isPublished;
       this.error = null;

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -21,11 +21,9 @@
     </div>
     <div>
       <span id="edit-note-details" class="bg-transparent note-details-editor">
-        <ckeditor
-          :value="model.body || ''"
-          :editor="editor"
-          :config="editorConfig"
-          @input="setBodyPerEvent"></ckeditor>
+        <RichTextEditor
+          :initial-value="model.body || ''"
+          :on-value-update="setBody" />
       </span>
     </div>
     <div>
@@ -91,17 +89,15 @@
 <script>
 import AdvisingNoteTopics from '@/components/note/AdvisingNoteTopics';
 import AreYouSureModal from '@/components/util/AreYouSureModal';
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 import Context from '@/mixins/Context';
 import NoteEditSession from '@/mixins/NoteEditSession';
+import RichTextEditor from '@/components/util/RichTextEditor';
 import Util from '@/mixins/Util';
 import { getNote, updateNote } from '@/api/notes';
 
-require('@/assets/styles/ckeditor-custom.css');
-
 export default {
   name: 'EditAdvisingNote',
-  components: { AdvisingNoteTopics, AreYouSureModal },
+  components: {AdvisingNoteTopics, AreYouSureModal, RichTextEditor},
   mixins: [Context, NoteEditSession, Util],
   props: {
     afterCancel: Function,
@@ -109,10 +105,6 @@ export default {
     noteId: Number
   },
   data: () => ({
-    editor: ClassicEditor,
-    editorConfig: {
-      toolbar: ['bold', 'italic', 'bulletedList', 'numberedList', 'link'],
-    },
     error: undefined,
     showAreYouSureModal: false,
     showErrorPopover: false,

--- a/src/components/note/create/CreateNoteModal.vue
+++ b/src/components/note/create/CreateNoteModal.vue
@@ -81,14 +81,12 @@
               <label for="create-note-body" class="font-size-14 font-weight-bolder mt-3 mb-1">Note Details</label>
             </div>
             <div id="note-details">
-              <span id="create-note-body">
-                <ckeditor
-                  :value="model.body || ''"
-                  :disabled="isSaving"
-                  :editor="editor"
-                  :config="editorConfig"
-                  @input="setBodyPerEvent"></ckeditor>
-              </span>
+              <RichTextEditor
+                id="create-note-body"
+                :initial-value="model.body || ''"
+                :disabled="isSaving"
+                :is-in-modal="undocked"
+                :on-value-update="setBody" />
             </div>
           </div>
           <div v-if="undocked">
@@ -146,20 +144,18 @@
 import AdvisingNoteAttachments from '@/components/note/AdvisingNoteAttachments';
 import AdvisingNoteTopics from '@/components/note/AdvisingNoteTopics';
 import AreYouSureModal from '@/components/util/AreYouSureModal';
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
-import Context from '@/mixins/Context';
-import FocusLock from 'vue-focus-lock';
-import NoteEditSession from '@/mixins/NoteEditSession';
 import BatchNoteFeatures from '@/components/note/create/BatchNoteFeatures';
+import Context from '@/mixins/Context';
 import CreateNoteFooter from '@/components/note/create/CreateNoteFooter';
 import CreateNoteHeader from '@/components/note/create/CreateNoteHeader';
 import CreateNoteMinimized from '@/components/note/create/CreateNoteMinimized';
 import CreateTemplateModal from "@/components/note/create/CreateTemplateModal";
+import FocusLock from 'vue-focus-lock';
+import NoteEditSession from '@/mixins/NoteEditSession';
+import RichTextEditor from '@/components/util/RichTextEditor';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
 import { createNoteTemplate, updateNoteTemplate } from '@/api/note-templates';
-
-require('@/assets/styles/ckeditor-custom.css');
 
 export default {
   name: 'CreateNoteModal',
@@ -172,7 +168,8 @@ export default {
     CreateNoteHeader,
     CreateNoteMinimized,
     CreateTemplateModal,
-    FocusLock
+    FocusLock,
+    RichTextEditor
   },
   mixins: [Context, NoteEditSession, UserMetadata, Util],
   props: {
@@ -194,10 +191,6 @@ export default {
   data: () => ({
     alert: undefined,
     dismissAlertSeconds: 0,
-    editor: ClassicEditor,
-    editorConfig: {
-      toolbar: ['bold', 'italic', 'bulletedList', 'numberedList', 'link'],
-    },
     isBatchFeature: undefined,
     isMinimizing: false,
     isModalOpen: false,

--- a/src/components/util/RichTextEditor.vue
+++ b/src/components/util/RichTextEditor.vue
@@ -1,0 +1,95 @@
+<template>
+  <div :id="ckElementId">
+    <ckeditor
+      :value="initialValue"
+      :disabled="disabled"
+      :editor="editor"
+      :config="editorConfig"
+      @input="onUpdate"></ckeditor>
+  </div>
+</template>
+
+<script>
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
+import Util from '@/mixins/Util';
+
+require('@/assets/styles/ckeditor-custom.css');
+
+export default {
+  name: "RichTextEditor",
+  mixins: [ Util ],
+  props: {
+    disabled: {
+      required: false,
+      default: false,
+      type: Boolean
+    },
+    editorConfig: {
+      required: false,
+      default: () => ({
+        toolbar: ['bold', 'italic', 'bulletedList', 'numberedList', 'link']
+      }),
+      type: Object
+    },
+    initialValue: {
+      required: true,
+      type: String
+    },
+    isInModal: {
+      required: false,
+      default: false,
+      type: Boolean
+    },
+    onValueUpdate: {
+      required: true,
+      type: Function
+    }
+  },
+  data: () => ({
+    domFixAttemptCount: 0,
+    domFixer: undefined,
+    editor: ClassicEditor,
+    ckElementId: undefined
+  }),
+  watch: {
+    isInModal() {
+      this.initDomFixer();
+    }
+  },
+  mounted() {
+    this.ckElementId = `rich-text-editor-${new Date().getTime()}`;
+    this.initDomFixer();
+  },
+  methods: {
+    correctTheDOM() {
+      if (this.domFixAttemptCount === 10) {
+        // Abort after N tries.
+        clearInterval(this.domFixer);
+      } else if (this.isInModal) {
+        // When embedded in a modal, the CKEditor toolbar elements are unreachable because they are attached to
+        // the end of the DOM and outside the modal. We must move these "ck" elements. The user should not notice.
+        const ckEditorTool = 'ck ck-reset_all ck-body ck-rounded-corners';
+        const elements = document.getElementsByClassName(ckEditorTool);
+        if (elements.length > 0) {
+          this.each(elements, element => {
+            document.getElementById(this.ckElementId).appendChild(element);
+          });
+          clearInterval(this.domFixer);
+        } else {
+          this.domFixAttemptCount++;
+        }
+      } else {
+        // We're not in a modal.
+        clearInterval(this.domFixer);
+      }
+    },
+    initDomFixer() {
+      this.domFixAttemptCount = 0;
+      this.domFixer = setInterval(this.correctTheDOM, 500);
+    },
+    onUpdate(event) {
+      this.onValueUpdate(this.isString(event) ? event : event.target.value);
+    }
+  }
+}
+</script>

--- a/src/mixins/NoteEditSession.vue
+++ b/src/mixins/NoteEditSession.vue
@@ -41,9 +41,6 @@ export default {
     ]),
     setSubjectPerEvent(event) {
       store.dispatch('noteEditSession/setSubject', _.isString(event) ? event : event.target.value);
-    },
-    setBodyPerEvent(event) {
-      store.dispatch('noteEditSession/setBody', _.isString(event) ? event : event.target.value);
     }
   }
 };

--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -39,6 +39,7 @@ export default {
     isEmpty: _.isEmpty,
     isNil: _.isNil,
     isNumber: _.isNumber,
+    isString: _.isString,
     isUndefined: _.isUndefined,
     join: _.join,
     keys: _.keys,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2663

The cause of this bug is explained in [my post on Stack Overflow](https://stackoverflow.com/questions/57877722/how-can-i-get-ckeditor-5-link-dialog-box-to-pin-to-custom-dom-element-instead). Unfortunately, CKEditor config options do offer a path to a solution.

The fix in this PR involves a bit of a hack – see `correctTheDOM()`  – but this is an opportunity to reduce redundant code. For example, fewer lines in the advising-notes-related components. 

