### PR TITLE
BOAC-2795, university_dept_members gets 'is_scheduler'; protect APIs from non-advisor scheduler

### DIFF
--- a/boac/api/alerts_controller.py
+++ b/boac/api/alerts_controller.py
@@ -23,15 +23,16 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+from boac.api.util import advisor_required
 from boac.lib.http import tolerant_jsonify
 from boac.models.alert import Alert
 from boac.models.cohort_filter import CohortFilter
 from flask import current_app as app
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 
 @app.route('/api/alerts/<alert_id>/dismiss')
-@login_required
+@advisor_required
 def dismiss_alert(alert_id):
     user_id = current_user.get_id()
     Alert.dismiss(alert_id, user_id)

--- a/boac/api/auth_controller.py
+++ b/boac/api/auth_controller.py
@@ -26,13 +26,13 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from urllib.parse import urlencode, urljoin, urlparse
 
 from boac.api.errors import ResourceNotFoundError
-from boac.api.util import admin_required
+from boac.api.util import admin_required, advisor_required
 from boac.lib.http import add_param_to_url, tolerant_jsonify
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.user_login import UserLogin
 import cas
 from flask import abort, current_app as app, flash, redirect, request, url_for
-from flask_login import current_user, login_required, login_user, logout_user
+from flask_login import current_user, login_user, logout_user
 
 
 @app.route('/cas/login_url', methods=['GET'])
@@ -97,7 +97,7 @@ def become():
 
 
 @app.route('/api/auth/logout')
-@login_required
+@advisor_required
 def logout():
     _logout_user()
     redirect_url = app.config['VUE_LOCALHOST_BASE_URL'] or request.url_root

--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -182,7 +182,13 @@ def refresh_department_memberships():
                 can_access_canvas_data=membership['can_access_canvas_data'],
             )
             if user:
-                UniversityDeptMember.create_or_update_membership(dept, user, is_advisor=True, is_director=False)
+                UniversityDeptMember.create_or_update_membership(
+                    dept,
+                    user,
+                    is_advisor=True,
+                    is_director=False,
+                    is_scheduler=False,
+                )
 
 
 def load_filtered_cohort_counts():

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from datetime import datetime
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import is_unauthorized_search, response_with_students_csv_download
+from boac.api.util import advisor_required, is_unauthorized_search, response_with_students_csv_download
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param, get_benchmarker, to_bool_or_none as to_bool
 from boac.merged import calnet
@@ -35,11 +35,11 @@ from boac.merged.student import get_student_query_scope as get_query_scope, get_
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.cohort_filter import CohortFilter
 from flask import current_app as app, request
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 
 @app.route('/api/cohorts/my')
-@login_required
+@advisor_required
 def my_cohorts():
     cohorts = []
     for cohort in CohortFilter.get_cohorts_of_user_id(current_user.get_id()):
@@ -49,7 +49,7 @@ def my_cohorts():
 
 
 @app.route('/api/cohorts/all')
-@login_required
+@advisor_required
 def all_cohorts():
     scope = get_query_scope(current_user)
     uids = AuthorizedUser.get_all_uids_in_scope(scope)
@@ -69,7 +69,7 @@ def all_cohorts():
 
 
 @app.route('/api/cohort/<cohort_id>/students_with_alerts')
-@login_required
+@advisor_required
 def students_with_alerts(cohort_id):
     benchmark = get_benchmarker(f'cohort {cohort_id} students_with_alerts')
     benchmark('begin')
@@ -102,7 +102,7 @@ def students_with_alerts(cohort_id):
 
 
 @app.route('/api/cohort/<cohort_id>')
-@login_required
+@advisor_required
 def get_cohort(cohort_id):
     benchmark = get_benchmarker(f'cohort {cohort_id} get_cohort')
     benchmark('begin')
@@ -133,7 +133,7 @@ def get_cohort(cohort_id):
 
 
 @app.route('/api/cohort/get_students_per_filters', methods=['POST'])
-@login_required
+@advisor_required
 def get_cohort_per_filters():
     benchmark = get_benchmarker('cohort get_students_per_filters')
     benchmark('begin')
@@ -165,7 +165,7 @@ def get_cohort_per_filters():
 
 
 @app.route('/api/cohort/download_csv_per_filters', methods=['POST'])
-@login_required
+@advisor_required
 def download_csv_per_filters():
     benchmark = get_benchmarker('cohort download_csv_per_filters')
     benchmark('begin')
@@ -187,7 +187,7 @@ def download_csv_per_filters():
 
 
 @app.route('/api/cohort/create', methods=['POST'])
-@login_required
+@advisor_required
 def create_cohort():
     params = request.get_json()
     name = get_param(params, 'name', None)
@@ -212,7 +212,7 @@ def create_cohort():
 
 
 @app.route('/api/cohort/update', methods=['POST'])
-@login_required
+@advisor_required
 def update_cohort():
     params = request.get_json()
     cohort_id = int(params.get('id'))
@@ -239,7 +239,7 @@ def update_cohort():
 
 
 @app.route('/api/cohort/delete/<cohort_id>', methods=['DELETE'])
-@login_required
+@advisor_required
 def delete_cohort(cohort_id):
     if cohort_id.isdigit():
         cohort_id = int(cohort_id)
@@ -253,7 +253,7 @@ def delete_cohort(cohort_id):
 
 
 @app.route('/api/cohort/filter_options/<cohort_owner_uid>', methods=['POST'])
-@login_required
+@advisor_required
 def all_cohort_filter_options(cohort_owner_uid):
     if cohort_owner_uid == 'me':
         cohort_owner_uid = current_user.get_uid()
@@ -262,7 +262,7 @@ def all_cohort_filter_options(cohort_owner_uid):
 
 
 @app.route('/api/cohort/translate_to_filter_options/<cohort_owner_uid>', methods=['POST'])
-@login_required
+@advisor_required
 def translate_cohort_filter_to_menu(cohort_owner_uid):
     if cohort_owner_uid == 'me':
         cohort_owner_uid = current_user.get_uid()

--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -24,17 +24,18 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import ForbiddenRequestError, ResourceNotFoundError
+from boac.api.util import advisor_required
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
 from boac.merged.sis_sections import get_sis_section
 from boac.merged.student import get_course_student_profiles
 from boac.models.alert import Alert
 from flask import current_app as app, request
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 
 @app.route('/api/section/<term_id>/<section_id>')
-@login_required
+@advisor_required
 def get_section(term_id, section_id):
     if not current_user.can_access_canvas_data:
         raise ForbiddenRequestError('Unauthorized to view course data')

--- a/boac/api/curated_group_controller.py
+++ b/boac/api/curated_group_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import get_my_curated_groups, response_with_students_csv_download
+from boac.api.util import advisor_required, get_my_curated_groups, response_with_students_csv_download
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param, get_benchmarker
 from boac.merged import calnet
@@ -34,17 +34,17 @@ from boac.models.authorized_user import AuthorizedUser
 from boac.models.curated_group import CuratedGroup
 from flask import current_app as app, request
 from flask_cors import cross_origin
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 
 @app.route('/api/curated_groups/my')
-@login_required
+@advisor_required
 def my_curated_groups():
     return tolerant_jsonify(get_my_curated_groups())
 
 
 @app.route('/api/curated_groups/all')
-@login_required
+@advisor_required
 def all_curated_groups():
     scope = get_query_scope(current_user)
     uids = AuthorizedUser.get_all_uids_in_scope(scope)
@@ -63,7 +63,7 @@ def all_curated_groups():
 
 
 @app.route('/api/curated_group/create', methods=['POST'])
-@login_required
+@advisor_required
 def create_curated_group():
     params = request.get_json()
     name = params.get('name', None)
@@ -78,7 +78,7 @@ def create_curated_group():
 
 
 @app.route('/api/curated_group/delete/<curated_group_id>', methods=['DELETE'])
-@login_required
+@advisor_required
 @cross_origin(allow_headers=['Content-Type'])
 def delete_curated_group(curated_group_id):
     curated_group = CuratedGroup.find_by_id(curated_group_id)
@@ -91,7 +91,7 @@ def delete_curated_group(curated_group_id):
 
 
 @app.route('/api/curated_group/<curated_group_id>')
-@login_required
+@advisor_required
 def get_curated_group(curated_group_id):
     offset = get_param(request.args, 'offset', 0)
     limit = get_param(request.args, 'limit', 50)
@@ -101,7 +101,7 @@ def get_curated_group(curated_group_id):
 
 
 @app.route('/api/curated_group/<curated_group_id>/download_csv')
-@login_required
+@advisor_required
 def download_csv(curated_group_id):
     benchmark = get_benchmarker(f'curated group {curated_group_id} download_csv')
     benchmark('begin')
@@ -114,7 +114,7 @@ def download_csv(curated_group_id):
 
 
 @app.route('/api/curated_group/<curated_group_id>/students_with_alerts')
-@login_required
+@advisor_required
 def get_students_with_alerts(curated_group_id):
     offset = get_param(request.args, 'offset', 0)
     limit = get_param(request.args, 'limit', 50)
@@ -149,13 +149,13 @@ def get_students_with_alerts(curated_group_id):
 
 
 @app.route('/api/curated_groups/my/<sid>')
-@login_required
+@advisor_required
 def curated_group_ids_per_sid(sid):
     return tolerant_jsonify(CuratedGroup.curated_group_ids_per_sid(user_id=current_user.get_id(), sid=sid))
 
 
 @app.route('/api/curated_group/<curated_group_id>/remove_student/<sid>', methods=['DELETE'])
-@login_required
+@advisor_required
 @cross_origin(allow_headers=['Content-Type'])
 def remove_student_from_curated_group(curated_group_id, sid):
     curated_group = CuratedGroup.find_by_id(curated_group_id)
@@ -168,7 +168,7 @@ def remove_student_from_curated_group(curated_group_id, sid):
 
 
 @app.route('/api/curated_group/students/add', methods=['POST'])
-@login_required
+@advisor_required
 def add_students_to_curated_group():
     params = request.get_json()
     curated_group_id = params.get('curatedGroupId')
@@ -190,7 +190,7 @@ def add_students_to_curated_group():
 
 
 @app.route('/api/curated_group/rename', methods=['POST'])
-@login_required
+@advisor_required
 def rename_curated_group():
     params = request.get_json()
     name = params['name']

--- a/boac/api/note_templates_controller.py
+++ b/boac/api/note_templates_controller.py
@@ -24,16 +24,16 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import get_note_attachments_from_http_post, get_note_topics_from_http_post
+from boac.api.util import advisor_required, get_note_attachments_from_http_post, get_note_topics_from_http_post
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import process_input_from_rich_text_editor
 from boac.models.note_template import NoteTemplate
 from flask import current_app as app, request
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 
 @app.route('/api/note_template/create', methods=['POST'])
-@login_required
+@advisor_required
 def create_note_template():
     params = request.form
     title = params.get('title', None)
@@ -59,7 +59,7 @@ def create_note_template():
 
 
 @app.route('/api/note_template/<note_template_id>')
-@login_required
+@advisor_required
 def get_note_template(note_template_id):
     note_template = NoteTemplate.find_by_id(note_template_id=note_template_id)
     if not note_template:
@@ -70,14 +70,14 @@ def get_note_template(note_template_id):
 
 
 @app.route('/api/note_templates/my')
-@login_required
+@advisor_required
 def get_my_note_templates():
     note_templates = NoteTemplate.get_templates_created_by(creator_id=current_user.get_id())
     return tolerant_jsonify([t.to_api_json() for t in note_templates])
 
 
 @app.route('/api/note_template/rename', methods=['POST'])
-@login_required
+@advisor_required
 def rename_note_template():
     params = request.get_json()
     note_template_id = params.get('id', None)
@@ -94,7 +94,7 @@ def rename_note_template():
 
 
 @app.route('/api/note_template/update', methods=['POST'])
-@login_required
+@advisor_required
 def update_note_template():
     params = request.form
     note_template_id = params.get('id', None)
@@ -123,7 +123,7 @@ def update_note_template():
 
 
 @app.route('/api/note_template/delete/<note_template_id>', methods=['DELETE'])
-@login_required
+@advisor_required
 def delete_note_template(note_template_id):
     note_template = NoteTemplate.find_by_id(note_template_id=note_template_id)
     if not note_template:

--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -27,7 +27,7 @@ from datetime import timedelta
 from itertools import islice
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError
-from boac.api.util import add_alert_counts, is_unauthorized_search
+from boac.api.util import add_alert_counts, advisor_required, is_unauthorized_search
 from boac.externals.data_loch import get_enrolled_primary_sections, get_enrolled_primary_sections_for_parsed_code
 from boac.lib import util
 from boac.lib.berkeley import current_term_id
@@ -36,11 +36,11 @@ from boac.merged.advising_note import search_advising_notes
 from boac.merged.student import search_for_students
 from boac.models.alert import Alert
 from flask import current_app as app, request
-from flask_login import current_user, login_required
+from flask_login import current_user
 
 
 @app.route('/api/search', methods=['POST'])
-@login_required
+@advisor_required
 def search():
     params = util.remove_none_values(request.get_json())
     order_by = util.get(params, 'orderBy', None)

--- a/boac/api/student_controller.py
+++ b/boac/api/student_controller.py
@@ -24,16 +24,15 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ResourceNotFoundError
-from boac.api.util import put_notifications
+from boac.api.util import advisor_required, put_notifications
 from boac.externals.data_loch import match_students_by_name_or_sid, query_historical_sids
 from boac.lib.http import tolerant_jsonify
 from boac.merged.student import get_student_and_terms_by_sid, get_student_and_terms_by_uid, query_students
 from flask import current_app as app, request
-from flask_login import login_required
 
 
 @app.route('/api/student/by_sid/<sid>')
-@login_required
+@advisor_required
 def get_student_by_sid(sid):
     student = get_student_and_terms_by_sid(sid)
     if not student:
@@ -43,7 +42,7 @@ def get_student_by_sid(sid):
 
 
 @app.route('/api/student/by_uid/<uid>')
-@login_required
+@advisor_required
 def get_student_by_uid(uid):
     student = get_student_and_terms_by_uid(uid)
     if not student:
@@ -53,7 +52,7 @@ def get_student_by_uid(uid):
 
 
 @app.route('/api/students/find_by_name_or_sid', methods=['GET'])
-@login_required
+@advisor_required
 def find_by_name_or_sid():
     query = request.args.get('q')
     if not query:
@@ -72,7 +71,7 @@ def find_by_name_or_sid():
 
 
 @app.route('/api/students/validate_sids', methods=['POST'])
-@login_required
+@advisor_required
 def validate_sids():
     params = request.get_json()
     sids = [sid.strip() for sid in list(params.get('sids'))]

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api import errors
-from boac.api.util import admin_required, authorized_users_api_feed
+from boac.api.util import admin_required, advisor_required, authorized_users_api_feed
 from boac.lib import util
 from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME
 from boac.lib.http import response_with_csv_download, tolerant_jsonify
@@ -50,13 +50,13 @@ def user_profile(uid):
 
 
 @app.route('/api/user/by_csid/<csid>')
-@login_required
+@advisor_required
 def calnet_profile(csid):
     return tolerant_jsonify(calnet.get_calnet_user_for_csid(app, csid))
 
 
 @app.route('/api/user/by_uid/<uid>')
-@login_required
+@advisor_required
 def user_by_uid(uid):
     return tolerant_jsonify(calnet.get_calnet_user_for_uid(app, uid))
 
@@ -72,6 +72,7 @@ def add_university_dept_membership():
         authorized_user=user,
         is_advisor=params.get('isAdvisor', False),
         is_director=params.get('isDirector', False),
+        is_scheduler=params.get('isScheduler', False),
         automate_membership=params.get('automateMembership', True),
     )
     return tolerant_jsonify(membership.to_api_json())
@@ -88,6 +89,7 @@ def update_university_dept_membership():
         authorized_user_id=user.id,
         is_advisor=params.get('isAdvisor', None),
         is_director=params.get('isDirector', None),
+        is_scheduler=params.get('isScheduler', False),
         automate_membership=params.get('automateMembership', None),
     )
     if not membership:

--- a/boac/merged/user_session.py
+++ b/boac/merged/user_session.py
@@ -128,6 +128,7 @@ class UserSession(UserMixin):
                         'role': get_dept_role(m),
                         'isAdvisor': m.is_advisor,
                         'isDirector': m.is_director,
+                        'isScheduler': m.is_scheduler,
                     })
             dept_codes = get_dept_codes(user) if user else []
             is_asc = 'UWASC' in dept_codes
@@ -140,7 +141,7 @@ class UserSession(UserMixin):
                 is_active = True
             elif len(user.department_memberships):
                 for m in user.department_memberships:
-                    is_active = m.is_advisor or m.is_director
+                    is_active = m.is_advisor or m.is_director or m.is_scheduler
                     if is_active:
                         break
         is_admin = user and user.is_admin

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -48,22 +48,128 @@ from sqlalchemy.sql import text
 no_calnet_record_for_uid = '13'
 
 _test_users = [
-    [no_calnet_record_for_uid, None, True, False, True],  # This user has no entry in calnet_search_entries
-    ['1', '111111111', None, True, False, False],
-    ['2', '222222222', None, True, False, False],
-    ['2040', None, True, True, True],
-    ['53791', None, True, False, True],
-    ['95509', None, True, False, True],
-    ['177473', None, True, False, True],
-    ['1133399', '800700600', False, False, True],
-    ['211159', None, True, False, True],
-    ['242881', '100100600', False, False, True, 'HENGL', 'Harmless Drudge'],
-    ['1022796', '100100300', False, False, True],
-    ['1015674', None, False, False, True],
-    ['1049291', None, True, False, True],
-    ['1081940', '100200300', False, False, True],
-    ['90412', '100100100', True, False, True],
-    ['6446', None, False, False, True],
+    {
+        # This user has no entry in calnet_search_entries
+        'uid': no_calnet_record_for_uid,
+        'csid': None,
+        'isAdmin': True,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '1',
+        'csid': '111111111',
+        'isAdmin': False,
+        'inDemoMode': True,
+        'canAccessCanvasData': False,
+    },
+    {
+        'uid': '2',
+        'csid': '222222222',
+        'isAdmin': False,
+        'inDemoMode': True,
+        'canAccessCanvasData': False,
+    },
+    {
+        'uid': '2040',
+        'csid': None,
+        'isAdmin': True,
+        'inDemoMode': True,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '53791',
+        'csid': None,
+        'isAdmin': True,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '95509',
+        'csid': None,
+        'isAdmin': True,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '177473',
+        'csid': None,
+        'isAdmin': True,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '1133399',
+        'csid': '800700600',
+        'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '211159',
+        'csid': None,
+        'isAdmin': True,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '242881',
+        'csid': '100100600',
+        'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+        'title': 'Harmless Drudge',
+        'calnetDeptCodes': ['HENGL'],
+    },
+    {
+        'uid': '1022796',
+        'csid': '100100300',
+        'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '6972201',
+        'csid': '100400900',
+        'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': False,
+    },
+    {
+        'uid': '1015674',
+        'csid': None,
+        'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '1049291',
+        'csid': None,
+        'isAdmin': True,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '1081940',
+        'csid': '100200300',
+        'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '90412',
+        'csid': '100100100',
+        'isAdmin': True,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
+    {
+        'uid': '6446',
+        'csid': None,
+        'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': True,
+    },
 ]
 
 _university_depts = {
@@ -71,26 +177,37 @@ _university_depts = {
         'users': [
             {
                 'uid': '1022796',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': True,
             },
             {
+                'uid': '6972201',
+                'isAdvisor': False,
+                'isDirector': False,
+                'isScheduler': True,
+                'automate_membership': False,
+            },
+            {
                 'uid': '90412',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': True,
             },
             {
                 'uid': '1133399',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': True,
             },
             {
                 'uid': '13',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': True,
             },
         ],
@@ -99,8 +216,9 @@ _university_depts = {
         'users': [
             {
                 'uid': '53791',
-                'is_advisor': False,
-                'is_director': True,
+                'isAdvisor': False,
+                'isDirector': True,
+                'isScheduler': False,
                 'automate_membership': False,
             },
         ],
@@ -109,8 +227,9 @@ _university_depts = {
         'users': [
             {
                 'uid': '242881',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': True,
             },
         ],
@@ -119,20 +238,23 @@ _university_depts = {
         'users': [
             {
                 'uid': '1081940',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': False,
             },
             {
                 'uid': '90412',
-                'is_advisor': False,
-                'is_director': True,
+                'isAdvisor': False,
+                'isDirector': True,
+                'isScheduler': False,
                 'automate_membership': False,
             },
             {
                 'uid': '6446',
-                'is_advisor': True,
-                'is_director': True,
+                'isAdvisor': True,
+                'isDirector': True,
+                'isScheduler': False,
                 'automate_membership': False,
             },
         ],
@@ -141,8 +263,9 @@ _university_depts = {
         'users': [
             {
                 'uid': '1',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': True,
             },
         ],
@@ -151,8 +274,9 @@ _university_depts = {
         'users': [
             {
                 'uid': '2',
-                'is_advisor': True,
-                'is_director': False,
+                'isAdvisor': True,
+                'isDirector': False,
+                'isScheduler': False,
                 'automate_membership': False,
             },
         ],
@@ -190,8 +314,8 @@ def load_development_data():
         UniversityDept.create(code, name)
     for test_user in _test_users:
         # This script can be run more than once. Do not create user if s/he exists in BOAC db.
-        uid = test_user[0]
-        csid = test_user[1]
+        uid = test_user['uid']
+        csid = test_user['csid']
         user = AuthorizedUser.find_by_uid(uid=uid)
         if uid != no_calnet_record_for_uid:
             # Put mock CalNet data in our json_cache for all users EXCEPT the test "no_calnet_record" user.
@@ -205,23 +329,23 @@ def load_development_data():
                 'lastName': last_name,
                 'name': f'{first_name} {last_name}',
             }
-            if len(test_user) > 5:
-                calnet_feed['departments'] = [
-                    {
-                        'code': test_user[5],
-                        'name': BERKELEY_DEPT_CODE_TO_NAME.get(test_user[5]),
-                    },
-                ]
-            if len(test_user) > 6:
-                calnet_feed['title'] = test_user[6]
+            if 'calnetDeptCodes' in test_user:
+                calnet_feed['departments'] = []
+                for dept_code in test_user['calnetDeptCodes']:
+                    calnet_feed['departments'].append({
+                        'code': dept_code,
+                        'name': BERKELEY_DEPT_CODE_TO_NAME.get(dept_code),
+                    })
+            if 'title' in test_user:
+                calnet_feed['title'] = test_user['title']
             insert_in_json_cache(f'calnet_user_for_uid_{uid}', calnet_feed)
         if not user:
             user = AuthorizedUser(
                 uid=uid,
                 created_by='2040',
-                is_admin=test_user[2],
-                in_demo_mode=test_user[3],
-                can_access_canvas_data=test_user[4],
+                is_admin=test_user['isAdmin'],
+                in_demo_mode=test_user['inDemoMode'],
+                can_access_canvas_data=test_user['canAccessCanvasData'],
             )
             db.session.add(user)
     for dept_code, dept_membership in _university_depts.items():
@@ -232,8 +356,9 @@ def load_development_data():
             UniversityDeptMember.create_or_update_membership(
                 university_dept,
                 authorized_user,
-                user['is_advisor'],
-                user['is_director'],
+                user['isAdvisor'],
+                user['isDirector'],
+                user['isScheduler'],
                 user['automate_membership'],
             )
     std_commit(allow_test_environment=True)

--- a/boac/models/university_dept_member.py
+++ b/boac/models/university_dept_member.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from boac import db, std_commit
 from boac.models.base import Base
 from boac.models.university_dept import UniversityDept
@@ -36,26 +35,44 @@ class UniversityDeptMember(Base):
     authorized_user_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), primary_key=True)
     is_advisor = db.Column(db.Boolean, nullable=False)
     is_director = db.Column(db.Boolean, nullable=False)
+    is_scheduler = db.Column(db.Boolean, nullable=False)
     automate_membership = db.Column(db.Boolean, nullable=False)
     authorized_user = db.relationship('AuthorizedUser', back_populates='department_memberships')
     # Pre-load UniversityDept below to avoid 'failed to locate', as seen during routes.py init phase
     university_dept = db.relationship(UniversityDept.__name__, back_populates='authorized_users')
 
-    def __init__(self, is_advisor, is_director, automate_membership=True):
+    def __init__(self, is_advisor, is_director, is_scheduler, automate_membership=True):
         self.is_advisor = is_advisor
         self.is_director = is_director
+        self.is_scheduler = is_scheduler
         self.automate_membership = automate_membership
 
     @classmethod
-    def create_or_update_membership(cls, university_dept, authorized_user, is_advisor, is_director, automate_membership=True):
-        existing_membership = cls.query.filter_by(university_dept_id=university_dept.id, authorized_user_id=authorized_user.id).first()
+    def create_or_update_membership(
+            cls,
+            university_dept,
+            authorized_user,
+            is_advisor,
+            is_director,
+            is_scheduler,
+            automate_membership=True,
+    ):
+        dept_id = university_dept.id
+        user_id = authorized_user.id
+        existing_membership = cls.query.filter_by(university_dept_id=dept_id, authorized_user_id=user_id).first()
         if existing_membership:
             membership = existing_membership
             membership.is_advisor = is_advisor
             membership.is_director = is_director
+            membership.is_scheduler = is_scheduler
             membership.automate_membership = automate_membership
         else:
-            membership = cls(is_advisor=is_advisor, is_director=is_director, automate_membership=automate_membership)
+            membership = cls(
+                is_advisor=is_advisor,
+                is_director=is_director,
+                is_scheduler=is_scheduler,
+                automate_membership=automate_membership,
+            )
             membership.authorized_user = authorized_user
             membership.university_dept = university_dept
             authorized_user.department_memberships.append(membership)
@@ -65,11 +82,20 @@ class UniversityDeptMember(Base):
         return membership
 
     @classmethod
-    def update_membership(cls, university_dept_id, authorized_user_id, is_advisor, is_director, automate_membership):
+    def update_membership(
+            cls,
+            university_dept_id,
+            authorized_user_id,
+            is_advisor,
+            is_director,
+            is_scheduler,
+            automate_membership,
+    ):
         membership = cls.query.filter_by(university_dept_id=university_dept_id, authorized_user_id=authorized_user_id).first()
         if membership:
             membership.is_advisor = membership.is_advisor if is_advisor is None else is_advisor
             membership.is_director = membership.is_director if is_director is None else is_director
+            membership.is_scheduler = membership.is_scheduler if is_scheduler is None else is_scheduler
             membership.automate_membership = membership.automate_membership if automate_membership is None else automate_membership
             std_commit()
             return membership
@@ -90,5 +116,6 @@ class UniversityDeptMember(Base):
             'authorizedUserId': self.authorized_user_id,
             'isAdvisor': self.is_advisor,
             'isDirector': self.is_director,
+            'isScheduler': self.is_scheduler,
             'automateMembership': self.automate_membership,
         }

--- a/scripts/db/migrate/20191007-BOAC-2805/pre_deploy_01_add_column_is_scheduler.sql
+++ b/scripts/db/migrate/20191007-BOAC-2805/pre_deploy_01_add_column_is_scheduler.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE university_dept_members ADD COLUMN is_scheduler boolean DEFAULT false;
+
+UPDATE university_dept_members SET is_scheduler = false;
+
+ALTER TABLE ONLY university_dept_members ALTER COLUMN is_scheduler SET NOT NULL;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -429,6 +429,7 @@ CREATE TABLE university_dept_members (
   authorized_user_id INTEGER,
   is_advisor BOOLEAN DEFAULT false NOT NULL,
   is_director BOOLEAN DEFAULT false NOT NULL,
+  is_scheduler BOOLEAN DEFAULT false NOT NULL,
   automate_membership boolean DEFAULT true NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -113,7 +113,7 @@ class TestRefreshDepartmentMemberships:
 
         dept_coe = UniversityDept.query.filter_by(dept_code='COENG').first()
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 3
+        assert len(coe_users) == 4
         assert next((u for u in coe_users if u.uid == '1022796'), None) is None
 
         from boac.api.cache_utils import refresh_department_memberships
@@ -121,7 +121,7 @@ class TestRefreshDepartmentMemberships:
         std_commit(allow_test_environment=True)
 
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 4
+        assert len(coe_users) == 5
         assert next(u for u in coe_users if u.uid == '1022796')
         user = AuthorizedUser.query.filter_by(uid='1022796').first()
         assert user.deleted_at is None
@@ -137,7 +137,7 @@ class TestRefreshDepartmentMemberships:
 
         dept_coe = UniversityDept.query.filter_by(dept_code='COENG').first()
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 3
+        assert len(coe_users) == 4
         assert next((u for u in coe_users if u.uid == '1022796'), None) is None
 
         from boac.api.cache_utils import refresh_department_memberships
@@ -145,7 +145,7 @@ class TestRefreshDepartmentMemberships:
         std_commit(allow_test_environment=True)
 
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 4
+        assert len(coe_users) == 5
         assert next(u for u in coe_users if u.uid == '1022796')
         user = AuthorizedUser.query.filter_by(uid='1022796').first()
         assert user.deleted_at is None
@@ -156,11 +156,17 @@ class TestRefreshDepartmentMemberships:
         """Removes COE advisors not found in the loch."""
         dept_coe = UniversityDept.query.filter_by(dept_code='COENG').first()
         bad_user = AuthorizedUser.create_or_restore(uid='666', created_by='2040')
-        UniversityDeptMember.create_or_update_membership(dept_coe, bad_user, is_advisor=True, is_director=False)
+        UniversityDeptMember.create_or_update_membership(
+            dept_coe,
+            bad_user,
+            is_advisor=True,
+            is_director=False,
+            is_scheduler=False,
+        )
         std_commit(allow_test_environment=True)
 
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 5
+        assert len(coe_users) == 6
         assert next(u for u in coe_users if u.uid == '666')
         assert AuthorizedUser.query.filter_by(uid='666').first().deleted_at is None
 
@@ -169,7 +175,7 @@ class TestRefreshDepartmentMemberships:
         std_commit(allow_test_environment=True)
 
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 4
+        assert len(coe_users) == 5
         assert next((u for u in coe_users if u.uid == '666'), None) is None
         assert AuthorizedUser.query.filter_by(uid='666').first().deleted_at
 
@@ -181,6 +187,7 @@ class TestRefreshDepartmentMemberships:
             manually_added_user,
             is_advisor=True,
             is_director=False,
+            is_scheduler=False,
             automate_membership=False,
         )
 
@@ -189,7 +196,7 @@ class TestRefreshDepartmentMemberships:
         std_commit(allow_test_environment=True)
 
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 5
+        assert len(coe_users) == 6
         assert next(u for u in coe_users if u.uid == '1024')
         assert AuthorizedUser.query.filter_by(uid='1024').first().deleted_at is None
 
@@ -201,7 +208,7 @@ class TestRefreshDepartmentMemberships:
         std_commit(allow_test_environment=True)
 
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == 4
+        assert len(coe_users) == 5
         assert next((u for u in coe_users if u.uid == '1024'), None) is None
         assert AuthorizedUser.query.filter_by(uid='1024').first().deleted_at
 
@@ -258,7 +265,13 @@ class TestRefreshDepartmentMemberships:
         """Updates membership for a former CoE advisor who switches to L&S."""
         user = AuthorizedUser.find_by_uid('242881')
         dept_coe = UniversityDept.query.filter_by(dept_code='COENG').first()
-        UniversityDeptMember.create_or_update_membership(dept_coe, user, is_advisor=True, is_director=False)
+        UniversityDeptMember.create_or_update_membership(
+            dept_coe,
+            user,
+            is_advisor=True,
+            is_director=False,
+            is_scheduler=False,
+        )
         dept_ucls = UniversityDept.query.filter_by(dept_code='QCADVMAJ').first()
         UniversityDeptMember.delete_membership(dept_ucls.id, user.id)
         std_commit(allow_test_environment=True)

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -27,6 +27,7 @@ import pytest
 
 asc_advisor_uid = '1081940'
 coe_advisor_uid = '1133399'
+coe_scheduler_uid = '6972201'
 term_id = 2178
 student_uid = '61889'
 student_sid = '11667051'
@@ -44,6 +45,11 @@ def coe_advisor(fake_auth):
 
 
 @pytest.fixture()
+def coe_scheduler(fake_auth):
+    fake_auth.login(coe_scheduler_uid)
+
+
+@pytest.fixture()
 def no_canvas_access_advisor(fake_auth):
     fake_auth.login('1')
 
@@ -53,6 +59,10 @@ class TestCourseController:
 
     def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
+        assert client.get('/api/section/2182/1').status_code == 401
+
+    def test_coe_scheduler_not_authorized(self, coe_scheduler, client):
+        """Returns 403 if user is only a scheduler."""
         assert client.get('/api/section/2182/1').status_code == 401
 
     def test_not_authorized(self, no_canvas_access_advisor, client):

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -33,6 +33,7 @@ import simplejson as json
 admin_uid = '2040'
 asc_advisor_uid = '6446'
 coe_advisor_uid = '1133399'
+coe_scheduler_uid = '6972201'
 asc_and_coe_advisor_uid = '90412'
 
 
@@ -49,6 +50,11 @@ def asc_and_coe_advisor(fake_auth):
 @pytest.fixture()
 def coe_advisor(fake_auth):
     fake_auth.login(coe_advisor_uid)
+
+
+@pytest.fixture()
+def coe_scheduler(fake_auth):
+    fake_auth.login(coe_scheduler_uid)
 
 
 @pytest.fixture()
@@ -269,6 +275,10 @@ class TestMyCuratedGroups:
 
     def test_not_authenticated(self, client):
         """Anonymous user is rejected."""
+        self._api_my_curated_groups(client, expected_status_code=401)
+
+    def test_coe_scheduler_not_allowed(self, client, coe_scheduler):
+        """User who is_scheduler will be denied."""
         self._api_my_curated_groups(client, expected_status_code=401)
 
     def test_coe_curated_groups(self, client, coe_advisor):

--- a/tests/test_api/test_search_controller.py
+++ b/tests/test_api/test_search_controller.py
@@ -48,6 +48,11 @@ def coe_advisor(fake_auth):
 
 
 @pytest.fixture()
+def coe_scheduler(fake_auth):
+    fake_auth.login('6972201')
+
+
+@pytest.fixture()
 def no_canvas_access_advisor(fake_auth):
     fake_auth.login('1')
 
@@ -67,6 +72,11 @@ class TestStudentSearch:
     def test_search_not_authenticated(self, client):
         """Search is not available to the world."""
         response = client.post('/api/search')
+        assert response.status_code == 401
+
+    def test_scheduler_cannot_search(self, client, coe_scheduler):
+        """Search is not available to scheduler."""
+        response = client.post('/api/search', data=json.dumps({'searchPhrase': 'Foo'}), content_type='application/json')
         assert response.status_code == 401
 
     def test_unauthorized_request_for_athletic_study_center_data(self, client, fake_auth):


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2795
https://jira.ets.berkeley.edu/jira/browse/BOAC-2805

Basic features of BOA are only available to admins and advisors. If user `is_scheduler` then s/he only gets `/appt/desk`. PR for front-end will follow.