### PR TITLE
BOAC-3004, topics graduate to top-level API, dedicated controller

### DIFF
--- a/boac/api/appointments_controller.py
+++ b/boac/api/appointments_controller.py
@@ -27,12 +27,10 @@ from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotF
 from boac.api.util import advisor_required, appointments_feature_flag, drop_in_advisors_for_dept_code, scheduler_required
 from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME
 from boac.lib.http import tolerant_jsonify
-from boac.lib.util import to_bool_or_none
 from boac.merged.student import get_distilled_student_profiles
 from boac.models.appointment import Appointment
 from boac.models.appointment_event import appointment_event_type, AppointmentEvent
 from boac.models.appointment_read import AppointmentRead
-from boac.models.topic import Topic
 from flask import current_app as app, request
 from flask_login import current_user
 
@@ -235,15 +233,6 @@ def find_appointment_advisors_by_name():
             'uid': a.advisor_uid,
         }
     return tolerant_jsonify([_advisor_feed(a) for a in advisors])
-
-
-@app.route('/api/appointments/topics', methods=['GET'])
-@appointments_feature_flag
-@scheduler_required
-def get_appointment_topics():
-    include_deleted = to_bool_or_none(request.args.get('includeDeleted'))
-    topics = Topic.get_all(available_in_appointments=True, include_deleted=include_deleted)
-    return tolerant_jsonify([topic.to_api_json() for topic in topics])
 
 
 def _dept_codes_with_scheduler_privilege():

--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -35,7 +35,7 @@ from boac.api.util import (
 from boac.externals import data_loch
 from boac.lib.berkeley import dept_codes_where_advising
 from boac.lib.http import tolerant_jsonify
-from boac.lib.util import get as get_param, is_int, process_input_from_rich_text_editor, to_bool_or_none
+from boac.lib.util import get as get_param, is_int, process_input_from_rich_text_editor
 from boac.merged.advising_note import (
     get_batch_distinct_sids,
     get_boa_attachment_stream,
@@ -47,7 +47,6 @@ from boac.models.cohort_filter import CohortFilter
 from boac.models.curated_group import CuratedGroup
 from boac.models.note import Note
 from boac.models.note_read import NoteRead
-from boac.models.topic import Topic
 from flask import current_app as app, request, Response
 from flask_login import current_user
 
@@ -198,14 +197,6 @@ def find_note_authors_by_name():
             'uid': a.get('uid'),
         }
     return tolerant_jsonify([_author_feed(a) for a in authors])
-
-
-@app.route('/api/notes/topics', methods=['GET'])
-@advisor_required
-def get_topics():
-    include_deleted = to_bool_or_none(request.args.get('includeDeleted'))
-    topics = Topic.get_all(available_in_notes=True, include_deleted=include_deleted)
-    return tolerant_jsonify([topic.to_api_json() for topic in topics])
 
 
 @app.route('/api/notes/<note_id>/attachment', methods=['POST'])

--- a/boac/api/topic_controller.py
+++ b/boac/api/topic_controller.py
@@ -1,0 +1,70 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.api.util import advisor_required, appointments_feature_flag, scheduler_required
+from boac.lib.http import tolerant_jsonify
+from boac.lib.util import to_bool_or_none
+from boac.models.topic import Topic
+from flask import current_app as app, request
+
+
+@app.route('/api/topics/all', methods=['GET'])
+@advisor_required
+def get_all_topics():
+    include_appointments = app.config['FEATURE_FLAG_ADVISOR_APPOINTMENTS']
+    include_deleted = to_bool_or_none(request.args.get('includeDeleted'))
+    if include_appointments:
+        topics = Topic.get_all(include_deleted=include_deleted)
+    else:
+        topics = Topic.get_all(available_in_notes=True, include_deleted=include_deleted)
+    if not app.config['FEATURE_FLAG_ADVISOR_APPOINTMENTS']:
+        for index, topic in enumerate(topics):
+            if not topic.available_in_notes:
+                topics.pop(index)
+    return tolerant_jsonify(_to_api_json(topics))
+
+
+@app.route('/api/topics/for_appointments', methods=['GET'])
+@appointments_feature_flag
+@scheduler_required
+def get_topics_for_appointment():
+    include_deleted = to_bool_or_none(request.args.get('includeDeleted'))
+    topics = Topic.get_all(available_in_appointments=True, include_deleted=include_deleted)
+    return tolerant_jsonify(_to_api_json(topics))
+
+
+@app.route('/api/topics/for_notes', methods=['GET'])
+@advisor_required
+def get_topics_for_notes():
+    include_deleted = to_bool_or_none(request.args.get('includeDeleted'))
+    topics = Topic.get_all(available_in_notes=True, include_deleted=include_deleted)
+    return tolerant_jsonify(_to_api_json(topics))
+
+
+def _to_api_json(topics):
+    indices_of_other = [index for index, topic in enumerate(topics) if topic.topic.startswith('Other')]
+    for index in indices_of_other:
+        topics.append(topics.pop(index))
+    return [topic.to_api_json() for topic in topics]

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -611,6 +611,11 @@ def _create_waiting_appointments():
 
 
 def _create_topics():
+    Topic.create_topic(
+        'Other / Reason not listed',
+        available_in_notes=True,
+        available_in_appointments=True,
+    )
     for index in range(10):
         true_for_both = index in [1, 5, 7]
         available_in_appointments = true_for_both or index % 2 == 0

--- a/boac/routes.py
+++ b/boac/routes.py
@@ -54,6 +54,7 @@ def register_routes(app):
     import boac.api.search_controller
     import boac.api.student_controller
     import boac.api.status_controller
+    import boac.api.topic_controller
     import boac.api.user_controller
 
     # Register error handlers.

--- a/src/api/appointments.ts
+++ b/src/api/appointments.ts
@@ -80,12 +80,6 @@ export function getDropInAppointmentWaitlist(deptCode) {
     .then(response => response.data, () => null);
 }
 
-export function getAllTopics(includeDeleted: boolean) {
-  return axios
-    .get(`${utils.apiBaseUrl()}/api/appointments/topics?includeDeleted=${includeDeleted}`)
-    .then(response => response.data, () => null);
-}
-
 export function markAppointmentRead(appointmentId) {
   return axios
     .post(`${utils.apiBaseUrl()}/api/appointments/${appointmentId}/mark_read`)

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -99,12 +99,6 @@ export function deleteNote(noteId: number) {
     .then(response => response.data);
 }
 
-export function getTopics(includeDeleted: boolean) {
-  return axios
-    .get(`${utils.apiBaseUrl()}/api/notes/topics?includeDeleted=${includeDeleted}`)
-    .then(response => response.data);
-}
-
 export function findAuthorsByName(query: string, limit: number) {
   let apiBaseUrl = store.getters['context/apiBaseUrl'];
   return axios

--- a/src/api/topics.ts
+++ b/src/api/topics.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+import utils from "@/api/api-utils";
+
+export function getAllTopics(includeDeleted?: boolean) {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/topics/all?includeDeleted=${includeDeleted}`)
+    .then(response => response.data, () => null);
+}
+
+export function getTopicsForAppointments(includeDeleted?: boolean) {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/topics/for_appointments?includeDeleted=${includeDeleted}`)
+    .then(response => response.data, () => null);
+}
+
+export function getTopicsForNotes(includeDeleted?: boolean) {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/topics/for_notes?includeDeleted=${includeDeleted}`)
+    .then(response => response.data, () => null);
+}

--- a/src/components/appointment/AppointmentTopics.vue
+++ b/src/components/appointment/AppointmentTopics.vue
@@ -75,7 +75,7 @@
 import Context from '@/mixins/Context';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
-import { getAllTopics } from '@/api/appointments';
+import { getTopicsForAppointments } from '@/api/topics';
 
 export default {
   name: 'AppointmentTopics',
@@ -113,7 +113,7 @@ export default {
     topicOptions: []
   }),
   created() {
-    getAllTopics().then(topics => {
+    getTopicsForAppointments().then(topics => {
       this.each(topics, topic => {
         this.topicOptions.push({
           text: topic,

--- a/src/components/appointment/DropInAvailabilityToggle.vue
+++ b/src/components/appointment/DropInAvailabilityToggle.vue
@@ -10,22 +10,24 @@
           class="aria-hidden availability-status">
           Off duty
         </div>
-        <button
-          id="toggle-drop-in-availability"
-          v-if="!isToggling"
-          v-model="isAvailable"
-          @click="toggle"
-          @keyup="toggle"
-          type="button"
-          class="btn btn-link pt-0 pb-0 pl-1 pr-1">
-          <span class="status-toggle-label">
-            <font-awesome v-if="isAvailable" icon="toggle-on" class="toggle toggle-on"></font-awesome>
-            <font-awesome v-if="!isAvailable" icon="toggle-off" class="toggle toggle-off"></font-awesome>
-            <span class="sr-only">{{ isAvailable ? 'On duty' : 'Off duty' }}</span>
-          </span>
-        </button>
-        <div v-if="isToggling">
-          <font-awesome icon="spinner" spin />
+        <div class="toggle-btn-column">
+          <button
+            id="toggle-drop-in-availability"
+            v-if="!isToggling"
+            v-model="isAvailable"
+            @click="toggle"
+            @keyup="toggle"
+            type="button"
+            class="btn btn-link pt-0 pb-0 pl-1 pr-1">
+            <span class="status-toggle-label">
+              <font-awesome v-if="isAvailable" icon="toggle-on" class="toggle toggle-on"></font-awesome>
+              <font-awesome v-if="!isAvailable" icon="toggle-off" class="toggle toggle-off"></font-awesome>
+              <span class="sr-only">{{ isAvailable ? 'On duty' : 'Off duty' }}</span>
+            </span>
+          </button>
+          <div v-if="isToggling" class="pl-2">
+            <font-awesome icon="spinner" spin />
+          </div>
         </div>
         <div
           :class="isAvailable ? 'availability-status-active' : 'availability-status-disabled'"
@@ -110,6 +112,9 @@ export default {
 }
 .toggle {
  font-size: 20px;
+}
+.toggle-btn-column {
+  min-width: 36px;
 }
 .toggle-off {
    color: #999999;

--- a/src/components/sidebar/SearchForm.vue
+++ b/src/components/sidebar/SearchForm.vue
@@ -250,9 +250,10 @@ import Autocomplete from '@/components/util/Autocomplete';
 import Context from '@/mixins/Context';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
-import { getAllTopics as getAppointmentTopics, findAdvisorsByName } from '@/api/appointments';
-import { getTopics as getNoteTopics, findAuthorsByName } from '@/api/notes';
+import { findAdvisorsByName } from '@/api/appointments';
+import { findAuthorsByName } from '@/api/notes';
 import { findStudentsByNameOrSid } from '@/api/student';
+import { getAllTopics } from '@/api/topics';
 
 export default {
   name: 'SearchForm',
@@ -425,16 +426,13 @@ export default {
       this.showNoteFilters = !this.showNoteFilters;
       if (!this.topicOptions) {
         this.topicOptions = [];
-        const queries = this.featureFlagAppointments ? [getNoteTopics(true), getAppointmentTopics(true)] : [getNoteTopics(true)];
-        Promise.all(queries).then((results) => {
-          this.each(this.uniq(this.flatten(results)), topic => {
+        getAllTopics(true).then(topics => {
+          this.each(topics, topic => {
             this.topicOptions.push({
               text: topic,
               value: topic
             })
           });
-        }).finally(() => {
-          this.topicOptions = this.orderBy(this.topicOptions, 'value');
         });
       }
     },

--- a/src/store/modules/note.ts
+++ b/src/store/modules/note.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { getMyNoteTemplates } from "@/api/note-templates";
-import { getTopics } from '@/api/notes';
+import { getTopicsForNotes } from '@/api/topics';
 
 const state = {
   noteTemplates: undefined,
@@ -34,7 +34,7 @@ const actions = {
   },
   async loadSuggestedNoteTopics({ commit, state }) {
     if (_.isUndefined(state.suggestedNoteTopics)) {
-      getTopics(false).then(data => {
+      getTopicsForNotes(false).then(data => {
         commit('setSuggestedNoteTopics', data);
       });
     }

--- a/tests/test_api/test_appointments_controller.py
+++ b/tests/test_api/test_appointments_controller.py
@@ -438,52 +438,6 @@ class TestMarkAppointmentRead:
         Appointment.delete(appointment_id)
 
 
-class TestAppointmentTopics:
-
-    @classmethod
-    def _get_topics(cls, client, include_deleted=None, expected_status_code=200):
-        api_path = '/api/appointments/topics'
-        if include_deleted is not None:
-            api_path += f'?includeDeleted={str(include_deleted).lower()}'
-        response = client.get(api_path)
-        assert response.status_code == expected_status_code
-        return response.json
-
-    def test_mark_read_not_authenticated(self, client):
-        """Returns 401 if not authenticated."""
-        self._get_topics(client, expected_status_code=401)
-
-    def test_deny_advisor(self, app, client, fake_auth):
-        """Returns 401 if user is not a drop-in advisor."""
-        fake_auth.login(l_s_college_advisor_uid)
-        self._get_topics(client, expected_status_code=401)
-
-    def test_scheduler_get_appointment_topics(self, app, client, fake_auth):
-        """COE scheduler can get topics."""
-        fake_auth.login(coe_scheduler_uid)
-        topics = self._get_topics(client)
-        assert len(topics) == 8
-
-    def test_advisor_get_appointment_topics(self, app, client, fake_auth):
-        """COE advisor can get topics."""
-        fake_auth.login(coe_advisor_uid)
-        topics = self._get_topics(client)
-        assert len(topics) == 8
-
-    def test_get_all_topics_including_deleted(self, client, fake_auth):
-        """Get all appointment topic options, including deleted."""
-        fake_auth.login(coe_advisor_uid)
-        topics = self._get_topics(client, include_deleted=True)
-        assert len(topics) == 10
-        assert 'Topic for appointments, deleted' in topics
-
-    def test_feature_flag(self, client, fake_auth, app):
-        """Appointments feature is false."""
-        with override_config(app, 'FEATURE_FLAG_ADVISOR_APPOINTMENTS', False):
-            fake_auth.login(coe_advisor_uid)
-            self._get_topics(client, expected_status_code=401)
-
-
 class TestAuthorSearch:
 
     def test_find_appointment_advisors_by_name(self, client, fake_auth):

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -376,38 +376,6 @@ class TestBatchNoteCreation:
         assert len(sids) + 1 == count
 
 
-class TestNoteTopics:
-
-    @classmethod
-    def _api_all_note_topics(cls, client, include_deleted=None, expected_status_code=200):
-        api_path = '/api/notes/topics'
-        if include_deleted is not None:
-            api_path += f'?includeDeleted={str(include_deleted).lower()}'
-        response = client.get(api_path)
-        assert response.status_code == expected_status_code
-        return response.json
-
-    def test_get_all_topics_not_authenticated(self, client):
-        """Deny anonymous access to note topics."""
-        self._api_all_note_topics(client, expected_status_code=401)
-
-    def test_get_all_topics_for_notes_including_deleted(self, client, fake_auth):
-        """Get all note topic options, including deleted."""
-        fake_auth.login(coe_advisor_uid)
-        api_json = self._api_all_note_topics(client, include_deleted=True)
-        assert 'Topic for all, 1' in api_json
-        assert 'Topic for notes, 9' in api_json
-        assert 'Topic for notes, deleted' in api_json
-
-    def test_get_all_topics_for_notes(self, client, fake_auth):
-        """Get all note topic options, not including deleted."""
-        fake_auth.login(coe_advisor_uid)
-        api_json = self._api_all_note_topics(client)
-        assert 'Topic for all, 1' in api_json
-        assert 'Topic for notes, 9' in api_json
-        assert 'Topic for notes, deleted' not in api_json
-
-
 class TestNoteAttachments:
 
     def test_remove_attachment(self, app, client, fake_auth):

--- a/tests/test_api/test_topic_controller.py
+++ b/tests/test_api/test_topic_controller.py
@@ -1,0 +1,163 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from tests.util import override_config
+
+coe_advisor_uid = '90412'
+coe_scheduler_uid = '6972201'
+l_s_college_advisor_uid = '188242'
+
+
+class TestGetTopics:
+
+    @classmethod
+    def _api_all_topics(cls, client, include_deleted=False, expected_status_code=200):
+        api_path = '/api/topics/all'
+        if include_deleted is not None:
+            api_path += f'?includeDeleted={str(include_deleted).lower()}'
+        response = client.get(api_path)
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_not_authenticated(self, client):
+        """Deny anonymous access."""
+        self._api_all_topics(client, expected_status_code=401)
+
+    def test_not_include_deleted(self, client, fake_auth):
+        """Get all topics, including deleted."""
+        fake_auth.login(coe_advisor_uid)
+        api_json = self._api_all_topics(client)
+        assert 'Topic for all, 1' in api_json
+        assert 'Topic for appointments, 2' in api_json
+        assert 'Topic for notes, 9' in api_json
+        assert 'Topic for appointments, deleted' not in api_json
+        assert 'Topic for notes, deleted' not in api_json
+        assert api_json[-1] == 'Other / Reason not listed'
+
+    def test_get_all_topics(self, client, fake_auth):
+        """Get all note topic options, not including deleted."""
+        fake_auth.login(coe_advisor_uid)
+        api_json = self._api_all_topics(client, include_deleted=True)
+        assert 'Topic for all, 1' in api_json
+        assert 'Topic for notes, 9' in api_json
+        assert 'Topic for appointments, 2' in api_json
+        assert 'Topic for appointments, deleted' in api_json
+        assert 'Topic for notes, deleted' in api_json
+        assert api_json[-1] == 'Other / Reason not listed'
+
+    def test_appointments_feature_flag(self, client, fake_auth, app):
+        """Appointments feature is false."""
+        with override_config(app, 'FEATURE_FLAG_ADVISOR_APPOINTMENTS', False):
+            fake_auth.login(coe_advisor_uid)
+            api_json = self._api_all_topics(client, include_deleted=True)
+            assert 'Topic for all, 1' in api_json
+            assert 'Topic for notes, 9' in api_json
+            assert 'Topic for appointments, 1' not in api_json
+            assert 'Topic for appointments, deleted' not in api_json
+            assert 'Topic for notes, deleted' in api_json
+            assert api_json[-1] == 'Other / Reason not listed'
+
+
+class TestTopicsForAppointment:
+
+    @classmethod
+    def _get_topics(cls, client, include_deleted=None, expected_status_code=200):
+        api_path = '/api/topics/for_appointments'
+        if include_deleted is not None:
+            api_path += f'?includeDeleted={str(include_deleted).lower()}'
+        response = client.get(api_path)
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_mark_read_not_authenticated(self, client):
+        """Returns 401 if not authenticated."""
+        self._get_topics(client, expected_status_code=401)
+
+    def test_deny_advisor(self, app, client, fake_auth):
+        """Returns 401 if user is not a drop-in advisor."""
+        fake_auth.login(l_s_college_advisor_uid)
+        self._get_topics(client, expected_status_code=401)
+
+    def test_scheduler_get_appointment_topics(self, app, client, fake_auth):
+        """COE scheduler can get topics."""
+        fake_auth.login(coe_scheduler_uid)
+        topics = self._get_topics(client)
+        assert len(topics) == 9
+        assert topics[-1] == 'Other / Reason not listed'
+
+    def test_advisor_get_appointment_topics(self, app, client, fake_auth):
+        """COE advisor can get topics."""
+        fake_auth.login(coe_advisor_uid)
+        topics = self._get_topics(client)
+        assert len(topics) == 9
+        assert topics[-1] == 'Other / Reason not listed'
+
+    def test_get_all_topics_including_deleted(self, client, fake_auth):
+        """Get all appointment topic options, including deleted."""
+        fake_auth.login(coe_advisor_uid)
+        topics = self._get_topics(client, include_deleted=True)
+        assert len(topics) == 11
+        assert 'Topic for appointments, deleted' in topics
+        assert topics[-1] == 'Other / Reason not listed'
+
+    def test_feature_flag(self, client, fake_auth, app):
+        """Appointments feature is false."""
+        with override_config(app, 'FEATURE_FLAG_ADVISOR_APPOINTMENTS', False):
+            fake_auth.login(coe_advisor_uid)
+            self._get_topics(client, expected_status_code=401)
+
+
+class TestTopicsForNotes:
+
+    @classmethod
+    def _api_all_note_topics(cls, client, include_deleted=None, expected_status_code=200):
+        api_path = '/api/topics/for_notes'
+        if include_deleted is not None:
+            api_path += f'?includeDeleted={str(include_deleted).lower()}'
+        response = client.get(api_path)
+        assert response.status_code == expected_status_code
+        return response.json
+
+    def test_get_all_topics_not_authenticated(self, client):
+        """Deny anonymous access to note topics."""
+        self._api_all_note_topics(client, expected_status_code=401)
+
+    def test_get_all_topics_for_notes_including_deleted(self, client, fake_auth):
+        """Get all note topic options, including deleted."""
+        fake_auth.login(coe_advisor_uid)
+        api_json = self._api_all_note_topics(client, include_deleted=True)
+        assert 'Topic for all, 1' in api_json
+        assert 'Topic for notes, 9' in api_json
+        assert 'Topic for notes, deleted' in api_json
+        assert api_json[-1] == 'Other / Reason not listed'
+
+    def test_get_all_topics_for_notes(self, client, fake_auth):
+        """Get all note topic options, not including deleted."""
+        fake_auth.login(coe_advisor_uid)
+        api_json = self._api_all_note_topics(client)
+        assert 'Topic for all, 1' in api_json
+        assert 'Topic for notes, 9' in api_json
+        assert 'Topic for notes, deleted' not in api_json
+        assert api_json[-1] == 'Other / Reason not listed'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3004

* With topic CRUD around the corner, breaking off a new controller seems appropriate.
* 'Other' is always last in list.
