### PR TITLE
BOAC-3069, remove unused /api/user/by_csid

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -66,20 +66,6 @@ def calnet_profile_by_uid(uid):
     return tolerant_jsonify(calnet.get_calnet_user_for_uid(app, uid))
 
 
-@app.route('/api/user/by_csid/<csid>')
-@advisor_required
-def user_by_csid(csid):
-    user = calnet.get_calnet_user_for_csid(app, csid)
-    uid = user.get('uid', None)
-    ignore_deleted = to_bool_or_none(util.get(request.args, 'ignoreDeleted'))
-    user = _find_user_by_uid(uid, ignore_deleted)
-    if user:
-        users_feed = authorized_users_api_feed([user])
-        return tolerant_jsonify(users_feed[0])
-    else:
-        raise errors.ResourceNotFoundError('User not found')
-
-
 @app.route('/api/user/by_uid/<uid>')
 @advisor_required
 def user_by_uid(uid):

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -37,12 +37,6 @@ export function getCalnetProfileByUid(uid) {
     .then(response => response.data, () => null);
 }
 
-export function getUserByCsid(csid) {
-  return axios
-    .get(`${utils.apiBaseUrl()}/api/user/by_csid/${csid}`)
-    .then(response => response.data, () => null);
-}
-
 export function getUserByUid(uid, ignoreDeleted?: boolean) {
   let url = `${utils.apiBaseUrl()}/api/user/by_uid/${uid}`;
   if (!_.isNil(ignoreDeleted)) {

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -142,11 +142,10 @@
 import AreYouSureModal from '@/components/util/AreYouSureModal';
 import Attachments from '@/mixins/Attachments';
 import Context from '@/mixins/Context';
-import store from '@/store';
 import UserMetadata from '@/mixins/UserMetadata';
 import Util from '@/mixins/Util';
 import { addAttachment, removeAttachment } from '@/api/notes';
-import { getCalnetProfileByUid } from '@/api/user';
+import { getCalnetProfileByCsid, getCalnetProfileByUid } from '@/api/user';
 
 export default {
   name: 'AdvisingNote',
@@ -221,12 +220,12 @@ export default {
               this.note.author = this.user;
             } else {
               getCalnetProfileByUid(author_uid).then(data => {
-                this.note.author = data || {};
+                this.note.author = data;
               });
             }
           } else if (this.note.author.sid) {
-            store.dispatch('user/loadCalnetUserByCsid', this.note.author.sid).then(data => {
-              this.note.author = data || {};
+            getCalnetProfileByCsid(this.note.author.sid).then(data => {
+              this.note.author = data;
             });
           }
         }

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -1,13 +1,12 @@
 import _ from 'lodash';
 import Vue from 'vue';
 import { event } from 'vue-analytics';
-import { getCalnetProfileByCsid, getUserProfile } from '@/api/user';
+import { getUserProfile } from '@/api/user';
 import { gaTrackUserSessionStart } from '@/api/ga';
 
 const gaEvent = (category, action, label, value) => event(category, action, label, value);
 
 const state = {
-  calnetUsersByCsid: {},
   preferences: {
     sortBy: 'last_name'
   },
@@ -21,8 +20,6 @@ const getters = {
 };
 
 const mutations = {
-  putCalnetUserByCsid: (state: any, {csid, calnetUser}: any) =>
-    (state.calnetUsersByCsid[csid] = calnetUser),
   registerUser: (state: any, user: any) => {
     if (user.uid) {
       state.user = user;
@@ -56,19 +53,6 @@ const actions = {
   gaNoteTemplateEvent: (state: any, {id, label, action}) => gaEvent('Advising Note Template', action, label, id),
   gaSearchEvent: (state: any, action: string) => gaEvent('Search', action, null, null),
   gaStudentAlert: (state: any, action: string) => gaEvent('Student Alert', action, null, null),
-  loadCalnetUserByCsid: ({commit, state}, csid) => {
-    return new Promise(resolve => {
-      if (state.calnetUsersByCsid[csid]) {
-        resolve(state.calnetUsersByCsid[csid]);
-      } else {
-        getCalnetProfileByCsid(csid)
-          .then(calnetUser => {
-            commit('putCalnetUserByCsid', {csid, calnetUser});
-            resolve(state.calnetUsersByCsid[csid]);
-          });
-      }
-    });
-  },
   loadUser: ({commit, state}) => {
     return new Promise(resolve => {
       if (state.user) {

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -715,14 +715,6 @@ class TestNotes:
         assert not len(author['departments'])
         advisor_sid = '800700600'
         assert author['sid'] == advisor_sid
-        # Lazy-load author info, as performed on front-end
-        response = client.get(f'/api/user/by_csid/{advisor_sid}')
-        assert response.status_code == 200
-        user = response.json
-        assert user['csid'] == advisor_sid
-        assert len(user['name'])
-        assert user['departments'][0]['code'] == 'COENG'
-        assert user['departments'][0]['name'] == 'College of Engineering'
 
 
 class TestValidateSids:

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -147,10 +147,10 @@ class TestCalnetProfileById:
         assert response.json['csid'] == '81067873'
 
 
-class TestUserById:
-    """User Profile API."""
+class TestUserByUid:
+    """User by UID API."""
 
-    def test_user_by_uid_not_authenticated(self, client):
+    def test_not_authenticated(self, client):
         """Returns 401 when not authenticated."""
         user = AuthorizedUser.find_by_uid(asc_advisor_uid)
         response = client.get(f'/api/user/by_uid/{user.uid}')
@@ -159,10 +159,9 @@ class TestUserById:
     def test_user_not_found(self, client, fake_auth):
         """404 when user not found."""
         fake_auth.login(admin_uid)
-        response = client.get('/api/user/by_csid/99999999999999999')
-        assert response.status_code == 404
+        assert client.get('/api/user/by_uid/99999999999999999').status_code == 404
 
-    def test_deleted_user_by_uid_not_found(self, client, fake_auth):
+    def test_deleted_user_not_found(self, client, fake_auth):
         """404 is default if get deleted user by UID."""
         fake_auth.login(admin_uid)
         assert client.get(f'/api/user/by_uid/{deleted_user_uid}').status_code == 404
@@ -175,39 +174,13 @@ class TestUserById:
         assert response.status_code == 200
         assert response.json['uid'] == deleted_user_uid
 
-    def test_user_by_uid(self, client, fake_auth):
-        """Delivers CalNet profile."""
-        fake_auth.login(admin_uid)
-        user = AuthorizedUser.find_by_uid(asc_advisor_uid)
-        response = client.get(f'/api/user/by_uid/{user.uid}')
-        assert response.status_code == 200
-        assert response.json['uid'] == asc_advisor_uid
-
-    def test_user_by_csid_not_authenticated(self, client):
-        """Returns 401 when not authenticated."""
-        response = client.get(f'/api/user/by_csid/{81067873}')
-        assert response.status_code == 401
-
     def test_user_by_csid(self, client, fake_auth):
         """Delivers CalNet profile."""
         fake_auth.login(admin_uid)
-        response = client.get('/api/user/by_csid/800700600')
+        response = client.get('/api/user/by_uid/1133399')
         assert response.status_code == 200
         assert response.json['csid'] == '800700600'
         assert response.json['uid'] == '1133399'
-
-    def test_deleted_user_by_csid_not_found(self, client, fake_auth):
-        """404 is default if get deleted user by CSID."""
-        fake_auth.login(admin_uid)
-        assert client.get(f'/api/user/by_csid/{deleted_user_csid}').status_code == 404
-        assert client.get(f'/api/user/by_csid/{deleted_user_csid}?ignoreDeleted=true').status_code == 404
-
-    def test_get_deleted_user_by_csid(self, client, fake_auth):
-        """Get deleted user by CSID if specific param is passed."""
-        fake_auth.login(admin_uid)
-        response = client.get(f'/api/user/by_csid/{deleted_user_csid}?ignoreDeleted=false')
-        assert response.status_code == 200
-        assert response.json['uid'] == deleted_user_uid
 
 
 class TestUniversityDeptMember:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3069

The work of BOAC-3068 made `/api/user/by_csid` obsolete. *Note:* client-side caching of CalNet data is overkill cuz it's cached on server-side; we don't need the overhead in vue-store. 
