### PR TITLE
NOJIRA, localhost only: screenReaderAlert is the dismissible message in footer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,15 +12,15 @@
           <b>BOA {{ getBoaEnvLabel() }} Environment</b>
         </div>
         <div>
-          {{ fixedWarningOnAllPages }}
+          {{ isVueAppDebugMode ? screenReaderAlert : fixedWarningOnAllPages }}
         </div>
         <div class="btn-wrapper ml-0 align-top">
           <b-btn
             id="speedbird"
+            @click="dismissTheWarning"
             class="btn-dismiss pl-2 pt-0 text-white"
             variant="link"
-            aria-label="Dismiss warning about BOA environment type"
-            @click="dismissTheWarning">
+            aria-label="Dismiss warning about BOA environment type">
             <font-awesome icon="plane-departure" />
           </b-btn>
         </div>

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -16,6 +16,7 @@ export default {
       'fixedWarningOnAllPages',
       'hasUserDismissedFooterAlert',
       'isDemoModeAvailable',
+      'isVueAppDebugMode',
       'maxAttachmentsPerNote',
       'pingFrequency',
       'announcement',

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -33,6 +33,7 @@ const getters = {
   googleAnalyticsId: (state: any): string => _.get(state.config, 'googleAnalyticsId'),
   hasUserDismissedFooterAlert: (state: any): boolean => state.hasUserDismissedFooterAlert,
   isDemoModeAvailable: (state: any): string => _.get(state.config, 'isDemoModeAvailable'),
+  isVueAppDebugMode: (): any => process.env.VUE_APP_DEBUG,
   maxAttachmentsPerNote: (state: any): string => _.get(state.config, 'maxAttachmentsPerNote'),
   pingFrequency: (state: any): string => _.get(state.config, 'pingFrequency'),
   loading: (state: any): boolean => state.loading,


### PR DESCRIPTION
This will only surface on developer workstations. The goal is to raise awareness of screenreader alerts and, hopefully, improve 'em.