### PR TITLE
BOAC-3041, Student profile > note author not found > graceful 404 server-side

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -58,12 +58,13 @@ def user_profile(uid):
 @advisor_required
 def calnet_profile(csid):
     user = calnet.get_calnet_user_for_csid(app, csid)
-    if user:
-        authorized_user = AuthorizedUser.find_by_uid(user['uid'])
+    uid = user.get('uid', None)
+    authorized_user = uid and AuthorizedUser.find_by_uid(uid)
+    if authorized_user:
         users_feed = authorized_users_api_feed([authorized_user])
         return tolerant_jsonify(users_feed[0])
     else:
-        return errors.ResourceNotFoundError('User not found')
+        raise errors.ResourceNotFoundError('User not found')
 
 
 @app.route('/api/user/by_uid/<uid>')
@@ -74,7 +75,7 @@ def user_by_uid(uid):
         users_feed = authorized_users_api_feed([user])
         return tolerant_jsonify(users_feed[0])
     else:
-        return errors.ResourceNotFoundError('User not found')
+        raise errors.ResourceNotFoundError('User not found')
 
 
 @app.route('/api/user/dept_membership/add', methods=['POST'])

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -28,7 +28,7 @@
       <div v-if="note.subject && note.message" class="mt-2">
         <span :id="`note-${note.id}-message-open`" v-html="note.message"></span>
       </div>
-      <div v-if="!isUndefined(note.author) && !note.author.name" class="mt-2 advisor-profile-not-found">
+      <div v-if="!isNil(note.author) && !note.author.name" class="mt-2 advisor-profile-not-found">
         Advisor profile not found
       </div>
       <div v-if="note.author" class="mt-2">
@@ -211,7 +211,7 @@ export default {
   },
   methods: {
     setAuthor() {
-      if (this.isOpen && (!this.note.author.name || !this.note.author.role)) {
+      if (this.isOpen && this.get(this.note, 'author.uid') && (!this.note.author.name || !this.note.author.role)) {
         const author_uid = this.note.author.uid;
         if (author_uid) {
           if (author_uid === this.user.uid) {

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -124,6 +124,12 @@ class TestUserById:
         response = client.get(f'/api/user/by_uid/{user.uid}')
         assert response.status_code == 401
 
+    def test_user_not_found(self, client, fake_auth):
+        """404 when user not found."""
+        fake_auth.login(admin_uid)
+        response = client.get('/api/user/by_csid/99999999999999999')
+        assert response.status_code == 404
+
     def test_user_by_uid(self, client, fake_auth):
         """Delivers CalNet profile."""
         fake_auth.login(admin_uid)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3041

* server-side must `raise`, not return, errors.ResourceNotFoundError
* client-side should gracefully handle advisor-not-found (no console error)