### PR TITLE
[QA] BOAC-3094, drop-in advisor sees 'Assign to me' rather than 'Assign'

### DIFF
--- a/src/components/appointment/DropInAppointmentDropdown.vue
+++ b/src/components/appointment/DropInAppointmentDropdown.vue
@@ -70,7 +70,7 @@
             v-if="appointment.status !== 'reserved'"
             :id="`btn-appointment-${appointment.id}-reserve`"
             @click="selfCheckIn ? reserveAppointment() : launchAppointmentAssign()">
-            <span class="text-nowrap">Assign</span>
+            <span class="text-nowrap">Assign<span v-if="selfCheckIn"> to me</span></span>
           </b-dropdown-item-button>
           <b-dropdown-item-button
             v-if="appointment.status === 'reserved'"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3094

Low-risk enhancement for `qa`: 'Assign to me' on Drop-in advisor `/home`.  The full BOAC-3094 fix will land on master.