### PR TITLE
[QA] BOAC-3068, no 404 when advisor not found; nil tolerant front-end

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -63,7 +63,8 @@ def calnet_profile(csid):
         users_feed = authorized_users_api_feed([authorized_user])
         return tolerant_jsonify(users_feed[0])
     else:
-        raise errors.ResourceNotFoundError('User not found')
+        app.logger.error(f'No user found for CS ID {csid}')
+        return tolerant_jsonify(None)
 
 
 @app.route('/api/user/by_uid/<uid>')
@@ -74,7 +75,8 @@ def user_by_uid(uid):
         users_feed = authorized_users_api_feed([user])
         return tolerant_jsonify(users_feed[0])
     else:
-        raise errors.ResourceNotFoundError('User not found')
+        app.logger.error(f'No user found for UID {uid}')
+        return tolerant_jsonify(None)
 
 
 @app.route('/api/user/dept_membership/add', methods=['POST'])

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -220,7 +220,7 @@ export default {
   },
   methods: {
     setAuthor() {
-      const requiresLazyLoad = this.isOpen && (!this.note.author.name || !this.note.author.role);
+      const requiresLazyLoad = this.isOpen && (!this.get(this.note, 'author.name') || !this.get(this.note, 'author.role'));
       if (requiresLazyLoad) {
         const hasIdentifier = this.get(this.note, 'author.uid') || this.get(this.note, 'author.sid');
         if (hasIdentifier) {

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -126,7 +126,7 @@ class TestUserById:
         """404 when user not found."""
         fake_auth.login(admin_uid)
         response = client.get('/api/user/by_csid/99999999999999999')
-        assert response.status_code == 404
+        assert not response.json
 
     def test_user_by_uid(self, client, fake_auth):
         """Delivers CalNet profile."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3068

IMO, the safest fix is to _not_ return 404 from API and make sure front-end is null tolerant.
