### PR TITLE
BOAC-3207, search: onClickOutside if evt.target is outside input el

### DIFF
--- a/src/components/util/Autocomplete.vue
+++ b/src/components/util/Autocomplete.vue
@@ -204,10 +204,14 @@ export default {
       }
     },
     onClickOutside(evt) {
-      if (this.restrict && !this.$el.contains(evt.target)) {
-        this.closeSuggestions();
-      } else if (!this.restrict) {
-        this.isOpen = false;
+      if (!this.$el.contains(evt.target)) {
+        if (this.restrict) {
+          // Close suggestions and clear the input.
+          this.closeSuggestions();
+        } else {
+          // Close only.
+          this.isOpen = false;
+        }
       }
     },
     onEnter() {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3207

Before search history work, this function was:
```
onClickOutside(evt) {
  if (!this.$el.contains(evt.target)) {
    this.closeSuggestions();
  }
}
```

This PR restores that outer conditional.
