### PR TITLE
BOAC-3163, remove unwanted topic: Readmission, Withdrawal

### DIFF
--- a/scripts/db/migrate/2019/20191218-BOAC-3163/pre_deploy_01_revise_topics.sql
+++ b/scripts/db/migrate/2019/20191218-BOAC-3163/pre_deploy_01_revise_topics.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DELETE FROM topics WHERE topic = 'Readmission, Withdrawal';
+
+COMMIT;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3163

I think a hard delete is justified because (1) `available_in_notes = false` and (2) the appointments feature is not yet in use.