### PR TITLE
BOAC-3045, topic_unique_constraint includes deleted_at – for notes and appts

### DIFF
--- a/scripts/db/migrate/2019/20191123-BOAC-3045/pre_deploy_01_topic_unique_constraint.sql
+++ b/scripts/db/migrate/2019/20191123-BOAC-3045/pre_deploy_01_topic_unique_constraint.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS ONLY public.appointment_topics
+    DROP CONSTRAINT IF EXISTS appointment_topics_appointment_id_topic_unique_constraint;
+ALTER TABLE IF EXISTS ONLY public.note_topics
+    DROP CONSTRAINT IF EXISTS note_topics_note_id_topic_unique_constraint;
+
+ALTER TABLE ONLY appointment_topics
+    ADD CONSTRAINT appointment_topics_appointment_id_topic_unique_constraint UNIQUE (appointment_id, topic, deleted_at);
+ALTER TABLE ONLY note_topics
+    ADD CONSTRAINT note_topics_note_id_topic_unique_constraint UNIQUE (note_id, topic, deleted_at);
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -101,7 +101,7 @@ ALTER TABLE ONLY appointment_topics ALTER COLUMN id SET DEFAULT nextval('appoint
 ALTER TABLE ONLY appointment_topics
     ADD CONSTRAINT appointment_topics_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY appointment_topics
-    ADD CONSTRAINT appointment_topics_appointment_id_topic_unique_constraint UNIQUE (appointment_id, topic);
+    ADD CONSTRAINT appointment_topics_appointment_id_topic_unique_constraint UNIQUE (appointment_id, topic, deleted_at);
 CREATE INDEX appointment_topics_appointment_id_idx ON appointment_topics (appointment_id);
 CREATE INDEX appointment_topics_topic_idx ON appointment_topics (topic);
 
@@ -470,7 +470,7 @@ ALTER TABLE ONLY note_topics ALTER COLUMN id SET DEFAULT nextval('note_topics_id
 ALTER TABLE ONLY note_topics
     ADD CONSTRAINT note_topics_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY note_topics
-    ADD CONSTRAINT note_topics_note_id_topic_unique_constraint UNIQUE (note_id, topic);
+    ADD CONSTRAINT note_topics_note_id_topic_unique_constraint UNIQUE (note_id, topic, deleted_at);
 CREATE INDEX note_topics_note_id_idx ON note_topics (note_id);
 CREATE INDEX note_topics_topic_idx ON note_topics (topic);
 

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -578,17 +578,27 @@ class TestUpdateNotes:
     def test_remove_note_topics(self, app, client, fake_auth, mock_asc_advising_note):
         """Delete note topics."""
         fake_auth.login(mock_asc_advising_note.author_uid)
-        expected_topics = []
+        original_topics = mock_asc_advising_note.topics
+        assert len(original_topics)
         api_json = self._api_note_update(
             app,
             client,
             note_id=mock_asc_advising_note.id,
             subject=mock_asc_advising_note.subject,
             body=mock_asc_advising_note.body,
-            topics=expected_topics,
+            topics=[],
         )
-        assert api_json['read'] is True
         assert not api_json['topics']
+        # Put those topics back
+        api_json = self._api_note_update(
+            app,
+            client,
+            note_id=mock_asc_advising_note.id,
+            subject=mock_asc_advising_note.subject,
+            body=mock_asc_advising_note.body,
+            topics=[t.topic for t in original_topics],
+        )
+        assert set(api_json['topics']) == set([t.topic for t in original_topics])
 
 
 class TestDeleteNote:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3045

For the indecisive advisor: No error when re-adding a topic.