### PR TITLE
BOAC-3432 Restore admit search checkbox

### DIFF
--- a/src/store/modules/current-user-extras.ts
+++ b/src/store/modules/current-user-extras.ts
@@ -4,6 +4,7 @@ import { getMyCohorts } from "@/api/cohort";
 import { getMyCuratedGroups } from "@/api/curated";
 
 const state = {
+  includeAdmits: false,
   myAdmitCohorts: undefined,
   myCohorts: undefined,
   myCuratedGroups: undefined,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3432

Seems like Vue can't track updates to this value unless it starts out in the store.