### PR TITLE
BOAC-2804, header dropdown in '/appt/desk' view includes 'Settings' option

### DIFF
--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -14,7 +14,10 @@
             <div class="b-link-text">{{ user.firstName }}</div><font-awesome icon="caret-down" class="ml-1 b-link-text" />
           </div>
         </template>
-        <b-dropdown-item v-if="user.isAdmin || isDemoModeAvailable" @click="goAdmin">Admin</b-dropdown-item>
+        <b-dropdown-item v-if="user.isAdmin || isDemoModeAvailable" @click="goAdmin">
+          <span v-if="user.isAdmin">Admin</span>
+          <span v-if="!user.isAdmin">Settings</span>
+        </b-dropdown-item>
         <b-dropdown-item href="#" @click="logOut">Log Out</b-dropdown-item>
         <b-dropdown-item :href="`mailto:${supportEmailAddress}`" target="_blank">Feedback/Help</b-dropdown-item>
       </b-dropdown>
@@ -35,7 +38,7 @@ export default {
       getCasLogoutUrl().then(data => window.location.href = data.casLogoutUrl);
     },
     goAdmin() {
-      this.$router.push({ path: '/admin' });
+      this.$router.push({ path: this.isUserSimplyScheduler() ? '/scheduler/settings' : '/admin' });
     }
   }
 };

--- a/src/components/student/SortBy.vue
+++ b/src/components/student/SortBy.vue
@@ -50,7 +50,7 @@ export default {
       {
         name: 'Team',
         value: 'group_name',
-        available: this.user.isAdmin || this.includes(this.myDeptCodesWhereAdvising(), 'UWASC')
+        available: this.user.isAdmin || this.includes(this.myDeptCodes(['isAdvisor', 'isDirector']), 'UWASC')
       },
       { name: 'Units Completed', value: 'units', available: true }
     ];

--- a/src/layouts/DropInDesk.vue
+++ b/src/layouts/DropInDesk.vue
@@ -1,6 +1,6 @@
 <template>
   <b-container id="app" class="h-100 p-0" fluid>
-    <StandardHeaderLayout :show-link-to-home="false" />
+    <StandardHeaderLayout />
     <b-row class="row-content" no-gutters>
       <b-col id="content" class="body-text h-100 min-width-100 pb-2" sm="10">
         <ServiceAnnouncement />

--- a/src/layouts/shared/StandardHeaderLayout.vue
+++ b/src/layouts/shared/StandardHeaderLayout.vue
@@ -7,10 +7,9 @@
         class="sr-only sr-only-focusable"
         tabindex="0">Skip to main content</a>
       <router-link
-        v-if="showLinkToHome"
         id="home-header"
         class="header-text"
-        to="/home"
+        to="/"
         tabindex="0">
         <span class="sr-only">Return to </span>Home
       </router-link>
@@ -28,13 +27,6 @@ export default {
   name: 'StandardHeaderLayout',
   components: {
     HeaderMenu
-  },
-  props: {
-    showLinkToHome: {
-      required: false,
-      type: Boolean,
-      default: true
-    }
   }
 }
 </script>

--- a/src/mixins/UserMetadata.vue
+++ b/src/mixins/UserMetadata.vue
@@ -3,6 +3,11 @@ import _ from 'lodash';
 import store from '@/store';
 import { mapActions, mapGetters } from 'vuex';
 
+const $_myDeptCodes = roles => {
+  const user = store.getters['user/user'];
+  return _.map(_.filter(user.departments, d => _.findIndex(roles, role => d[role]) > -1), ['deptCode']);
+};
+
 export default {
   name: 'UserMetadata',
   computed: {
@@ -28,10 +33,12 @@ export default {
       'loadCalnetUserByCsid',
       'setUserPreference'
     ]),
-    myDeptCodesWhereAdvising() {
-      const user = store.getters['user/user'];
-      return _.map(_.filter(user.departments, d => d.isAdvisor || d.isDirector), ['deptCode']);
-    }
+    isUserSimplyScheduler() {
+     const user = store.getters['user/user'];
+     const isScheduler = _.size($_myDeptCodes(['isScheduler']));
+     return isScheduler && !user.isAdmin && !_.size($_myDeptCodes(['isAdvisor', 'isDirector']));
+    },
+    myDeptCodes: $_myDeptCodes
   }
 };
 </script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -128,10 +128,16 @@ const router = new Router({
       children: [
         {
           path: '/appt/desk',
-          name: 'apptDesk',
           component: DropInWaitlist,
           meta: {
             title: 'Drop-in Appointments Desk'
+          }
+        },
+        {
+          path: '/scheduler/settings',
+          component: Admin,
+          meta: {
+            title: 'Settings'
           }
         }
       ]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2804

We'll want to demo the '/appt/desk' page. Therefore, the "scheduler" user must have an Admin page that uses the custom `DropInDesk` page layout.