### PR TITLE
BOAC-3209, friendly truncation of search history entries

### DIFF
--- a/src/components/sidebar/SearchForm.vue
+++ b/src/components/sidebar/SearchForm.vue
@@ -440,10 +440,12 @@ export default {
           this.noop
         );
         this.scrollToTop();
-        addToSearchHistory(searchPhrase).then(history => {
-          this.searchHistory = history;
-          this.$ga.searchEvent(`Search with courses: ${this.includeCourses}; notes: ${this.includeNotes}; students: ${this.includeStudents}`);
-        });
+        if (this.trim(searchPhrase)) {
+          addToSearchHistory(searchPhrase).then(history => {
+            this.searchHistory = history;
+            this.$ga.searchEvent(`Search with courses: ${this.includeCourses}; notes: ${this.includeNotes}; students: ${this.includeStudents}`);
+          });
+        }
       } else {
         this.alertScreenReader('Search input is required');
       }

--- a/src/components/util/Autocomplete.vue
+++ b/src/components/util/Autocomplete.vue
@@ -8,7 +8,7 @@
       :class="inputClass"
       :disabled="disabled"
       :placeholder="placeholder"
-      maxlength="56"
+      :maxlength="maxlength"
       name="autocomplete-name"
       :required="isRequired"
       :type="demoModeBlur && $currentUser.inDemoMode ? 'password': 'text'"
@@ -100,6 +100,11 @@ export default {
     onEscFormInput: {
       required: false,
       type: Function
+    },
+    maxlength: {
+      default: '56',
+      required: false,
+      type: String
     },
     placeholder: {
       required: false,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3209

Search input and search history entries have max-length 256.