### PR TITLE
BOAC-2882, include deleted users in Passenger Manifest get-admin-users

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -165,7 +165,8 @@ def all_users():
 @admin_required
 def get_admin_users():
     params = request.get_json()
-    users = AuthorizedUser.query.filter(AuthorizedUser.is_admin).all()
+    ignore_deleted = to_bool_or_none(util.get(params, 'ignoreDeleted'))
+    users = AuthorizedUser.get_admin_users(ignore_deleted=True if ignore_deleted is None else ignore_deleted)
     return tolerant_jsonify({
         'users': authorized_users_api_feed(
             users,

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -160,12 +160,20 @@ class AuthorizedUser(Base):
 
     @classmethod
     def find_by_uid(cls, uid, ignore_deleted=True):
-        results = cls.query.filter_by(uid=uid, deleted_at=None) if ignore_deleted else cls.query.filter_by(uid=uid)
-        return results.first()
+        query = cls.query.filter_by(uid=uid, deleted_at=None) if ignore_deleted else cls.query.filter_by(uid=uid)
+        return query.first()
 
     @classmethod
     def get_all_active_users(cls, include_deleted=False):
         return cls.query.all() if include_deleted else cls.query.filter_by(deleted_at=None).all()
+
+    @classmethod
+    def get_admin_users(cls, ignore_deleted=True):
+        if ignore_deleted:
+            query = cls.query.filter(and_(cls.is_admin, cls.deleted_at == None))  # noqa: E711
+        else:
+            query = cls.query.filter(cls.is_admin)
+        return query.all()
 
     @classmethod
     def get_users(

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -48,6 +48,7 @@ from flask import current_app as app
 from sqlalchemy.sql import text
 
 
+delete_this_admin_uid = '44444'
 delete_this_uid = '33333'
 no_calnet_record_for_uid = '13'
 
@@ -79,6 +80,14 @@ _test_users = [
         'uid': delete_this_uid,
         'csid': '333333333',
         'isAdmin': False,
+        'inDemoMode': False,
+        'canAccessCanvasData': False,
+    },
+    {
+        # User deleted (see below)
+        'uid': delete_this_admin_uid,
+        'csid': '444444444',
+        'isAdmin': True,
         'inDemoMode': False,
         'canAccessCanvasData': False,
     },
@@ -443,7 +452,9 @@ def _create_users():
                 user.deleted_at = utc_now()
             db.session.add(user)
 
+    AuthorizedUser.delete_and_block(delete_this_admin_uid)
     AuthorizedUser.delete_and_block(delete_this_uid)
+
     std_commit(allow_test_environment=True)
 
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -9,9 +9,13 @@ export function getDepartments(excludeEmpty?: boolean) {
     .then(response => response.data, () => null);
 }
 
-export function getAdminUsers(sortBy: string, sortDescending: boolean) {
+export function getAdminUsers(sortBy: string, sortDescending: boolean, ignoreDeleted?: boolean) {
   return axios
-    .post(`${utils.apiBaseUrl()}/api/users/admins`, {sortBy, sortDescending})
+    .post(`${utils.apiBaseUrl()}/api/users/admins`, {
+      ignoreDeleted: _.isNil(ignoreDeleted) ? null : ignoreDeleted,
+      sortBy,
+      sortDescending
+    })
     .then(response => response.data, () => null);
 }
 

--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -281,7 +281,7 @@ export default {
       let promise = undefined;
       switch(this.filterType) {
         case 'admins':
-          promise = getAdminUsers(this.sortBy, this.sortDescending).then(data => {
+          promise = getAdminUsers(this.sortBy, this.sortDescending, false).then(data => {
             this.totalUserCount = data.totalUserCount;
             return data.users;
           });


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-2882

Passenger Manifest `filter` and `search` include deleted users. Now `Admins` option does the same.