### PR TITLE
BOAC-2753, suppress the unitsMin and unitsMax messaging in BOA

### DIFF
--- a/fixtures/loch_student_profile_11667051.json
+++ b/fixtures/loch_student_profile_11667051.json
@@ -10,8 +10,8 @@
         "cumulativeGPA": 3.7999999999999998,
         "cumulativeUnits": 101.3,
         "currentTerm": {
-            "unitsMaxOverride": 25,
-            "unitsMinOverride": 0
+            "unitsMax": 25,
+            "unitsMin": 0
         },
         "degreeProgress": {
             "reportDate": "2017-03-03",

--- a/src/components/student/StudentRow.vue
+++ b/src/components/student/StudentRow.vue
@@ -135,14 +135,17 @@
     <div class="student-column">
       <div :id="`row-${rowIndex}-student-enrolled-units`" class="student-gpa">{{ get(student.term, 'enrolledUnits', 0) }}</div>
       <div class="student-text">Units in Progress</div>
-      <div v-if="get(student, 'currentTerm.unitsMinOverride')">
-        <div :id="`row-${rowIndex}-student-min-units`" class="student-gpa">{{ student.currentTerm.unitsMinOverride }}</div>
+      <!--
+      TODO: Until SISRP-48560 is resolved we will suppress unitsMin and unitsMax data in BOA.
+      <div v-if="get(student, 'currentTerm.unitsMin')">
+        <div :id="`row-${rowIndex}-student-min-units`" class="student-gpa">{{ student.currentTerm.unitsMin }}</div>
         <div class="student-text">Min&nbsp;Approved</div>
       </div>
-      <div v-if="get(student, 'currentTerm.unitsMaxOverride')">
-        <div :id="`row-${rowIndex}-student-max-units`" class="student-gpa">{{ student.currentTerm.unitsMaxOverride }}</div>
+      <div v-if="get(student, 'currentTerm.unitsMax')">
+        <div :id="`row-${rowIndex}-student-max-units`" class="student-gpa">{{ student.currentTerm.unitsMax }}</div>
         <div class="student-text">Max&nbsp;Approved</div>
       </div>
+      -->
       <div
         v-if="student.cumulativeUnits"
         :id="`row-${rowIndex}-student-cumulative-units`"

--- a/src/components/student/profile/StudentClasses.vue
+++ b/src/components/student/profile/StudentClasses.vue
@@ -223,16 +223,19 @@ v-if="section.isViewableOnCoursePage"
           <div class="student-course-heading-units-total">
             <span>Total {{ term.enrolledUnits }}</span>
             <span class="sr-only">units</span>
+            <!--
+            TODO: Until SISRP-48560 is resolved we will suppress unitsMin and unitsMax data in BOA.
             <span
-              v-if="currentEnrollmentTermId === parseInt(term.termId) && get(student, 'sisProfile.currentTerm.unitsMinOverride')"
+              v-if="currentEnrollmentTermId === parseInt(term.termId) && get(student, 'sisProfile.currentTerm.unitsMin')"
               class="student-course-heading-units-override">
-              <span>Min&nbsp;Approved </span><span :id="`term-${term.termId}-min-units`">{{ student.sisProfile.currentTerm.unitsMinOverride }}</span>
+              <span>Min&nbsp;Approved </span><span :id="`term-${term.termId}-min-units`">{{ student.sisProfile.currentTerm.unitsMin }}</span>
             </span>
             <span
-              v-if="currentEnrollmentTermId === parseInt(term.termId) && get(student, 'sisProfile.currentTerm.unitsMaxOverride')"
+              v-if="currentEnrollmentTermId === parseInt(term.termId) && get(student, 'sisProfile.currentTerm.unitsMax')"
               class="student-course-heading-units-override">
-              <span>Max&nbsp;Approved </span><span :id="`term-${term.termId}-max-units`">{{ student.sisProfile.currentTerm.unitsMaxOverride }}</span>
+              <span>Max&nbsp;Approved </span><span :id="`term-${term.termId}-max-units`">{{ student.sisProfile.currentTerm.unitsMax }}</span>
             </span>
+            -->
           </div>
         </div>
       </div>

--- a/tests/test_merged/test_student.py
+++ b/tests/test_merged/test_student.py
@@ -37,5 +37,5 @@ class TestMergedStudent:
 
         assert len(profiles['students']) == 1
         assert profiles['students'][0]['cumulativeUnits'] == 101.3
-        assert profiles['students'][0]['currentTerm']['unitsMaxOverride'] == 25
-        assert profiles['students'][0]['currentTerm']['unitsMinOverride'] == 0
+        assert profiles['students'][0]['currentTerm']['unitsMax'] == 25
+        assert profiles['students'][0]['currentTerm']['unitsMin'] == 0


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2753
https://jira-secure.berkeley.edu/browse/SISRP-48560

Why suppress? See comments in BOAC-2753. QA PR will follow.