### PR TITLE
BOAC-2995, most recent appointment_event for appointments_fts_index; simplify API

### DIFF
--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -88,6 +88,15 @@ def scheduler_required(func):
     return _scheduler_required
 
 
+def appointments_feature_flag(func):
+    @wraps(func)
+    def _feature_flag_required(*args, **kw):
+        if not app.config['FEATURE_FLAG_ADVISOR_APPOINTMENTS']:
+            return app.login_manager.unauthorized()
+        return func(*args, **kw)
+    return _feature_flag_required
+
+
 def add_alert_counts(alert_counts, students):
     students_by_sid = {student['sid']: student for student in students}
     for alert_count in alert_counts:

--- a/boac/models/appointment_event.py
+++ b/boac/models/appointment_event.py
@@ -57,8 +57,8 @@ class AppointmentEvent(db.Model):
         appointment_id,
         user_id,
         event_type,
-        cancel_reason,
-        cancel_reason_explained,
+        cancel_reason=None,
+        cancel_reason_explained=None,
     ):
         self.appointment_id = appointment_id
         self.event_type = event_type

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -131,6 +131,12 @@ class AuthorizedUser(Base):
         return result and result['id']
 
     @classmethod
+    def get_uid_per_id(cls, user_id):
+        query = text(f'SELECT uid FROM authorized_users WHERE id = :user_id AND deleted_at IS NULL')
+        result = db.session.execute(query, {'user_id': user_id}).first()
+        return result and result['uid']
+
+    @classmethod
     def find_by_id(cls, db_id):
         return AuthorizedUser.query.filter_by(id=db_id, deleted_at=None).first()
 

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -236,7 +236,7 @@ _university_depts = {
                 'uid': '90412',
                 'isAdvisor': True,
                 'isDirector': False,
-                'isDropInAdvisor': False,
+                'isDropInAdvisor': True,
                 'isScheduler': False,
                 'automate_membership': True,
             },
@@ -459,64 +459,41 @@ def _create_department_memberships():
 
 
 def _create_appointments():
-    _create_waiting_appointments()
-    _create_checked_in_appointments()
     _create_canceled_appointments()
+    _create_checked_in_appointments()
+    _create_reserved_appointments()
+    _create_waiting_appointments()
 
 
-def _create_waiting_appointments():
-    coe_advisor_uid = '90412'
-    coe_advisor_user_id = AuthorizedUser.get_id_per_uid(coe_advisor_uid)
-    scheduler_uid = '6972201'
-    scheduler_user_id = AuthorizedUser.get_id_per_uid(scheduler_uid)
-    Appointment.create(
-        appointment_type='Drop-in',
-        created_by=scheduler_user_id,
-        dept_code='COENG',
-        details='Meet me at the crossroads.',
-        student_sid='3456789012',
-        topics=['Topic for appointments, 2'],
-    )
-    Appointment.create(
+def _create_canceled_appointments():
+    coe_advisor_user_id = AuthorizedUser.get_id_per_uid('90412')
+    scheduler_user_id = AuthorizedUser.get_id_per_uid('6972201')
+    cancel_me = Appointment.create(
         appointment_type='Drop-in',
         created_by=coe_advisor_user_id,
         dept_code='COENG',
-        details='Life is what happens while you\'re making appointments.',
-        student_sid='5678901234',
-        topics=['Good Show'],
+        details='We will cancel this appointment.',
+        student_sid='7890123456',
+        topics=['Whoops'],
     )
-    # L&S College Advising appointments
-    l_s_advisor_uid = '53791'
-    l_s_advisor_user_id = AuthorizedUser.get_id_per_uid(l_s_advisor_uid)
-    Appointment.create(
-        appointment_type='Drop-in',
-        created_by=l_s_advisor_user_id,
-        dept_code='QCADV',
-        details='C-c-catch the wave!',
-        student_sid='5678901234',
-        topics=['Topic for appointments, 1', 'Good Show'],
-    )
-    Appointment.create(
-        appointment_type='Drop-in',
-        created_by=l_s_advisor_user_id,
-        dept_code='QCADV',
-        details='You be you.',
-        student_sid='11667051',
-        topics=['Topic for appointments, 1'],
+    Appointment.cancel(
+        appointment_id=cancel_me.id,
+        canceled_by=scheduler_user_id,
+        cancel_reason='Just because',
+        cancel_reason_explained='I felt like it.',
     )
 
 
 def _create_checked_in_appointments():
+    coe_scheduler_user_id = AuthorizedUser.get_id_per_uid('6972201')
     coe_advisor_uid = '90412'
     coe_advisor_user_id = AuthorizedUser.get_id_per_uid(coe_advisor_uid)
-    scheduler_uid = '6972201'
-    scheduler_user_id = AuthorizedUser.get_id_per_uid(scheduler_uid)
     l_s_advisor_uid = '53791'
     l_s_advisor_user_id = AuthorizedUser.get_id_per_uid(l_s_advisor_uid)
 
     check_me_in = Appointment.create(
         appointment_type='Drop-in',
-        created_by=scheduler_user_id,
+        created_by=coe_scheduler_user_id,
         dept_code='COENG',
         details='Pick me, pick me!',
         student_sid='3456789012',
@@ -548,7 +525,7 @@ def _create_checked_in_appointments():
     )
     check_me_in = Appointment.create(
         appointment_type='Drop-in',
-        created_by=scheduler_user_id,
+        created_by=coe_scheduler_user_id,
         dept_code='COENG',
         details='We will check in this student.',
         student_sid='9012345678',
@@ -562,6 +539,7 @@ def _create_checked_in_appointments():
         advisor_role='Advisor',
         advisor_dept_codes=['COENG'],
     )
+    # L&S College Advising
     check_me_in = Appointment.create(
         appointment_type='Drop-in',
         created_by=l_s_advisor_user_id,
@@ -580,24 +558,55 @@ def _create_checked_in_appointments():
     )
 
 
-def _create_canceled_appointments():
-    coe_advisor_uid = '90412'
-    coe_advisor_user_id = AuthorizedUser.get_id_per_uid(coe_advisor_uid)
-    scheduler_uid = '6972201'
-    scheduler_user_id = AuthorizedUser.get_id_per_uid(scheduler_uid)
-    cancel_me = Appointment.create(
+def _create_reserved_appointments():
+    coe_advisor_user_id = AuthorizedUser.get_id_per_uid('90412')
+    reserve_me = Appointment.create(
         appointment_type='Drop-in',
         created_by=coe_advisor_user_id,
         dept_code='COENG',
-        details='We will cancel this appointment.',
+        details='I will reserve this appointment.',
         student_sid='7890123456',
         topics=['Whoops'],
     )
-    Appointment.cancel(
-        appointment_id=cancel_me.id,
-        canceled_by=scheduler_user_id,
-        cancel_reason='Just because',
-        cancel_reason_explained='I felt like it.',
+    Appointment.reserve(appointment_id=reserve_me.id, reserved_by=coe_advisor_user_id)
+
+
+def _create_waiting_appointments():
+    coe_advisor_user_id = AuthorizedUser.get_id_per_uid('90412')
+    coe_scheduler_user_id = AuthorizedUser.get_id_per_uid('6972201')
+    l_s_advisor_user_id = AuthorizedUser.get_id_per_uid('53791')
+    Appointment.create(
+        appointment_type='Drop-in',
+        created_by=coe_scheduler_user_id,
+        dept_code='COENG',
+        details='Meet me at the crossroads.',
+        student_sid='3456789012',
+        topics=['Topic for appointments, 2'],
+    )
+    Appointment.create(
+        appointment_type='Drop-in',
+        created_by=coe_advisor_user_id,
+        dept_code='COENG',
+        details='Life is what happens while you\'re making appointments.',
+        student_sid='5678901234',
+        topics=['Good Show'],
+    )
+    # L&S College Advising
+    Appointment.create(
+        appointment_type='Drop-in',
+        created_by=l_s_advisor_user_id,
+        dept_code='QCADV',
+        details='C-c-catch the wave!',
+        student_sid='5678901234',
+        topics=['Topic for appointments, 1', 'Good Show'],
+    )
+    Appointment.create(
+        appointment_type='Drop-in',
+        created_by=l_s_advisor_user_id,
+        dept_code='QCADV',
+        details='You be you.',
+        student_sid='11667051',
+        topics=['Topic for appointments, 1'],
     )
 
 

--- a/scripts/db/migrate/2019/20191031-BOAC-2993/create_appointment_events_table.sql
+++ b/scripts/db/migrate/2019/20191031-BOAC-2993/create_appointment_events_table.sql
@@ -66,11 +66,12 @@ CREATE MATERIALIZED VIEW appointments_fts_index AS (
   SELECT
     a.id,
     to_tsvector('english', trim(concat(a.details, ' ', e.cancel_reason, ' ', e.cancel_reason_explained))) AS fts_index
-  FROM appointments a
-    JOIN appointment_events e ON e.appointment_id = a.id
+  FROM (SELECT MAX(id) as id FROM appointment_events GROUP BY appointment_id) as recent_events
+  JOIN appointment_events e ON e.id = recent_events.id
+  JOIN appointments a ON a.id = e.appointment_id
   WHERE
-    details IS NOT NULL
-    AND deleted_at IS NULL
+    a.details IS NOT NULL
+    AND a.deleted_at IS NULL
 );
 CREATE INDEX idx_appointments_fts_index ON appointments_fts_index USING gin(fts_index);
 

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -178,10 +178,12 @@ CREATE MATERIALIZED VIEW appointments_fts_index AS (
   SELECT
     a.id,
     to_tsvector('english', trim(concat(a.details, ' ', e.cancel_reason, ' ', e.cancel_reason_explained))) AS fts_index
-  FROM appointments a
-  LEFT JOIN appointment_events e ON e.appointment_id = a.id
-  WHERE details IS NOT NULL
-    AND deleted_at IS NULL
+  FROM (SELECT MAX(id) as id FROM appointment_events GROUP BY appointment_id) as recent_events
+  JOIN appointment_events e ON e.id = recent_events.id
+  JOIN appointments a ON a.id = e.appointment_id
+  WHERE
+    a.details IS NOT NULL
+    AND a.deleted_at IS NULL
 );
 
 CREATE INDEX idx_appointments_fts_index

--- a/src/api/appointments.ts
+++ b/src/api/appointments.ts
@@ -67,9 +67,9 @@ export function findAdvisorsByName(query: string, limit: number) {
     .then(response => response.data);
 }
 
-export function getDropInAppointmentWaitlist(deptCode, includeResolved=false) {
+export function getDropInAppointmentWaitlist(deptCode) {
   return axios
-    .get(`${utils.apiBaseUrl()}/api/appointments/waitlist/${deptCode}?includeResolved=${includeResolved}`)
+    .get(`${utils.apiBaseUrl()}/api/appointments/waitlist/${deptCode}`)
     .then(response => response.data, () => null);
 }
 

--- a/src/components/appointment/AdvisingAppointment.vue
+++ b/src/components/appointment/AdvisingAppointment.vue
@@ -29,16 +29,16 @@
             :show-modal="showCancelAppointmentModal"
             :student="student" />
         </div>
-        <div v-if="!!appointment.checkedInBy">
+        <div v-if="appointment.status === 'checked_in'">
           <font-awesome :id="`appointment-${appointment.id}-checked-in-icon`" icon="calendar-check" class="status-checked-in-icon" />
           <span class="text-secondary ml-1">
             Check In
-            <span v-if="appointment.checkedInAt">
-              @ <span :id="`appointment-${appointment.id}-checked-in-at`">{{ datePerTimezone(appointment.checkedInAt) | moment('h:mma') }}</span>
+            <span v-if="appointment.statusDate">
+              @ <span :id="`appointment-${appointment.id}-checked-in-at`">{{ datePerTimezone(appointment.statusDate) | moment('h:mma') }}</span>
             </span>
           </span>
         </div>
-        <div v-if="appointment.canceledAt">
+        <div v-if="appointment.status === 'canceled'">
           <div>
             <font-awesome :id="`appointment-${appointment.id}-canceled-in-icon`" icon="calendar-minus" class="status-canceled-icon" />
             <span class="text-secondary ml-1">
@@ -127,8 +127,7 @@ export default {
     checkInAvailable() {
       return (
         this.includes(this.map((this.user.dropInAdvisorStatus || []), 'deptCode'), this.appointment.deptCode) &&
-        !this.appointment.checkedInBy &&
-        !this.appointment.canceledAt
+        this.includes(['waiting', 'reserved'], this.appointment.status)
       );
     }
   },

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -214,19 +214,25 @@
           <td class="column-right align-top pt-1 pr-1">
             <div v-if="!includes(openMessages, message.transientId) && message.type === 'appointment'">
               <div
-                v-if="message.appointmentType === 'Drop-in' && message.canceledAt"
+                v-if="message.appointmentType === 'Drop-in' && message.status === 'canceled'"
                 :id="`collapsed-${message.type}-${message.id}-status-canceled`"
                 class="pill-appointment-status pill-canceled pl-2 pr-2 mr-2 text-nowrap">
                 Canceled
               </div>
               <div
-                v-if="message.appointmentType === 'Drop-in' && !message.canceledAt && message.checkedInAt"
+                v-if="message.appointmentType === 'Drop-in' && message.status === 'checked_in'"
                 :id="`collapsed-${message.type}-${message.id}-status-checked-in`"
                 class="pill-appointment-status pill-checked-in pl-2 pr-2 mr-2 text-nowrap">
                 Checked In
               </div>
               <div
-                v-if="message.appointmentType === 'Drop-in' && !message.canceledAt && !message.checkedInAt"
+                v-if="message.appointmentType === 'Drop-in' && message.status === 'reserved'"
+                :id="`collapsed-${message.type}-${message.id}-status-waiting`"
+                class="pill-appointment-status pill-waiting pl-2 pr-2 mr-2 text-nowrap">
+                Reserved
+              </div>
+              <div
+                v-if="message.appointmentType === 'Drop-in' && message.status === 'waiting'"
                 :id="`collapsed-${message.type}-${message.id}-status-waiting`"
                 class="pill-appointment-status pill-waiting pl-2 pr-2 mr-2 text-nowrap">
                 Waiting

--- a/src/mixins/DropInWaitlistContainer.vue
+++ b/src/mixins/DropInWaitlistContainer.vue
@@ -5,7 +5,7 @@ export default {
   name: 'DropInWaitlistContainer',
   methods: {
     loadDropInWaitlist() {
-      getDropInAppointmentWaitlist(this.deptCode, this.includeResolvedAppointments).then(waitlist => {
+      getDropInAppointmentWaitlist(this.deptCode).then(waitlist => {
         let announceLoad = false;
         let announceUpdate = false;
         if (!this.isEqual(waitlist, this.waitlist)) {

--- a/src/views/DropInAdvisorHome.vue
+++ b/src/views/DropInAdvisorHome.vue
@@ -11,7 +11,7 @@
             <DropInWaitlist
               :dept-code="deptCode"
               :is-homepage="true"
-              :on-appointment-status-change="onAppointmentStatusChange"
+              :on-appointment-status-change="loadDropInWaitlist"
               :waitlist="waitlist" />
           </div>
         </b-col>
@@ -90,22 +90,12 @@ export default {
   mixins: [Context, DropInWaitlistContainer, Loading, UserMetadata, Util],
   data: () => ({
     deptCode: undefined,
-    includeResolvedAppointments: true,
     waitlist: undefined
   }),
   mounted() {
     this.deptCode = this.get(this.$route, 'params.deptCode');
     this.loadDropInWaitlist();
     setInterval(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
-  },
-  methods: {
-    onAppointmentStatusChange() {
-      this.waitlist = this.partitionByCanceledStatus(this.waitlist);
-    },
-    partitionByCanceledStatus(waitlist) {
-      const partitioned = this.partition(waitlist, a => !a.canceledAt);
-      return partitioned[0].concat(partitioned[1]);
-    }
   }
 }
 </script>

--- a/src/views/DropInDesk.vue
+++ b/src/views/DropInDesk.vue
@@ -2,7 +2,10 @@
   <div class="ml-3 mr-3 mt-3">
     <Spinner alert-prefix="Appointment waitlist" />
     <div v-if="!loading" class="waitlist-container">
-      <DropInWaitlist :dept-code="deptCode" :waitlist="waitlist" />
+      <DropInWaitlist
+        :dept-code="deptCode"
+        :on-appointment-status-change="loadDropInWaitlist"
+        :waitlist="waitlist" />
     </div>
   </div>
 </template>
@@ -22,7 +25,6 @@ export default {
   components: {DropInWaitlist, Spinner},
   mixins: [Context, DropInWaitlistContainer, Loading, UserMetadata, Util],
   data: () => ({
-    includeResolvedAppointments: false,
     waitlist: undefined
   }),
   created() {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2995

Notable:
* fix `appointments_fts_index`: only grab latest event from `appointment_events` table, no dupe rows per appointment_id
* remove `canceledAt`, `canceledBy`, `reservedAt`, etc. in favor of `statusBy` and `statusDate`
* remove unnecessary calls to `refresh_search_index()`