### PR TITLE
BOAC-3340, simpler cohort_filters.to_api_json uses get_all_filter_categories() to get keys and types

### DIFF
--- a/boac/merged/cohort_filter_options.py
+++ b/boac/merged/cohort_filter_options.py
@@ -66,7 +66,7 @@ class CohortFilterOptions:
         return list(filter(lambda g: len(g), available_categories))
 
     def get_all_filter_categories(self):
-        owner_user_id = AuthorizedUser.get_id_per_uid(self.owner_uid)
+        owner_user_id = AuthorizedUser.get_id_per_uid(self.owner_uid) if self.owner_uid else None
         return [
             [
                 _filter('colleges', 'College', options=colleges),
@@ -112,11 +112,11 @@ class CohortFilterOptions:
                     available_to=['COENG'],
                     validation='char',
                 ),
-                _filter('curatedGroupIds', 'My Curated Groups', options=lambda: curated_groups(owner_user_id)),
+                _filter('curatedGroupIds', 'My Curated Groups', options=lambda: curated_groups(owner_user_id) if owner_user_id else None),
                 _filter(
                     'cohortOwnerAcademicPlans',
                     'My Students',
-                    options=lambda: academic_plans_for_cohort_owner(self.owner_uid),
+                    options=lambda: academic_plans_for_cohort_owner(self.owner_uid) if self.owner_uid else None,
                 ),
                 _filter('coePrepStatuses', 'PREP', options=coe_prep_status_options, available_to=['COENG']),
                 _boolean_filter_coe('coeProbation', 'Probation'),

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -788,7 +788,7 @@ class TestCohortUpdate:
         assert updated_cohort['alertCount'] is not None
         assert updated_cohort['criteria']['majors'] == ['Engineering Undeclared UG']
         assert updated_cohort['criteria']['gpaRanges'] == [gpa_range]
-        assert updated_cohort['criteria']['groupCodes'] is None
+        assert updated_cohort['criteria'].get('groupCodes') is None
 
         def remove_empties(criteria):
             return {k: v for k, v in criteria.items() if v is not None}
@@ -983,7 +983,7 @@ class TestCohortPerFilters:
             'unitRanges',
             'visaTypes',
         ]:
-            assert criteria[key] is None
+            assert criteria.get(key) is None
 
     def test_my_students_filter_all_plans(self, client, coe_advisor_login):
         """Returns students mapped to advisor, across all academic plans."""


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3325
https://jira.ets.berkeley.edu/jira/browse/BOAC-3340

* using filter keys from `cohort_filter_options` guarantees consistency in `cohort.to_api_json`
* in `cohort_filter`, I broke off `to_base_json()` to reduce complexity in `to_api_json` (fewer lines of code)
* no more `_mock_ce3_students()`