### PR TITLE
BOAC-2685, if create template and then immediately create note: avoid dupe files in S3

### DIFF
--- a/src/components/note/create/CreateNoteModal.vue
+++ b/src/components/note/create/CreateNoteModal.vue
@@ -277,15 +277,15 @@ export default {
         // File upload might take time; alert will be overwritten when API call is done.
         this.showAlert('Creating template...', 60);
       }
-      createNoteTemplate(title, this.model.subject, this.model.body, this.model.topics, this.model.attachments).then(() => {
+      createNoteTemplate(title, this.model.subject, this.model.body, this.model.topics, this.model.attachments).then(template => {
         this.showAlert(`Template '${title}' created.`);
         this.setIsSaving(false);
         this.setModel({
           id: undefined,
-          subject: this.model.subject,
-          body: this.model.body,
-          topics: this.model.topics,
-          attachments: this.model.attachments,
+          subject: template.subject,
+          body: template.body,
+          topics: template.topics,
+          attachments: template.attachments,
           deleteAttachmentIds: []
         });
         this.setMode(this.isBatchFeature ? 'batch' : 'advanced');


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2685

This fixes an edge case. The standard workflow, (1) load template and (2) create note(s), has been working: only one file in S3.