### PR TITLE
BOAC-3002: Looks to the loch for term configs

### DIFF
--- a/boac/api/admin_controller.py
+++ b/boac/api/admin_controller.py
@@ -25,16 +25,16 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from boac.api import cache_utils
 from boac.api.util import admin_required
-from boac.lib import berkeley
 from boac.lib.http import tolerant_jsonify
 from boac.merged import reporter
+from boac.merged.sis_terms import current_term_id
 from boac.models.job_progress import JobProgress
 from boac.models.manually_added_advisee import ManuallyAddedAdvisee
 from flask import current_app as app, request
 
 
 def term():
-    term_id = request.args.get('term') or berkeley.current_term_id()
+    term_id = request.args.get('term') or current_term_id()
     return term_id
 
 

--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -28,9 +28,9 @@ import json
 from boac import __version__ as version
 from boac.api.errors import BadRequestError
 from boac.api.util import admin_required
-from boac.lib.berkeley import sis_term_id_for_name
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import process_input_from_rich_text_editor, to_bool_or_none
+from boac.merged.sis_terms import current_term_id, current_term_name
 from boac.models.tool_setting import ToolSetting
 from flask import current_app as app, request
 from flask_login import current_user
@@ -38,13 +38,11 @@ from flask_login import current_user
 
 @app.route('/api/config')
 def app_config():
-    current_term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
-    current_term_id = sis_term_id_for_name(current_term_name)
     return tolerant_jsonify({
         'apptDeskRefreshInterval': app.config['APPT_DESK_REFRESH_INTERVAL'],
         'boacEnv': app.config['BOAC_ENV'],
-        'currentEnrollmentTerm': current_term_name,
-        'currentEnrollmentTermId': int(current_term_id),
+        'currentEnrollmentTerm': current_term_name(),
+        'currentEnrollmentTermId': int(current_term_id()),
         'disableMatrixViewThreshold': app.config['DISABLE_MATRIX_VIEW_THRESHOLD'],
         'devAuthEnabled': app.config['DEVELOPER_AUTH_ENABLED'],
         'ebEnvironment': app.config['EB_ENVIRONMENT'] if 'EB_ENVIRONMENT' in app.config else None,

--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -30,10 +30,10 @@ from boac.api.errors import BadRequestError, ForbiddenRequestError
 from boac.api.util import add_alert_counts, advisor_required, is_unauthorized_search
 from boac.externals.data_loch import get_enrolled_primary_sections, get_enrolled_primary_sections_for_parsed_code
 from boac.lib import util
-from boac.lib.berkeley import current_term_id
 from boac.lib.http import tolerant_jsonify
 from boac.merged.advising_note import search_advising_notes
 from boac.merged.calnet import get_uid_for_csid
+from boac.merged.sis_terms import current_term_id
 from boac.merged.student import search_for_students
 from boac.models.alert import Alert
 from boac.models.appointment import Appointment

--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -25,8 +25,6 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import re
 
-from flask import current_app as app
-
 
 """A utility module collecting logic specific to the Berkeley campus."""
 
@@ -398,31 +396,10 @@ BERKELEY_DEPT_CODE_TO_PROGRAM_AFFILIATIONS = {
 }
 
 
-def current_term_id():
-    term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
-    return sis_term_id_for_name(term_name)
-
-
-def future_term_id():
-    term_name = app.config['CANVAS_FUTURE_ENROLLMENT_TERM']
-    return sis_term_id_for_name(term_name)
-
-
 def previous_term_id(term_id):
     term_id = int(term_id)
     previous = term_id - (4 if (term_id % 10 == 2) else 3)
     return str(previous)
-
-
-def all_term_ids():
-    """Return SIS IDs of each term covered by BOAC, from current to oldest."""
-    earliest_term_id = sis_term_id_for_name(app.config['CANVAS_EARLIEST_TERM'])
-    term_id = current_term_id()
-    ids = []
-    while int(term_id) >= int(earliest_term_id):
-        ids.append(term_id)
-        term_id = previous_term_id(term_id)
-    return ids
 
 
 def term_ids_range(earliest_term_id, latest_term_id):
@@ -433,20 +410,6 @@ def term_ids_range(earliest_term_id, latest_term_id):
         ids.append(str(term_id))
         term_id += 4 if (term_id % 10 == 8) else 3
     return ids
-
-
-def reverse_terms_until(stop_term):
-    term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
-    while True:
-        yield term_name
-        if (term_name == stop_term) or (term_name == app.config['CANVAS_EARLIEST_TERM']):
-            break
-        if term_name.startswith('Fall'):
-            term_name = term_name.replace('Fall', 'Summer')
-        elif term_name.startswith('Summer'):
-            term_name = term_name.replace('Summer', 'Spring')
-        elif term_name.startswith('Spring'):
-            term_name = 'Fall ' + str(int(term_name[-4:]) - 1)
 
 
 def sis_term_id_for_name(term_name=None):

--- a/boac/merged/cohort_filter_options.py
+++ b/boac/merged/cohort_filter_options.py
@@ -27,9 +27,10 @@ from copy import copy, deepcopy
 
 from boac.api.util import authorized_users_api_feed
 from boac.externals import data_loch
-from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME, COE_ETHNICITIES_PER_CODE, current_term_id, term_name_for_sis_id
+from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME, COE_ETHNICITIES_PER_CODE, term_name_for_sis_id
 from boac.merged import athletics
 from boac.merged.calnet import get_csid_for_uid
+from boac.merged.sis_terms import current_term_id
 from boac.merged.student import get_student_query_scope
 from boac.models.authorized_user import AuthorizedUser
 from flask import current_app as app

--- a/boac/merged/reporter.py
+++ b/boac/merged/reporter.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import json
 
 from boac.externals import data_loch
-from boac.lib.berkeley import current_term_id
+from boac.merged.sis_terms import current_term_id
 from flask import current_app as app
 
 

--- a/boac/merged/sis_terms.py
+++ b/boac/merged/sis_terms.py
@@ -1,0 +1,65 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.externals import data_loch
+from boac.lib.berkeley import previous_term_id, sis_term_id_for_name
+from boac.models.json_cache import stow
+from flask import current_app as app
+
+
+@stow('current_term_index')
+def get_current_term_index():
+    return data_loch.get_current_term_index()
+
+
+def current_term_id(use_cache=True):
+    return sis_term_id_for_name(current_term_name(use_cache))
+
+
+def current_term_name(use_cache=True):
+    term_name = app.config['CANVAS_CURRENT_ENROLLMENT_TERM']
+    if term_name == 'auto':
+        index = get_current_term_index() if use_cache else data_loch.get_current_term_index()
+        return index and index['current_term_name']
+    return term_name
+
+
+def future_term_id():
+    term_name = app.config['CANVAS_FUTURE_ENROLLMENT_TERM']
+    if term_name == 'auto':
+        index = get_current_term_index()
+        return index and sis_term_id_for_name(index['future_term_name'])
+    return sis_term_id_for_name(term_name)
+
+
+def all_term_ids():
+    """Return SIS IDs of each term covered by BOAC, from current to oldest."""
+    earliest_term_id = sis_term_id_for_name(app.config['CANVAS_EARLIEST_TERM'])
+    term_id = current_term_id()
+    ids = []
+    while int(term_id) >= int(earliest_term_id):
+        ids.append(term_id)
+        term_id = previous_term_id(term_id)
+    return ids

--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -30,8 +30,9 @@ import re
 
 from boac.externals import data_loch, s3
 from boac.lib import analytics
-from boac.lib.berkeley import current_term_id, dept_codes_where_advising, future_term_id, term_name_for_sis_id
+from boac.lib.berkeley import dept_codes_where_advising, term_name_for_sis_id
 from boac.lib.util import get_benchmarker
+from boac.merged.sis_terms import current_term_id, future_term_id
 from boac.models.manually_added_advisee import ManuallyAddedAdvisee
 from flask import current_app as app
 from flask_login import current_user
@@ -363,6 +364,7 @@ def query_students(
         coe_prep_statuses=coe_prep_statuses,
         coe_probation=coe_probation,
         coe_underrepresented=coe_underrepresented,
+        current_term_id=current_term_id(),
         entering_terms=entering_terms,
         ethnicities=ethnicities,
         expected_grad_terms=expected_grad_terms,
@@ -400,6 +402,7 @@ def query_students(
     }
     if not sids_only:
         o, o_secondary, o_tertiary, supplemental_query_tables = data_loch.get_students_ordering(
+            current_term_id=current_term_id(),
             order_by=order_by,
             group_codes=group_codes,
             majors=majors,
@@ -447,7 +450,10 @@ def search_for_students(
             'students': [],
             'totalStudentCount': 0,
         }
-    o, o_secondary, o_tertiary, supplemental_query_tables = data_loch.get_students_ordering(order_by=order_by)
+    o, o_secondary, o_tertiary, supplemental_query_tables = data_loch.get_students_ordering(
+        current_term_id=current_term_id(),
+        order_by=order_by,
+    )
     if supplemental_query_tables:
         query_tables += supplemental_query_tables
     benchmark('begin SID query')

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -32,8 +32,9 @@ import time
 from boac import db, std_commit
 from boac.api.errors import BadRequestError
 from boac.externals import data_loch
-from boac.lib.berkeley import current_term_id, section_is_eligible_for_alerts, term_name_for_sis_id
+from boac.lib.berkeley import section_is_eligible_for_alerts, term_name_for_sis_id
 from boac.lib.util import camelize, unix_timestamp_to_localtime, utc_timestamp_to_localtime
+from boac.merged.sis_terms import current_term_id
 from boac.models.base import Base
 from boac.models.db_relationships import AlertView
 from flask import current_app as app

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -28,10 +28,10 @@ import json
 from boac import db, std_commit
 from boac.api.errors import InternalServerError
 from boac.lib import util
-from boac.lib.berkeley import current_term_id
 from boac.lib.util import get_benchmarker
 from boac.merged import athletics
 from boac.merged.calnet import get_csid_for_uid
+from boac.merged.sis_terms import current_term_id
 from boac.merged.student import query_students
 from boac.models.alert import Alert
 from boac.models.authorized_user import AuthorizedUser

--- a/config/default.py
+++ b/config/default.py
@@ -60,9 +60,9 @@ BOAC_SUPPORT_EMAIL = 'boahelp@berkeley.edu'
 CACHE_DEFAULT_TIMEOUT = False
 CACHE_TYPE = 'null'
 
-CANVAS_CURRENT_ENROLLMENT_TERM = 'Fall 2017'
+CANVAS_CURRENT_ENROLLMENT_TERM = 'auto'
 CANVAS_EARLIEST_TERM = 'Fall 2016'
-CANVAS_FUTURE_ENROLLMENT_TERM = 'Spring 2018'
+CANVAS_FUTURE_ENROLLMENT_TERM = 'auto'
 
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
 CAS_LOGOUT_URL = 'https://auth-test.berkeley.edu/cas/logout'

--- a/fixtures/loch.sql
+++ b/fixtures/loch.sql
@@ -213,6 +213,12 @@ CREATE TABLE sis_advising_notes.advising_note_topic_mappings (
   sis_topic VARCHAR NOT NULL
 );
 
+CREATE TABLE sis_data.current_term_index
+(
+    current_term_name VARCHAR NOT NULL,
+    future_term_name VARCHAR NOT NULL
+);
+
 CREATE TABLE sis_data.enrolled_primary_sections
 (
     term_id VARCHAR NOT NULL,
@@ -539,6 +545,11 @@ CREATE MATERIALIZED VIEW boac_advising_notes.advising_notes_search_index AS (
   UNION SELECT id, fts_index FROM boac_advising_e_i.advising_notes_search_index
   UNION SELECT id, fts_index FROM sis_advising_notes.advising_notes_search_index
 );
+
+INSERT INTO sis_data.current_term_index
+(current_term_name, future_term_name)
+VALUES
+('Fall 2017', 'Spring 2018');
 
 INSERT INTO sis_data.enrolled_primary_sections
 (term_id, sis_section_id, sis_course_name, sis_course_name_compressed, sis_subject_area_compressed, sis_catalog_id, sis_course_title, sis_instruction_format, sis_section_num, instructors)

--- a/run.py
+++ b/run.py
@@ -65,8 +65,8 @@ def initdb():
 @application.cli.command()
 def refresh_external_data():
     from boac.api import cache_utils
-    from boac.lib import berkeley
-    cache_utils.refresh_request_handler(berkeley.current_term_id())
+    from boac.merged.sis_terms import current_term_id
+    cache_utils.refresh_request_handler(current_term_id())
 
 
 host = application.config['HOST']

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -103,6 +103,28 @@ class TestRefreshCalnetAttributes:
         assert json_cache.fetch(f'calnet_user_for_uid_{removed_advisor}') is None
 
 
+class TestRefreshCurrentTermIndex:
+    """Test current term index refresh."""
+
+    def test_refresh_current_term_index(self, app):
+        """Deletes existing index from the cache and adds a fresh one."""
+        from boac.api.cache_utils import refresh_current_term_index
+        from boac.models import json_cache
+        from boac.models.json_cache import JsonCache
+
+        index_row = JsonCache.query.filter_by(key='current_term_index').first()
+        index_row.json = 'old'
+        json_cache.update_jsonb_row(index_row)
+        index = json_cache.fetch('current_term_index')
+        assert(index) == 'old'
+
+        refresh_current_term_index()
+
+        index = json_cache.fetch('current_term_index')
+        assert(index['current_term_name']) == 'Fall 2017'
+        assert(index['future_term_name']) == 'Spring 2018'
+
+
 class TestRefreshDepartmentMemberships:
     """Test department membership refresh."""
 

--- a/tests/test_externals/test_data_loch.py
+++ b/tests/test_externals/test_data_loch.py
@@ -34,6 +34,11 @@ import pytest
 @pytest.mark.usefixtures('db_session')
 class TestDataLoch:
 
+    def test_get_current_term_index(self):
+        index = data_loch.get_current_term_index()
+        assert index['current_term_name'] == 'Fall 2017'
+        assert index['future_term_name'] == 'Spring 2018'
+
     def test_get_student_profiles(self, app):
         import json
         sid = '11667051'

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -50,9 +50,6 @@ class TestBerkeleySisTermIdForName:
         """Returns None for missing term names."""
         assert berkeley.sis_term_id_for_name(None) is None
 
-    def test_all_term_ids(self):
-        assert berkeley.all_term_ids() == ['2178', '2175', '2172', '2168']
-
     def test_term_ids_range(self, app):
         assert berkeley.term_ids_range('2158', '2208') == [
             '2158', '2162', '2165', '2168', '2172', '2175', '2178', '2182', '2185', '2188', '2192', '2195', '2198', '2202', '2205', '2208',

--- a/tests/test_merged/test_sis_terms.py
+++ b/tests/test_merged/test_sis_terms.py
@@ -1,0 +1,80 @@
+"""
+Copyright ©2019. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+from boac.merged import sis_terms
+from tests.util import override_config
+
+
+class TestSisTerms:
+
+    def test_get_current_term_index(self):
+        """Gets the current and future terms."""
+        index = sis_terms.get_current_term_index()
+        assert(index['current_term_name']) == 'Fall 2017'
+        assert(index['future_term_name']) == 'Spring 2018'
+
+    def test_all_term_ids(self):
+        """Returns SIS IDs of each term covered by BOAC, from current to oldest."""
+        assert sis_terms.all_term_ids() == ['2178', '2175', '2172', '2168']
+
+    def test_current_term_id(self):
+        """Returns the current term ID."""
+        assert(sis_terms.current_term_id()) == '2178'
+
+    def test_current_term_id_caching(self):
+        """Fetches current term ID from the loch instead of cache when asked."""
+        import json
+        from boac.models import json_cache
+        from boac.models.json_cache import JsonCache
+
+        index_row = JsonCache.query.filter_by(key='current_term_index').first()
+        index_row.json = json.loads('{"current_term_name": "Spring 2020"}')
+        json_cache.update_jsonb_row(index_row)
+
+        assert(sis_terms.current_term_id()) == '2202'
+        assert(sis_terms.current_term_id(use_cache=False)) == '2178'
+
+    def test_current_term_id_from_config(self, app):
+        """Falls back on configured current term ID when not set to auto."""
+        with override_config(app, 'CANVAS_CURRENT_ENROLLMENT_TERM', 'Summer 1969'):
+            assert(sis_terms.current_term_id()) == '1695'
+
+    def test_current_term_name(self):
+        """Returns the current term name."""
+        assert(sis_terms.current_term_name()) == 'Fall 2017'
+
+    def test_current_term_name_from_config(self, app):
+        """Falls back on configured current term name when not set to auto."""
+        with override_config(app, 'CANVAS_CURRENT_ENROLLMENT_TERM', 'Summer 1969'):
+            assert(sis_terms.current_term_name()) == 'Summer 1969'
+
+    def test_future_term_id(self):
+        """Returns the future term id."""
+        assert(sis_terms.future_term_id()) == '2182'
+
+    def test_future_term_id_from_config(self, app):
+        """Falls back on configured future term ID when not set to auto."""
+        with override_config(app, 'CANVAS_FUTURE_ENROLLMENT_TERM', 'Summer 1969'):
+            assert(sis_terms.future_term_id()) == '1695'


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3002

boa-dev will continue to rely on the term configs in boac-dev.py until those are switched to 'auto'.   I'll wait until things are settled on the Nessie side before making that switch.