### PR TITLE
BOAC-3191, suggestions from search-history using Autocomplete component

### DIFF
--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -83,9 +83,11 @@ def search():
 @app.route('/api/search/add_to_search_history', methods=['POST'])
 @login_required
 def add_to_search_history():
-    search_phrase = util.get(request.get_json(), 'phrase', '').strip()
+    search_phrase = request.get_json().get('phrase')
+    search_phrase = search_phrase and search_phrase.strip()
     if search_phrase:
-        return tolerant_jsonify(AuthorizedUser.add_to_search_history(current_user.get_id(), search_phrase))
+        search_history = AuthorizedUser.add_to_search_history(current_user.get_id(), search_phrase)
+        return tolerant_jsonify(search_history)
     else:
         raise BadRequestError('Search phrase not found in request')
 
@@ -93,7 +95,8 @@ def add_to_search_history():
 @app.route('/api/search/my_search_history')
 @login_required
 def my_search_history():
-    return tolerant_jsonify(AuthorizedUser.get_search_history(current_user.get_id()))
+    search_history = AuthorizedUser.get_search_history(current_user.get_id()) or []
+    return tolerant_jsonify(search_history)
 
 
 def _appointments_search(search_phrase, params):

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -2,6 +2,18 @@ import axios from 'axios';
 import utils from '@/api/api-utils';
 import Vue from "vue";
 
+export function getMySearchHistory() {
+  return axios
+    .get(`${utils.apiBaseUrl()}/api/search/my_search_history`)
+    .then(response => response.data, () => null);
+}
+
+export function addToSearchHistory(phrase) {
+  return axios
+    .post(`${utils.apiBaseUrl()}/api/search/add_to_search_history`, { phrase })
+    .then(response => response.data, () => null);
+}
+
 export function search(
   phrase: string,
   includeAppointments: boolean,

--- a/tests/test_api/test_search_controller.py
+++ b/tests/test_api/test_search_controller.py
@@ -748,6 +748,11 @@ class TestSearchHistory:
         """Returns empty array if user has no search history."""
         assert self._api_my_search_history(client) == []
 
+    def test_blank_input(self, asc_advisor, client):
+        """Blank search phrase is not added to search history."""
+        self._api_add_to_my_search_history(client, '    ', expected_status_code=400)
+        assert self._api_my_search_history(client=client) == ['Moe', 'Larry', 'Curly']
+
     def test_search_history(self, asc_advisor, client):
         """Returns search history."""
         api_json = self._api_my_search_history(client)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3191

Suggestions from search history are shown when you first put focus on input and the list narrows as you type. The new `restrict` prop in `Autocomplete` allows for a query that is _not_ in list o' suggestions.