### PR TITLE
[QA] BOAC-3068, get-advisor-info is strictly CalNet-based, no authorized_user dependency

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -53,9 +53,21 @@ def user_profile(uid):
     return tolerant_jsonify(calnet.get_calnet_user_for_uid(app, uid))
 
 
+@app.route('/api/user/calnet_profile/by_csid/<csid>')
+@advisor_required
+def calnet_profile_by_csid(csid):
+    return tolerant_jsonify(calnet.get_calnet_user_for_csid(app, csid))
+
+
+@app.route('/api/user/calnet_profile/by_uid/<uid>')
+@advisor_required
+def calnet_profile_by_uid(uid):
+    return tolerant_jsonify(calnet.get_calnet_user_for_uid(app, uid))
+
+
 @app.route('/api/user/by_csid/<csid>')
 @advisor_required
-def calnet_profile(csid):
+def user_by_csid(csid):
     user = calnet.get_calnet_user_for_csid(app, csid)
     uid = user.get('uid', None)
     authorized_user = uid and AuthorizedUser.find_by_uid(uid)
@@ -63,8 +75,7 @@ def calnet_profile(csid):
         users_feed = authorized_users_api_feed([authorized_user])
         return tolerant_jsonify(users_feed[0])
     else:
-        app.logger.error(f'No user found for CS ID {csid}')
-        return tolerant_jsonify(None)
+        raise errors.ResourceNotFoundError('User not found')
 
 
 @app.route('/api/user/by_uid/<uid>')
@@ -75,8 +86,7 @@ def user_by_uid(uid):
         users_feed = authorized_users_api_feed([user])
         return tolerant_jsonify(users_feed[0])
     else:
-        app.logger.error(f'No user found for UID {uid}')
-        return tolerant_jsonify(None)
+        raise errors.ResourceNotFoundError('User not found')
 
 
 @app.route('/api/user/dept_membership/add', methods=['POST'])

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -20,6 +20,18 @@ export function getUserProfile() {
     .then(response => response.data, () => null);
 }
 
+export function getCalnetProfileByCsid(csid) {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/user/calnet_profile/by_csid/${csid}`)
+    .then(response => response.data, () => null);
+}
+
+export function getCalnetProfileByUid(uid) {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/user/calnet_profile/by_uid/${uid}`)
+    .then(response => response.data, () => null);
+}
+
 export function getUserByCsid(csid) {
   return axios
     .get(`${utils.apiBaseUrl()}/api/user/by_csid/${csid}`)

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -152,7 +152,7 @@ import store from '@/store';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
 import { addAttachment, removeAttachment } from '@/api/notes';
-import { getUserByUid } from '@/api/user';
+import { getCalnetProfileByUid } from '@/api/user';
 
 export default {
   name: 'AdvisingNote',
@@ -229,7 +229,7 @@ export default {
             if (author_uid === this.user.uid) {
               this.note.author = this.user;
             } else {
-              getUserByUid(author_uid).then(data => {
+              getCalnetProfileByUid(author_uid).then(data => {
                 this.note.author = data || {};
               });
             }

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Vue from 'vue';
 import { event } from 'vue-analytics';
-import { getUserByCsid, getUserProfile } from '@/api/user';
+import { getCalnetProfileByCsid, getUserProfile } from '@/api/user';
 import { gaTrackUserSessionStart } from '@/api/ga';
 
 const gaEvent = (category, action, label, value) => event(category, action, label, value);
@@ -61,7 +61,7 @@ const actions = {
       if (state.calnetUsersByCsid[csid]) {
         resolve(state.calnetUsersByCsid[csid]);
       } else {
-        getUserByCsid(csid)
+        getCalnetProfileByCsid(csid)
           .then(calnetUser => {
             commit('putCalnetUserByCsid', {csid, calnetUser});
             resolve(state.calnetUsersByCsid[csid]);

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -113,6 +113,36 @@ class TestUserProfile:
         assert response.status_code == 404
 
 
+class TestCalnetProfileById:
+    """Calnet Profile API."""
+
+    def test_user_by_uid_not_authenticated(self, client):
+        """Returns 401 when not authenticated."""
+        user = AuthorizedUser.find_by_uid(asc_advisor_uid)
+        response = client.get(f'/api/user/calnet_profile/by_uid/{user.uid}')
+        assert response.status_code == 401
+
+    def test_user_by_uid(self, client, fake_auth):
+        """Delivers CalNet profile."""
+        fake_auth.login(admin_uid)
+        user = AuthorizedUser.find_by_uid(asc_advisor_uid)
+        response = client.get(f'/api/user/calnet_profile/by_uid/{user.uid}')
+        assert response.status_code == 200
+        assert response.json['uid'] == asc_advisor_uid
+
+    def test_user_by_csid_not_authenticated(self, client):
+        """Returns 401 when not authenticated."""
+        response = client.get(f'/api/user/calnet_profile/by_csid/{81067873}')
+        assert response.status_code == 401
+
+    def test_user_by_csid(self, client, fake_auth):
+        """Delivers CalNet profile."""
+        fake_auth.login(admin_uid)
+        response = client.get(f'/api/user/calnet_profile/by_csid/{81067873}')
+        assert response.status_code == 200
+        assert response.json['csid'] == '81067873'
+
+
 class TestUserById:
     """User Profile API."""
 
@@ -126,7 +156,7 @@ class TestUserById:
         """404 when user not found."""
         fake_auth.login(admin_uid)
         response = client.get('/api/user/by_csid/99999999999999999')
-        assert not response.json
+        assert response.status_code == 404
 
     def test_user_by_uid(self, client, fake_auth):
         """Delivers CalNet profile."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3068

Originally, `/api/user/by_csid/<csid>` and `/api/user/by_uid/<uid>` were strictly CalNet-based. Recent changes to Passenger Manifest added an `authorized_user` dependency. I don't want to roll back that work BUT the get-advisor-info calls on student profile needs a CalNet-only API endpoint.

Fyi, these two new endpoints will not return 404.
