### PR TITLE
BOAC-3010, if advisor uid when create appt then all advisor info please

### DIFF
--- a/boac/api/appointments_controller.py
+++ b/boac/api/appointments_controller.py
@@ -184,7 +184,6 @@ def create_appointment():
     params = request.get_json()
     dept_code = params.get('deptCode', None)
     sid = params.get('sid', None)
-    advisor_uid = params.get('advisorUid', None)
     appointment_type = params.get('appointmentType', None)
     topics = params.get('topics', None)
     if not dept_code or not sid or not appointment_type or not len(topics):
@@ -195,7 +194,10 @@ def create_appointment():
     if dept_code not in _dept_codes_with_scheduler_privilege():
         raise ForbiddenRequestError(f'You are unauthorized to manage {dept_code} appointments.')
     appointment = Appointment.create(
-        advisor_uid=advisor_uid,
+        advisor_dept_codes=params.get('advisorDeptCodes', None),
+        advisor_name=params.get('advisorName', None),
+        advisor_role=params.get('advisorRole', None),
+        advisor_uid=params.get('advisorUid', None),
         appointment_type=appointment_type,
         created_by=current_user.get_id(),
         dept_code=dept_code,

--- a/boac/models/appointment.py
+++ b/boac/models/appointment.py
@@ -148,6 +148,9 @@ class Appointment(Base):
             details,
             appointment_type,
             student_sid,
+            advisor_dept_codes=None,
+            advisor_name=None,
+            advisor_role=None,
             advisor_uid=None,
             topics=(),
     ):
@@ -161,6 +164,9 @@ class Appointment(Base):
 
         appointment = cls(
             advisor_uid=advisor_uid,
+            advisor_name=advisor_name,
+            advisor_role=advisor_role,
+            advisor_dept_codes=advisor_dept_codes,
             appointment_type=appointment_type,
             created_by=created_by,
             dept_code=dept_code,

--- a/src/api/appointments.ts
+++ b/src/api/appointments.ts
@@ -41,9 +41,22 @@ export function checkIn(
     }, () => null);
 }
 
-export function create(deptCode, details, sid, appointmentType, topics, advisorUid) {
+export function create(
+    deptCode,
+    details,
+    sid,
+    appointmentType,
+    topics,
+    advisorDeptCodes?,
+    advisorName?,
+    advisorRole?,
+    advisorUid?,
+  ) {
   return axios
     .post(`${utils.apiBaseUrl()}/api/appointments/create`, {
+      advisorDeptCodes,
+      advisorName,
+      advisorRole,
       advisorUid,
       appointmentType,
       deptCode,

--- a/src/components/appointment/CreateAppointmentModal.vue
+++ b/src/components/appointment/CreateAppointmentModal.vue
@@ -198,7 +198,16 @@ export default {
     },
     create() {
       this.saving = true;
-      this.createAppointment(this.details, this.student, this.topics, this.selectedAdvisorUid);
+      const advisor = this.selectedAdvisorUid ? this.find(this.advisors, ['uid', this.selectedAdvisorUid]) : null;
+      this.createAppointment(
+        this.details,
+        this.student,
+        this.topics,
+        advisor && Object.keys(advisor.departments),
+        this.get(advisor, 'name'),
+        this.get(advisor, 'title'),
+        this.selectedAdvisorUid
+      );
       this.showCreateAppointmentModal = false;
       this.saving = false;
       this.reset();

--- a/src/components/appointment/DropInWaitlist.vue
+++ b/src/components/appointment/DropInWaitlist.vue
@@ -194,9 +194,27 @@ export default {
       this.alertScreenReader('Dialog closed');
       this.selectedAppointment = undefined;
     },
-    createAppointment(details, student, topics, advisorUid) {
+    createAppointment(
+      details,
+      student,
+      topics,
+      advisorDeptCodes,
+      advisorName,
+      advisorRole,
+      advisorUid
+    ) {
       this.creating = true;
-      apiCreate(this.deptCode, details, student.sid, 'Drop-in', topics, advisorUid).then(() => {
+      apiCreate(
+        this.deptCode,
+        details,
+        student.sid,
+        'Drop-in',
+        topics,
+        advisorDeptCodes,
+        advisorName,
+        advisorRole,
+        advisorUid
+      ).then(() => {
         this.showCreateAppointmentModal = false;
         this.onAppointmentStatusChange().then(() => {
           this.creating = false;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3010

Passing all advisor info from the client, as done in this PR, is surprisingly less complex than using `advisor_uid` on server-side to pull from various data-sources.