### PR TITLE
BOAC-3102, do not set apptDeskRefreshInterval on user-initiated appt update

### DIFF
--- a/src/views/DropInAdvisorHome.vue
+++ b/src/views/DropInAdvisorHome.vue
@@ -11,7 +11,7 @@
             <DropInWaitlist
               :dept-code="deptCode"
               :is-homepage="true"
-              :on-appointment-status-change="loadDropInWaitlist"
+              :on-appointment-status-change="onAppointmentStatusChange"
               :waitlist="waitlist" />
           </div>
         </b-col>
@@ -99,11 +99,13 @@ export default {
     this.loadDropInWaitlist();
   },
   methods: {
-    loadDropInWaitlist() {
+    loadDropInWaitlist(scheduleFutureRefresh=true) {
       return new Promise(resolve => {
         if (this.loadingWaitlist) {
           resolve();
-          setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
+          if (scheduleFutureRefresh) {
+            setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
+          }
           return;
         }
         this.loadingWaitlist = true;
@@ -132,7 +134,9 @@ export default {
 
           this.loadingWaitlist = false;
           resolve();
-          setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
+          if (scheduleFutureRefresh) {
+            setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
+          }
 
           if (announceLoad) {
             this.loaded('Appointment waitlist');
@@ -142,6 +146,10 @@ export default {
           }
         });
       });
+    },
+    onAppointmentStatusChange() {
+      // We return a Promise.
+      return this.loadDropInWaitlist(false);
     }
   }
 }

--- a/src/views/DropInDesk.vue
+++ b/src/views/DropInDesk.vue
@@ -22,7 +22,7 @@
           ref="dropInWaitlist"
           :advisors="advisors"
           :dept-code="deptCode"
-          :on-appointment-status-change="loadDropInWaitlist"
+          :on-appointment-status-change="onAppointmentStatusChange"
           :waitlist="waitlist" />
       </div>
     </div>
@@ -53,11 +53,13 @@ export default {
     this.loadDropInWaitlist();
   },
   methods: {
-    loadDropInWaitlist() {
+    loadDropInWaitlist(scheduleFutureRefresh=true) {
       return new Promise(resolve => {
         if (this.loadingWaitlist) {
           resolve();
-          setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
+          if (scheduleFutureRefresh) {
+            setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
+          }
           return;
         }
         this.loadingWaitlist = true;
@@ -78,8 +80,9 @@ export default {
 
           this.loadingWaitlist = false;
           resolve();
-          setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
-
+          if (scheduleFutureRefresh) {
+            setTimeout(this.loadDropInWaitlist, this.apptDeskRefreshInterval);
+          }
           if (announceUpdate) {
             this.alertScreenReader("The drop-in waitlist has been updated");
           } else if (response.waitlist) {
@@ -87,6 +90,10 @@ export default {
           }
         });
       });
+    },
+    onAppointmentStatusChange() {
+      // We return a Promise.
+      return this.loadDropInWaitlist(false);
     }
   }
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3102

We do not want another refresh-waitlist thread every time user edits an appt.
