### PR TITLE
BOAC-2864: Fixes details toggle + pagination mischief

### DIFF
--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -255,7 +255,7 @@ export default {
       {text: 'Expired', value: 'isExpiredPerLdap'}
     ]
   }),
-  created() {
+  mounted() {
     this.items = this.cloneDeep(this.users);
     this.departments = this.orderBy(this.uniqBy(this.flatMap(this.users, this.getDepartments), 'code'), 'name');
     this.filter = this.concat(this.filterNameUid, this.filterDept, this.filterPermissions, this.filterStatuses);
@@ -304,8 +304,11 @@ export default {
       });
     },
     onFilter(filteredItems) {
-      this.rowCount = filteredItems.length
-      this.currentPage = 1
+      const newRowCount = this.size(filteredItems);
+      if (newRowCount !== this.rowCount) {
+        this.currentPage = 1;
+      }
+      this.rowCount = newRowCount;
     },
     openEdit() {
       //TODO: BOAC-2844


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2864

On /admin, it appears that toggling details was triggering the pagination to reset (probably because it sets a property on the item whose details you want to see).

The fix is to prevent pagination resets unless the items array actually changed.