### PR TITLE
BOAC-2813, API and tests for 'mark appointment as read'

### DIFF
--- a/src/api/appointments.ts
+++ b/src/api/appointments.ts
@@ -15,10 +15,20 @@ export function cancel(appointmentId) {
     }, () => null);
 }
 
-export function checkIn(appointmentId) {
+export function checkIn(
+    advisorDeptCodes,
+    advisorName,
+    advisorRole,
+    advisorUid,
+    appointmentId
+) {
   return axios
-    .post(`${utils.apiBaseUrl()}/api/appointments/${appointmentId}/check_in`)
-    .then(response => {
+    .post(`${utils.apiBaseUrl()}/api/appointments/${appointmentId}/check_in`, {
+      advisorDeptCodes,
+      advisorName,
+      advisorRole,
+      advisorUid
+    }).then(response => {
       store.dispatch('user/gaAppointmentEvent', {
         id: appointmentId,
         name: `Advisor ${store.getters['user/uid']} checked in a drop-in appointment`,
@@ -28,25 +38,9 @@ export function checkIn(appointmentId) {
     }, () => null);
 }
 
-export function create(
-    advisorDeptCodes,
-    advisorName,
-    advisorRole,
-    advisorUid,
-    details,
-    sid,
-    topics
-) {
+export function create(details, sid, topics) {
   return axios
-    .post(`${utils.apiBaseUrl()}/api/appointments/create`, {
-      advisorDeptCodes,
-      advisorName,
-      advisorRole,
-      advisorUid,
-      details,
-      sid,
-      topics
-    }).then(response => {
+    .post(`${utils.apiBaseUrl()}/api/appointments/create`, {details, sid, topics}).then(response => {
       const appointmentId = response.data.id;
       store.dispatch('user/gaAppointmentEvent', {
         id: appointmentId,

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -447,7 +447,13 @@ export default {
       this.editModeNoteId = null;
     },
     appointmentCheckIn(appointmentId) {
-      checkIn(appointmentId).then(a => {
+      checkIn(
+        this.myDeptCodes(),
+        this.user.name,
+        this.title || this.isAdmin ? 'BOA Admin' : null,
+        this.user.uid,
+        appointmentId
+      ).then(a => {
         this.refreshTimelineAppointment(appointmentId, a);
       });
     },

--- a/src/views/AppointmentWaitlist.vue
+++ b/src/views/AppointmentWaitlist.vue
@@ -130,15 +130,7 @@ export default {
       this.selectedAppointment = undefined;
     },
     createAppointment(details, sid, topics) {
-      create(
-        this.myDeptCodes(),
-        this.user.name,
-        this.title || this.isAdmin ? 'BOA Admin' : null,
-        this.user.uid,
-        details,
-        sid,
-        topics
-      ).then(appointment => {
+      create(details, sid, topics).then(appointment => {
         this.showCreateAppointmentModal = false;
         this.waitlist.push(appointment);
       });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2813

I also removed advisor info from `/appointment/create` transaction. Advisor info is expected only at check-in. 