### PR TITLE
BOAC-2971 Shared appointments polling for scheduler and drop-in advisor

### DIFF
--- a/src/mixins/DropInWaitlistContainer.vue
+++ b/src/mixins/DropInWaitlistContainer.vue
@@ -1,0 +1,29 @@
+<script>
+import { getDropInAppointmentWaitlist } from '@/api/appointments';
+
+export default {
+  name: 'DropInWaitlistContainer',
+  methods: {
+    loadDropInWaitlist() {
+      getDropInAppointmentWaitlist(this.deptCode, this.includeResolvedAppointments).then(waitlist => {
+        var announceLoad = false;
+        var announceUpdate = false;
+        if (!this.isEqual(waitlist, this.waitlist)) {
+          if (this.waitlist) {
+            announceUpdate = true;
+          } else {
+            announceLoad = true;
+          }
+          this.waitlist = waitlist;
+        }
+        if (announceLoad) {
+          this.loaded('Appointment waitlist');
+        }
+        if (announceUpdate) {
+          this.alertScreenReader('The appointment waitlist has been updated');
+        }
+      });
+    }
+  }
+}
+</script>

--- a/src/views/DropInAdvisorHome.vue
+++ b/src/views/DropInAdvisorHome.vue
@@ -71,13 +71,14 @@
 </template>
 
 <script>
-import DropInWaitlist from "@/components/appointment/DropInWaitlist";
+import Context from '@/mixins/Context';
+import DropInWaitlist from '@/components/appointment/DropInWaitlist';
+import DropInWaitlistContainer from '@/mixins/DropInWaitlistContainer';
 import Loading from '@/mixins/Loading';
 import SortableGroup from '@/components/search/SortableGroup';
 import Spinner from '@/components/util/Spinner';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
-import { getDropInAppointmentWaitlist } from '@/api/appointments'
 
 export default {
   name: 'DropInAdvisorHome',
@@ -86,17 +87,16 @@ export default {
     SortableGroup,
     Spinner
   },
-  mixins: [Loading, UserMetadata, Util],
+  mixins: [Context, DropInWaitlistContainer, Loading, UserMetadata, Util],
   data: () => ({
     deptCode: undefined,
+    includeResolvedAppointments: true,
     waitlist: undefined
   }),
   mounted() {
     this.deptCode = this.get(this.$route, 'params.deptCode');
-    getDropInAppointmentWaitlist(this.deptCode, true).then(waitlist => {
-      this.waitlist = this.partitionByCanceledStatus(waitlist);
-      this.loaded('Drop-in Waitlist');
-    });
+    this.loadDropInWaitlist();
+    setInterval(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
   },
   methods: {
     onAppointmentCancellation() {

--- a/src/views/DropInDesk.vue
+++ b/src/views/DropInDesk.vue
@@ -9,7 +9,8 @@
 
 <script>
 import Context from '@/mixins/Context';
-import DropInWaitlist from "@/components/appointment/DropInWaitlist";
+import DropInWaitlist from '@/components/appointment/DropInWaitlist';
+import DropInWaitlistContainer from '@/mixins/DropInWaitlistContainer';
 import Loading from '@/mixins/Loading';
 import Spinner from '@/components/util/Spinner';
 import UserMetadata from '@/mixins/UserMetadata';
@@ -19,8 +20,9 @@ import { getDropInAppointmentWaitlist } from '@/api/appointments';
 export default {
   name: 'DropInDesk',
   components: {DropInWaitlist, Spinner},
-  mixins: [Context, Loading, UserMetadata, Util],
+  mixins: [Context, DropInWaitlistContainer, Loading, UserMetadata, Util],
   data: () => ({
+    includeResolvedAppointments: false,
     waitlist: undefined
   }),
   created() {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2971

A shared DropInWaitlistContainer mixin is silly, but the alternative I was attempting (making DropInWaitlist responsible for its own data updates) really didn't play well with the nested components model.