### PR TITLE
BOAC-3269 Back end for drop-in status text

### DIFF
--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -489,7 +489,7 @@ def _create_department_memberships():
                 automate_membership=user['automate_membership'],
             )
             if user['isDropInAdvisor']:
-                DropInAdvisor.create_or_update_status(
+                DropInAdvisor.create_or_update_membership(
                     dept_code=dept_code,
                     authorized_user_id=authorized_user.id,
                     is_available=True,

--- a/boac/models/drop_in_advisor.py
+++ b/boac/models/drop_in_advisor.py
@@ -33,6 +33,7 @@ class DropInAdvisor(Base):
     authorized_user_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False, primary_key=True)
     dept_code = db.Column(db.String(80), nullable=False, primary_key=True)
     is_available = db.Column(db.Boolean, default=False, nullable=False)
+    status = db.Column(db.String(255))
 
     authorized_user = db.relationship('AuthorizedUser', back_populates='drop_in_departments')
 
@@ -45,21 +46,25 @@ class DropInAdvisor(Base):
         self.is_available = available
         std_commit()
 
+    def update_status(self, status):
+        self.status = status
+        std_commit()
+
     @classmethod
-    def create_or_update_status(cls, dept_code, authorized_user_id, is_available=False):
-        existing_status = cls.query.filter_by(dept_code=dept_code, authorized_user_id=authorized_user_id).first()
-        if existing_status:
-            new_status = existing_status
-            new_status.is_available = is_available
+    def create_or_update_membership(cls, dept_code, authorized_user_id, is_available=False):
+        existing_membership = cls.query.filter_by(dept_code=dept_code, authorized_user_id=authorized_user_id).first()
+        if existing_membership:
+            new_membership = existing_membership
+            new_membership.is_available = is_available
         else:
-            new_status = cls(
+            new_membership = cls(
                 authorized_user_id=authorized_user_id,
                 dept_code=dept_code,
                 is_available=is_available,
             )
-        db.session.add(new_status)
+        db.session.add(new_membership)
         std_commit()
-        return new_status
+        return new_membership
 
     @classmethod
     def advisors_for_dept_code(cls, dept_code):
@@ -100,4 +105,5 @@ class DropInAdvisor(Base):
         return {
             'deptCode': self.dept_code,
             'available': self.is_available,
+            'status': self.status,
         }

--- a/scripts/db/migrate/2020/20200128-BOAC-3269/pre_deploy_01_add_drop_in_advisors_status.sql
+++ b/scripts/db/migrate/2020/20200128-BOAC-3269/pre_deploy_01_add_drop_in_advisors_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE drop_in_advisors ADD COLUMN status character varying(255);

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -275,6 +275,7 @@ CREATE TABLE drop_in_advisors (
     authorized_user_id INTEGER NOT NULL,
     dept_code character varying(255) NOT NULL,
     is_available BOOLEAN DEFAULT false NOT NULL,
+    status character varying(255),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -85,9 +85,9 @@ export function getDropInAdvisorsForDept(deptCode: string) {
 }
 
 export function setDropInAvailability(deptCode: string, uid: string, available: boolean) {
-  const action = available ? 'activate' : 'deactivate';
+  const availability = available ? 'available' : 'unavailable';
   return axios
-    .post(`${utils.apiBaseUrl()}/api/user/${uid}/drop_in_status/${deptCode}/${action}`)
+    .post(`${utils.apiBaseUrl()}/api/user/${uid}/drop_in_advising/${deptCode}/${availability}`)
     .then(response => {
       if (uid === Vue.prototype.$currentUser.uid) {
         store.commit('currentUserExtras/setDropInStatus', {

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -321,7 +321,7 @@ class TestRefreshDepartmentMemberships:
             is_director=False,
             is_scheduler=False,
         )
-        DropInAdvisor.create_or_update_status(dept_ucls.dept_code, bad_user.id)
+        DropInAdvisor.create_or_update_membership(dept_ucls.dept_code, bad_user.id)
         std_commit(allow_test_environment=True)
 
         ucls_drop_in_advisors = DropInAdvisor.advisors_for_dept_code(dept_ucls.dept_code)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3269

Adding a new status field required cleaning up some previous loose usage of the word "status."

The "isAvailable" boolean feed value represents not a "status" but an "availability."

The entire feed object corresponding to a row in the drop_in_advisors table is not a "status" but a "membership."