### PR TITLE
BOAC-2711: Revamps admin page

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -108,11 +108,17 @@ def delete_university_dept_membership(university_dept_id, authorized_user_id):
     )
 
 
-@app.route('/api/users/authorized_groups')
+@app.route('/api/users/all')
 @admin_required
-def authorized_user_groups():
+def all_users():
     sort_users_by = util.get(request.args, 'sortUsersBy', None)
-    return tolerant_jsonify(_get_boa_user_groups(sort_users_by))
+    return tolerant_jsonify(_get_boa_users(sort_users_by))
+
+
+@app.route('/api/users/departments')
+@admin_required
+def departments():
+    return tolerant_jsonify(_get_boa_departments())
 
 
 @app.route('/api/user/demo_mode', methods=['POST'])
@@ -152,6 +158,16 @@ def download_boa_users_csv():
         filename_prefix='boa_users',
         fieldnames=['last_name', 'first_name', 'uid', 'email', 'dept_code', 'dept_name'],
     )
+
+
+def _get_boa_users(sort_user_by=None):
+    users = AuthorizedUser.get_all_users()
+    return authorized_users_api_feed(users, sort_user_by)
+
+
+def _get_boa_departments():
+    departments = [{'name': BERKELEY_DEPT_CODE_TO_NAME[dept_code], 'code': dept_code} for dept_code in BERKELEY_DEPT_CODE_TO_NAME.keys()]
+    return sorted(departments, key=lambda dept: dept['name'])
 
 
 def _get_boa_user_groups(sort_users_by=None):

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -35,6 +35,7 @@ from boac.merged import calnet
 from boac.merged.advising_note import get_advising_notes
 from boac.models.alert import Alert
 from boac.models.curated_group import CuratedGroup
+from dateutil.tz import tzutc
 from flask import current_app as app, request
 from flask_login import current_user
 
@@ -79,13 +80,18 @@ def authorized_users_api_feed(users, sort_by='lastName'):
         profile.update({
             'id': user.id,
             'isAdmin': user.is_admin,
+            'isBlocked': user.is_blocked,
+            'canAccessCanvasData': user.can_access_canvas_data,
+            'deletedAt': _isoformat(user.deleted_at),
             'departments': {},
         })
         for m in user.department_memberships:
             profile['departments'].update({
                 m.university_dept.dept_code: {
+                    'deptName': m.university_dept.dept_name,
                     'isAdvisor': m.is_advisor,
                     'isDirector': m.is_director,
+                    'automateMembership': m.automate_membership,
                 },
             })
         profiles.append(profile)
@@ -302,3 +308,7 @@ def response_with_students_csv_download(sids, benchmark):
         filename_prefix='cohort',
         fieldnames=['first_name', 'last_name', 'sid', 'email', 'phone'],
     )
+
+
+def _isoformat(value):
+    return value and value.astimezone(tzutc()).isoformat()

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -40,6 +40,7 @@ class AuthorizedUser(Base):
     can_access_canvas_data = db.Column(db.Boolean, nullable=False)
     created_by = db.Column(db.String(255), nullable=False)
     deleted_at = db.Column(db.DateTime, nullable=True)
+    # When True, is_blocked prevents a deleted user from being revived by the automated refresh.
     is_blocked = db.Column(db.Boolean, nullable=False, default=False)
     department_memberships = db.relationship(
         'UniversityDeptMember',
@@ -135,6 +136,10 @@ class AuthorizedUser(Base):
     @classmethod
     def get_all_active_users(cls):
         return cls.query.filter_by(deleted_at=None).all()
+
+    @classmethod
+    def get_all_users(cls):
+        return cls.query.all()
 
     @classmethod
     def get_all_uids_in_scope(cls, scope=()):

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -26,10 +26,16 @@ export function getUserByUid(uid) {
     .then(response => response.data, () => null);
 }
 
-export function getUserGroups(sortUsersBy: string) {
+export function getUsers(sortUsersBy: string) {
   let query = sortUsersBy ? `sortUsersBy=${sortUsersBy}` : '';
   return axios
-    .get(`${utils.apiBaseUrl()}/api/users/authorized_groups?${query}`)
+    .get(`${utils.apiBaseUrl()}/api/users/all?${query}`)
+    .then(response => response.data, () => null);
+}
+
+export function getDepartments() {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/users/departments`)
     .then(response => response.data, () => null);
 }
 

--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -1,0 +1,244 @@
+<template>
+  <div class="list-group">
+    <h2 id="dept-users-section" class="page-section-header-sub pb-2">
+      Users
+      <span class="text-black-50 font-size-14">(<a id="download-boa-users-csv" :href="`${apiBaseUrl}/api/users/csv`">download</a>)</span>
+    </h2>
+    <b-container class="pl-0 ml-0">
+      <b-form-row class="pb-2">
+        <b-col>
+          <b-form-select
+            v-if="departments.length"
+            id="department-select-list"
+            v-model="filter"
+            :options="departments"
+            value-field="code"
+            text-field="name"
+            role="listbox"
+            aria-label="Use up and down arrows to review departments. Hit enter to select a department.">
+            <template v-slot:first>
+              <option :value="null" disabled>-- Select a department --</option>
+            </template>
+          </b-form-select>
+        </b-col>
+        <b-col>
+          <b-input-group-append>
+            <b-button 
+              :disabled="!filter" 
+              @click="clearFilter">
+              Clear Filter
+            </b-button>
+          </b-input-group-append>
+        </b-col>
+      </b-form-row>
+    </b-container>
+    <b-table
+      id="users-table"
+      :fields="fields"
+      :filter="filter"
+      :filter-function="filterUsers"
+      :filter-included-fields="filterFields"
+      :items="items"
+      :no-sort-reset="true"
+      :small="true"
+      :sort-by.sync="sortBy"
+      :sort-compare="sortCompare"
+      :sort-desc.sync="sortDesc"
+      :per-page="perPage"
+      :current-page="currentPage"
+      fixed
+      primary-key="uid"
+      responsive
+      sort-icon-left
+      stacked="lg"
+      tbody-tr-class="font-size-14"
+      thead-class="sortable-table-header text-nowrap"
+      @filtered="onFilter">
+      <template slot="toggleDetails" slot-scope="row">
+        <b-btn
+          :id="`user-${row.item.uid}-details-toggle`"
+          class="user-details-toggle-button"
+          variant="link"
+          @click="row.toggleDetails">
+          <font-awesome v-if="!row.detailsShowing" icon="caret-right" />
+          <span v-if="!row.detailsShowing" class="sr-only">Show user details</span>
+          <font-awesome v-if="row.detailsShowing" icon="caret-down" />
+          <span v-if="row.detailsShowing" class="sr-only">Hide user details</span>
+        </b-btn>
+      </template>
+      <template slot="uid" slot-scope="row">
+        <span class="sr-only">U I D</span>
+        <div>{{ row.item.uid }}</div>
+      </template>
+      <template slot="name" slot-scope="row">
+        <span class="sr-only">User name</span>
+        <a
+          :id="`directory-link-${row.item.uid}`"
+          class="user-name"
+          :aria-label="`Go to UC Berkeley Directory page of ${row.item.name}`"
+          :href="`https://www.berkeley.edu/directory/results?search-term=${row.item.name}`"
+          target="_blank">
+          {{ row.item.name }}
+        </a>
+      </template>
+      <template slot="title" slot-scope="row">
+        <div>{{ row.item.title }}</div>
+      </template>
+      <template slot="depts" slot-scope="row">
+        <div
+          v-for="deptCode in keys(row.item.departments)"
+          :key="deptCode">
+          <span>{{ row.item.departments[deptCode]['deptName'] }}</span>
+        </div>
+      </template>
+      <template slot="campusEmail" slot-scope="row">
+        <div>{{ row.item.campusEmail }}</div>
+      </template>
+      <template slot="row-details" slot-scope="row">
+        <b-card>
+          <b-container>
+            <b-row>
+              <b-col>
+                <h3 class="user-details-header">Permissions</h3>
+                <ul class="flex-container flex-col">
+                  <li>{{ row.item.canAccessCanvasData ? 'Canvas data access' : 'No Canvas data' }}</li>
+                  <li v-if="row.item.isAdmin">Admin</li>
+                </ul>
+              </b-col>
+              <b-col>
+                <h3 class="user-details-header">Status</h3>
+                <ul class="flex-container flex-col">
+                  <li>{{ row.item.deletedAt ? 'Deleted' : 'Active' }}</li>
+                  <li v-if="row.item.isBlocked">Blocked</li>
+                  <li v-if="row.item.isExpiredPerLdap">Expired account (according to CalNet)</li>
+                </ul>
+              </b-col>
+            </b-row>
+          </b-container>
+        </b-card>
+      </template>
+      <template slot="actions" slot-scope="row">
+        <div class="flex-row">
+          <b-btn
+            :id="`user-${row.item.uid}-edit`"
+            :disabled="true"
+            :title="`Edit user ${row.item.name}`"
+            variant="link"
+            @click="openEdit">
+            <font-awesome icon="edit" />
+            <span class="sr-only">Edit user</span>
+          </b-btn>
+          <b-btn
+            v-if="devAuthEnabled && (row.item.uid !== user.uid) && !row.item.isExpiredPerLdap"
+            :id="'become-' + row.item.uid"
+            :title="`Log in as ${row.item.name}`"
+            variant="link"
+            @click="become(row.item.uid)">
+            <font-awesome icon="sign-in-alt" />
+          </b-btn>
+        </div>
+      </template>
+    </b-table>
+    <b-pagination
+      v-if="items"
+      id="users-paginator"
+      v-model="currentPage"
+      :total-rows="rowCount"
+      :per-page="perPage"
+      aria-controls="users-table">
+    </b-pagination>
+  </div>
+</template>
+
+<script>
+import Context from '@/mixins/Context';
+import UserMetadata from '@/mixins/UserMetadata';
+import Util from '@/mixins/Util';
+import { becomeUser } from '@/api/user';
+
+export default {
+  name: 'Users',
+  mixins: [Context, UserMetadata, Util],
+  props: {
+    departments: Array,
+    users: Array
+  },
+  data: () => ({
+    currentPage: 1,
+    fields: [
+      {key: 'toggleDetails', label: '', class: 'user-details-toggle'},
+      {key: 'uid', sortable: true, class: 'user-uid'},
+      {key: 'name', sortable: true},
+      {key: 'title', sortable: true},
+      {key: 'depts', label: 'Department(s)'},
+      {key: 'campusEmail'},
+      {key: 'actions', label: '', class: 'user-actions'}
+    ],
+    filter: null,
+    filterFields: ['depts'],
+    items: [],
+    perPage: 10,
+    rowCount: 0,
+    sortBy: 'lastName',
+    sortDesc: false
+  }),
+  created() {
+    this.items = this.cloneDeep(this.users);
+    this.rowCount = this.users ? this.size(this.users) : 0;
+  },
+  methods: {
+    become(uid) {
+      becomeUser(uid).then(() => (window.location.href = '/home'));
+    },
+    clearFilter() {
+      this.filter = null;
+    },
+    filterUsers(user, filter) {
+      return this.includes(this.keys(user.departments), filter);
+    },
+    onFilter(filteredItems) {
+      this.rowCount = filteredItems.length
+      this.currentPage = 1
+    },
+    openEdit() {
+      //TODO: BOAC-2844
+      return false;
+    },
+    sortCompare(a, b, sortBy) {
+      const key = sortBy === 'name' ? 'lastName' : sortBy
+      let aValue = this.get(a, key);
+      let bValue = this.get(b, key);
+      return this.sortComparator(aValue, bValue);
+    }
+  }
+}
+</script>
+
+<style>
+.user-actions {
+  width: 96px;
+}
+.user-details-header {
+  color: #aaa;
+  font-size: 13px;
+  font-weight: normal;
+  vertical-align: top;
+}
+.user-details-toggle {
+  width: 25px;
+}
+.user-details-toggle-button {
+  color: #337ab7;
+  height: 15px;
+  line-height: 1;
+  margin-right: 10px;
+  padding: 0;
+}
+.user-name {
+  color: #49b;
+  margin: 0;
+}
+.user-uid {
+  width: 75px;
+}
+</style>

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -1,18 +1,19 @@
 import _ from 'lodash';
 import Vue from 'vue';
 import { event } from 'vue-analytics';
-import { getUserByCsid, getUserGroups, getUserProfile } from '@/api/user';
+import { getUserByCsid, getUsers, getDepartments, getUserProfile } from '@/api/user';
 import { gaTrackUserSessionStart } from '@/api/ga';
 
 const gaEvent = (category, action, label, value) => event(category, action, label, value);
 
 const state = {
   calnetUsersByCsid: {},
+  departments: undefined,
   preferences: {
     sortBy: 'last_name'
   },
   user: undefined,
-  userGroups: undefined
+  users: undefined
 };
 
 const getters = {
@@ -32,7 +33,7 @@ const mutations = {
   },
   setDemoMode: (state: any, demoMode: boolean) =>
     (state.user.inDemoMode = demoMode),
-  setUserGroups: (state: any, userGroups: any[]) => (state.userGroups = userGroups),
+  setDepartments: (state: any, departments: any[]) => (state.departments = departments),
   setUserPreference: (state: any, {key, value}) => {
     if (_.has(state.preferences, key)) {
       state.preferences[key] = value;
@@ -40,7 +41,8 @@ const mutations = {
     } else {
       throw new TypeError('Invalid user preference type: ' + key);
     }
-  }
+  },
+  setUsers: (state: any, users: any[]) => (state.users = users)
 };
 
 const actions = {
@@ -64,15 +66,28 @@ const actions = {
       }
     });
   },
-  loadUserGroups: ({commit, state}) => {
+  loadUsers: ({commit, state}) => {
     return new Promise(resolve => {
-      if (state.userGroups) {
-        resolve(state.userGroups);
+      if (state.users) {
+        resolve(state.users);
       } else {
-        getUserGroups('firstName')
+        getUsers('firstName')
           .then(data => {
-            commit('setUserGroups', data);
-            resolve(state.userGroups);
+            commit('setUsers', data);
+            resolve(state.users);
+          });
+      }
+    });
+  },
+  loadDepartments: ({commit, state}) => {
+    return new Promise(resolve => {
+      if (state.departments) {
+        resolve(state.departments);
+      } else {
+        getDepartments()
+          .then(data => {
+            commit('setDepartments', data);
+            resolve(state.departments);
           });
       }
     });

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -254,39 +254,52 @@ class TestUniversityDeptMember:
         )
 
 
-class TestUserGroups:
-    """User API."""
+class TestDepartments:
+    """Departments API."""
 
     def test_not_authenticated(self, client):
         """Returns 'unauthorized' response status if user is not authenticated."""
-        response = client.get('/api/users/authorized_groups')
+        response = client.get('/api/users/departments')
         assert response.status_code == 401
 
     def test_unauthorized(self, client, fake_auth):
         """Returns 'unauthorized' response status if user is not admin."""
         fake_auth.login(coe_advisor_uid)
-        response = client.get('/api/users/authorized_groups')
+        response = client.get('/api/users/departments')
         assert response.status_code == 401
 
     def test_authorized(self, client, fake_auth):
         """Returns a well-formed response including cached and uncached users."""
         fake_auth.login(admin_uid)
-        response = client.get('/api/users/authorized_groups')
+        response = client.get('/api/users/departments')
         assert response.status_code == 200
-        user_groups = response.json
-        assert len(user_groups) == 6
-        assert user_groups[0]['name'] == 'Admins'
-        assert len(user_groups[0]['users']) == 8
-        assert user_groups[1]['name'] == 'Athletic Study Center'
-        assert len(user_groups[1]['users']) == 3
-        assert user_groups[2]['name'] == 'College of Engineering'
-        assert len(user_groups[2]['users']) == 4
-        assert user_groups[3]['name'] == 'L&S College Advising'
-        assert len(user_groups[3]['users']) == 1
-        assert user_groups[4]['name'] == 'L&S Major Advising'
-        assert len(user_groups[5]['users']) == 2
-        assert user_groups[5]['name'] == 'Notes Only'
-        assert len(user_groups[5]['users']) == 2
+        departments = response.json
+        assert len(departments) == 183
+
+
+class TestUsers:
+    """Users API."""
+
+    def test_not_authenticated(self, client):
+        """Returns 'unauthorized' response status if user is not authenticated."""
+        response = client.get('/api/users/all')
+        assert response.status_code == 401
+
+    def test_unauthorized(self, client, fake_auth):
+        """Returns 'unauthorized' response status if user is not admin."""
+        fake_auth.login(coe_advisor_uid)
+        response = client.get('/api/users/all')
+        assert response.status_code == 401
+
+    def test_authorized(self, client, fake_auth):
+        """Returns a well-formed response including cached, uncached, and deleted users."""
+        fake_auth.login(admin_uid)
+        response = client.get('/api/users/all')
+        assert response.status_code == 200
+        users = response.json
+        assert len(users) == 19
+        deleted_users = [user for user in users if user['deletedAt'] is not None]
+        assert len(deleted_users) == 3
 
 
 class TestDemoMode:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2844

The new table allows filtering by department, but that doesn't include not-real departments like Admin and Notes Only.  I'll submit another PR to expand filtering capabilities to include permissions and status.