### PR TITLE
BOAC-3189, db schema mod for search history feature

### DIFF
--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -28,6 +28,7 @@ from boac.lib.util import utc_now
 from boac.models.base import Base
 from boac.models.db_relationships import cohort_filter_owners
 from sqlalchemy import and_, text
+from sqlalchemy.dialects.postgresql import ARRAY
 
 
 class AuthorizedUser(Base):
@@ -42,6 +43,7 @@ class AuthorizedUser(Base):
     deleted_at = db.Column(db.DateTime, nullable=True)
     # When True, is_blocked prevents a deleted user from being revived by the automated refresh.
     is_blocked = db.Column(db.Boolean, nullable=False, default=False)
+    search_history = db.Column(ARRAY(db.String), nullable=True)
     department_memberships = db.relationship(
         'UniversityDeptMember',
         back_populates='authorized_user',

--- a/scripts/db/migrate/2020/20200106-BOAC-3189/pre_deploy_01_add_search_history_column.sql
+++ b/scripts/db/migrate/2020/20200106-BOAC-3189/pre_deploy_01_add_search_history_column.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE authorized_users ADD COLUMN search_history CHARACTER VARYING[];
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -211,6 +211,7 @@ CREATE TABLE authorized_users (
     is_admin boolean,
     in_demo_mode boolean DEFAULT false NOT NULL,
     can_access_canvas_data boolean DEFAULT true NOT NULL,
+    search_history CHARACTER VARYING[],
     created_at timestamp with time zone NOT NULL,
     created_by character varying(255) NOT NULL,
     updated_at timestamp with time zone NOT NULL,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3189

We will keep it simple in first iteration of this feature: add `search_history` column to `authorized_users`.