### PR TITLE
BOAC-3204, SearchForm uses getQuery in child component to get input

### DIFF
--- a/src/components/util/Autocomplete.vue
+++ b/src/components/util/Autocomplete.vue
@@ -155,6 +155,9 @@ export default {
         }
       });
     },
+    getQuery() {
+      return this.query;
+    },
     highlightQuery(string) {
       var regex = new RegExp(this.query, 'i');
       var match = string.match(regex);
@@ -201,7 +204,7 @@ export default {
       }
     },
     onClickOutside(evt) {
-      if (!this.$el.contains(evt.target)) {
+      if (this.restrict && !this.$el.contains(evt.target)) {
         this.closeSuggestions();
       }
     },


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3204

Two fixes:
* We use the more reliable `$refs.searchInput.getQuery()` instead of computed `searchInput`. 
* In sidebar search, do not clear input when `clickOutside`.