### PR TITLE
BOAC-2706, Context mixin offers disableNewNoteButton

### DIFF
--- a/src/components/note/create/CreateNoteModal.vue
+++ b/src/components/note/create/CreateNoteModal.vue
@@ -6,7 +6,7 @@
         class="mt-1 mr-2 btn-primary-color-override btn-primary-color-override-opaque"
         :class="{'w-100': isBatchFeature}"
         variant="primary"
-        :disabled="isModalOpen"
+        :disabled="disableNewNoteButton"
         @click="openNoteModal()">
         <span class="m-1">
           <font-awesome icon="file-alt" />

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -137,6 +137,7 @@
                   :id="`edit-note-${message.id}-button`"
                   variant="link"
                   class="p-0 edit-note-button"
+                  :disabled="disableNewNoteButton"
                   @keypress.enter.stop="editNote(message)"
                   @click.stop="editNote(message)">
                   Edit Note
@@ -147,6 +148,7 @@
                   id="delete-note-button"
                   variant="link"
                   class="p-0 edit-note-button"
+                  :disabled="disableNewNoteButton"
                   @keypress.enter.stop="deleteNote(message)"
                   @click.stop="deleteNote(message)">
                   Delete Note

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -18,7 +18,8 @@ export default {
       'srAlert',
       'supportEmailAddress',
       'timezone'
-    ])
+    ]),
+    ...mapGetters('noteEditSession', ['disableNewNoteButton'])
   },
   methods: {
     ...mapActions('context', [

--- a/src/store/modules/note-edit-session.ts
+++ b/src/store/modules/note-edit-session.ts
@@ -41,6 +41,7 @@ const state = {
 const getters = {
   addedCohorts: (state: any): any[] => state.addedCohorts,
   addedCuratedGroups: (state: any): any[] => state.addedCuratedGroups,
+  disableNewNoteButton: (state: any): boolean => !!state.mode,
   isFocusLockDisabled: (state: any): boolean => state.isFocusLockDisabled,
   isSaving: (state: any): boolean => state.isSaving,
   mode: (state: any): string => state.mode,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2706

The `NoteEditSession` mixin is reserved for components that are directly involved in the note editing. `Context.disableNewNoteButton` gives lightweight access to note-edit state.