### PR TITLE
BOAC-3309: Includes SIS appointments in appointment search results

### DIFF
--- a/boac/api/appointments_controller.py
+++ b/boac/api/appointments_controller.py
@@ -28,6 +28,7 @@ from boac.api.util import advisor_required, authorized_users_api_feed, drop_in_a
 from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import localize_datetime, localized_timestamp_to_utc, process_input_from_rich_text_editor, utc_now
+from boac.merged.advising_appointment import get_appointment_advisors
 from boac.merged.student import get_distilled_student_profiles
 from boac.models.appointment import Appointment
 from boac.models.appointment_availability import AppointmentAvailability
@@ -294,15 +295,9 @@ def find_appointment_advisors_by_name():
     if not query:
         raise BadRequestError('Search query must be supplied')
     limit = request.args.get('limit')
-    query_fragments = filter(None, query.upper().split(' '))
-    advisors = Appointment.find_advisors_by_name(query_fragments, limit=limit)
-
-    def _advisor_feed(a):
-        return {
-            'label': a.advisor_name,
-            'uid': a.advisor_uid,
-        }
-    return tolerant_jsonify([_advisor_feed(a) for a in advisors])
+    query_fragments = list(filter(None, query.upper().split(' ')))
+    advisors = get_appointment_advisors(query_fragments, limit=limit)
+    return tolerant_jsonify(advisors)
 
 
 def _advisor_attrs_for_uid(advisor_uid):

--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -214,13 +214,10 @@ def add_attachment(note_id):
         note_id=note_id,
         attachment=attachments[0],
     )
-    note_json = note.to_api_json()
     return tolerant_jsonify(
-        note_to_compatible_json(
-            note=note_json,
+        _boa_note_to_compatible_json(
+            note=note,
             note_read=NoteRead.find_or_create(current_user.get_id(), note_id),
-            attachments=note_json.get('attachments'),
-            topics=note_json.get('topics'),
         ),
     )
 
@@ -237,13 +234,10 @@ def remove_attachment(note_id, attachment_id):
         note_id=note_id,
         attachment_id=int(attachment_id),
     )
-    note_json = note.to_api_json()
     return tolerant_jsonify(
-        note_to_compatible_json(
-            note=note_json,
+        _boa_note_to_compatible_json(
+            note=note,
             note_read=NoteRead.find_or_create(current_user.get_id(), note_id),
-            attachments=note_json.get('attachments'),
-            topics=note_json.get('topics'),
         ),
     )
 
@@ -331,13 +325,12 @@ def _get_author_profile():
 
 
 def _boa_note_to_compatible_json(note, note_read):
-    note_json = note.to_api_json()
     return {
         **note_to_compatible_json(
-            note=note_json,
+            note=note.__dict__,
             note_read=note_read,
-            attachments=note_json.get('attachments'),
-            topics=note_json.get('topics'),
+            attachments=[a.to_api_json() for a in note.attachments if not a.deleted_at],
+            topics=[t.to_api_json() for t in note.topics if not t.deleted_at],
         ),
         **{
             'message': note.body,

--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -32,12 +32,12 @@ from boac.externals.data_loch import get_enrolled_primary_sections, get_enrolled
 from boac.lib import util
 from boac.lib.http import tolerant_jsonify
 from boac.merged.admitted_student import search_for_admitted_students
+from boac.merged.advising_appointment import search_advising_appointments
 from boac.merged.advising_note import search_advising_notes
 from boac.merged.calnet import get_uid_for_csid
 from boac.merged.sis_terms import current_term_id
 from boac.merged.student import search_for_students
 from boac.models.alert import Alert
-from boac.models.appointment import Appointment
 from boac.models.authorized_user import AuthorizedUser
 from flask import current_app as app, request
 from flask_login import current_user, login_required
@@ -150,7 +150,7 @@ def _appointments_search(search_phrase, params):
     if datetime_from and datetime_to and datetime_to <= datetime_from:
         raise BadRequestError('dateFrom must be less than dateTo')
 
-    appointment_results = Appointment.search(
+    appointment_results = search_advising_appointments(
         search_phrase=search_phrase,
         advisor_uid=advisor_uid,
         student_csid=student_csid,

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -40,6 +40,8 @@ from titlecase import titlecase
 
 """Generic utilities."""
 
+TEXT_SEARCH_PATTERN = r'(\w*[.:/-@]\w+([.:/-]\w+)*)|[^\s?!(),;:.`]+'
+
 
 def camelize(string):
     def lower_then_capitalize():

--- a/boac/merged/advising_appointment.py
+++ b/boac/merged/advising_appointment.py
@@ -1,0 +1,167 @@
+"""
+Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+import re
+
+from boac.externals import data_loch
+from boac.lib.berkeley import resolve_sis_created_at, resolve_sis_updated_at
+from boac.lib.util import get_benchmarker, join_if_present, search_result_text_snippet, TEXT_SEARCH_PATTERN
+from boac.merged.calnet import get_calnet_users_for_csids, get_uid_for_csid
+from boac.models.appointment import Appointment
+from dateutil.tz import tzutc
+from flask import current_app as app
+
+
+"""Provide advising appointment data from local and external sources."""
+
+
+def search_advising_appointments(
+    search_phrase,
+    advisor_csid=None,
+    advisor_uid=None,
+    student_csid=None,
+    topic=None,
+    datetime_from=None,
+    datetime_to=None,
+    offset=0,
+    limit=20,
+):
+    benchmark = get_benchmarker('search_advising_appointments')
+    benchmark('begin')
+
+    if search_phrase:
+        search_terms = [t.group(0) for t in list(re.finditer(TEXT_SEARCH_PATTERN, search_phrase)) if t]
+        search_phrase = ' & '.join(search_terms)
+    else:
+        search_terms = []
+
+    advisor_uid = get_uid_for_csid(app, advisor_csid) if (not advisor_uid and advisor_csid) else advisor_uid
+
+    benchmark('begin local appointments query')
+    appointments_feed = Appointment.search(
+        search_phrase=search_phrase,
+        advisor_uid=advisor_uid,
+        student_csid=student_csid,
+        topic=topic,
+        datetime_from=datetime_from,
+        datetime_to=datetime_to,
+        limit=limit,
+        offset=offset,
+    )
+    benchmark('end local appointments query')
+
+    local_appointments_count = len(appointments_feed)
+    if local_appointments_count == limit:
+        return appointments_feed
+
+    benchmark('begin loch appointments query')
+    loch_results = data_loch.search_advising_appointments(
+        search_phrase=search_phrase,
+        advisor_uid=advisor_uid,
+        advisor_csid=advisor_csid,
+        student_csid=student_csid,
+        topic=topic,
+        datetime_from=datetime_from,
+        datetime_to=datetime_to,
+        offset=max(0, offset - local_appointments_count),
+        limit=(limit - local_appointments_count),
+    )
+    benchmark('end loch appointments query')
+
+    benchmark('begin loch appointments parsing')
+    appointments_feed += _get_loch_appointments_search_results(loch_results, search_terms)
+    benchmark('end loch appointments parsing')
+
+    return appointments_feed
+
+
+def get_appointment_advisors(query_fragments, limit=None):
+    appointment_advisors = Appointment.find_advisors_by_name(query_fragments, limit=limit)
+    legacy_appointment_advisors = data_loch.match_appointment_advisors_by_name(query_fragments, limit=limit)
+    advisors_feed = _local_advisor_feed(appointment_advisors) + _loch_advisor_feed(legacy_appointment_advisors)
+    advisors_by_uid = {a.get('uid'): a for a in advisors_feed}
+    return list(advisors_by_uid.values())
+
+
+def _get_loch_appointments_search_results(loch_results, search_terms):
+    results = []
+    calnet_advisor_feeds = get_calnet_users_for_csids(
+        app,
+        list(set([row.get('advisor_sid') for row in loch_results if row.get('advisor_sid') is not None])),
+    )
+    for appointment in loch_results:
+        advisor_feed = calnet_advisor_feeds.get(appointment.get('advisor_sid'))
+        if advisor_feed:
+            advisor_name = advisor_feed.get('name') or join_if_present(' ', [advisor_feed.get('firstName'), advisor_feed.get('lastName')])
+        else:
+            advisor_name = None
+        details = (appointment.get('note_body') or '').strip() or join_if_present(
+            ', ',
+            [appointment.get('note_category'), appointment.get('note_subcategory')],
+        )
+        student_sid = appointment.get('sid')
+        results.append({
+            'id': appointment.get('id'),
+            'advisorName': advisor_name or join_if_present(' ', [appointment.get('advisor_first_name'), appointment.get('advisor_last_name')]),
+            'advisorRole': advisor_feed.get('title'),
+            'advisorUid': advisor_feed.get('uid'),
+            'advisorDeptCodes': [dept['code'] for dept in advisor_feed.get('departments')],
+            'createdAt': resolve_sis_created_at(appointment),
+            'details': details,
+            'detailsSnippet': search_result_text_snippet(details, search_terms, TEXT_SEARCH_PATTERN),
+            'studentSid': student_sid,
+            'updatedAt': resolve_sis_updated_at(appointment),
+            'student': {
+                'uid': appointment.get('uid'),
+                'firstName': appointment.get('first_name'),
+                'lastName': appointment.get('last_name'),
+                'sid': student_sid,
+            },
+        })
+    return results
+
+
+def _isoformat(obj, key):
+    value = obj.get(key)
+    return value and value.astimezone(tzutc()).isoformat()
+
+
+def _local_advisor_feed(local_results):
+    return [
+        {
+            'label': a.get('advisor_name'),
+            'uid': a.get('advisor_uid'),
+        } for a in local_results
+    ]
+
+
+def _loch_advisor_feed(loch_results):
+    return [
+        {
+            'label': f"{a.get('first_name')} {a.get('last_name')}",
+            'uid': a.get('uid'),
+        } for a in loch_results
+    ]

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -105,6 +105,8 @@ _test_users = [
         'isAdmin': False,
         'inDemoMode': False,
         'canAccessCanvasData': True,
+        'firstName': 'Milicent',
+        'lastName': 'Balthazar',
     },
     {
         'uid': '19735',
@@ -147,6 +149,8 @@ _test_users = [
         'isAdmin': False,
         'inDemoMode': False,
         'canAccessCanvasData': True,
+        'firstName': 'Joni',
+        'lastName': 'Mitchell',
     },
     {
         'uid': '211159',
@@ -204,8 +208,8 @@ _test_users = [
     {
         'uid': '90412',
         'csid': '100100100',
-        'first_name': 'COE Add',
-        'last_name': 'Visor',
+        'firstName': 'COE Add',
+        'lastName': 'Visor',
         'isAdmin': False,
         'inDemoMode': False,
         'canAccessCanvasData': True,
@@ -430,8 +434,8 @@ def _create_users():
         uid = test_user['uid']
         # Mock CSIDs and names are random unless we need them to correspond to test data elsewhere.
         csid = test_user['csid'] or datetime.now().strftime('%H%M%S%f')
-        first_name = test_user.get('first_name', ''.join(random.choices(string.ascii_uppercase, k=6)))
-        last_name = test_user.get('last_name', ''.join(random.choices(string.ascii_uppercase, k=6)))
+        first_name = test_user.get('firstName', ''.join(random.choices(string.ascii_uppercase, k=6)))
+        last_name = test_user.get('lastName', ''.join(random.choices(string.ascii_uppercase, k=6)))
 
         # Put mock CalNet data in our json_cache for all users EXCEPT the test "no_calnet_record" user.
         if uid != no_calnet_record_for_uid:

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -309,8 +309,8 @@ class Note(Base):
             cls.refresh_search_index()
 
     def to_api_json(self):
-        attachments = [a.to_api_json() for a in self.attachments if not a.deleted_at]
-        topics = [t.to_api_json() for t in self.topics if not t.deleted_at]
+        attachments = self.attachments_to_api_json()
+        topics = self.topics_to_api_json()
         return {
             'id': self.id,
             'attachments': attachments,
@@ -325,6 +325,12 @@ class Note(Base):
             'createdAt': self.created_at,
             'updatedAt': self.updated_at,
         }
+
+    def attachments_to_api_json(self):
+        return [a.to_api_json() for a in self.attachments if not a.deleted_at]
+
+    def topics_to_api_json(self):
+        return [t.to_api_json() for t in self.topics if not t.deleted_at]
 
 
 def _create_notes(author_id, author_uid, author_name, author_role, author_dept_codes, body, sids, subject):

--- a/fixtures/calnet_search_entries.json
+++ b/fixtures/calnet_search_entries.json
@@ -366,6 +366,8 @@
             "attributes": {
                 "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
                 "berkeleyEduCSID": "100200300",
+                "departmentNumber": "UWASC",
+                "displayName": "Loramps Glub",
                 "objectClass": [
                     "top",
                     "eduPerson",
@@ -381,6 +383,9 @@
             "dn": "uid=1081940,ou=people,dc=berkeley,dc=edu",
             "raw": {
                 "berkeleyEduAffiliations": [ "EMPLOYEE-TYPE-STAFF" ],
+                "berkeleyEduCSID": [ "100200300" ],
+                "departmentNumber": [ "UWASC" ],
+                "displayName": [ "Loramps Glub" ],
                 "objectClass": [
                     "top",
                     "eduPerson",

--- a/fixtures/loch.sql
+++ b/fixtures/loch.sql
@@ -248,6 +248,36 @@ CREATE TABLE boac_analytics.section_mean_gpas
     avg_gpa DOUBLE PRECISION NOT NULL
 );
 
+CREATE TABLE sis_advising_notes.advising_appointments
+(
+    id VARCHAR NOT NULL,
+    sid VARCHAR NOT NULL,
+    student_note_nr VARCHAR NOT NULL,
+    advisor_sid VARCHAR,
+    appointment_id VARCHAR,
+    note_category VARCHAR NOT NULL,
+    note_subcategory VARCHAR,
+    note_body VARCHAR NOT NULL,
+    created_by VARCHAR,
+    updated_by VARCHAR,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE TABLE sis_advising_notes.advising_appointment_advisor_names
+(
+    uid VARCHAR NOT NULL,
+    name VARCHAR NOT NULL
+);
+
+CREATE TABLE sis_advising_notes.advising_appointment_advisors
+(
+    uid VARCHAR NOT NULL,
+    sid VARCHAR NOT NULL,
+    first_name VARCHAR NOT NULL,
+    last_name VARCHAR NOT NULL
+);
+
 CREATE TABLE sis_advising_notes.advising_notes
 (
     id VARCHAR NOT NULL,
@@ -595,14 +625,51 @@ VALUES
 ('2178','90200','2175',3.055),
 ('2178','90200','2172',3.23);
 
+INSERT INTO sis_advising_notes.advising_appointments
+(id, sid, student_note_nr, advisor_sid, appointment_id, note_category, note_subcategory, note_body, created_by, updated_by, created_at, updated_at)
+VALUES
+('11667051-00010', '11667051', '00010', '53791', '000000123', 'Appointment Type', 'Document', 'To my people who keep an impressive wingspan even when the cubicle shrink: you got to pull up the intruder by the root of the weed; N.Y. Chew through the machine', NULL, NULL, '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00'),
+('11667051-00011', '11667051', '00011', '700600500', NULL, 'Appointment Type', '', '', NULL, NULL, '2017-11-01T12:00:00+00', '2017-11-01T12:00:00+00'),
+('11667051-00012', '11667051', '00012', '100200300', NULL, 'Appointment Type', 'Entry w/o Contact', 'When soldering a perfect union it is vital to calculate any ornery loose ends so if mutiny ensues the aloof is assumed nuisance. The clue is in his vacancy, the proof is in his goosebumps.', NULL, NULL, '2017-11-05T12:00:00+00', '2017-11-06T12:00:00+00'),
+('9100000000-00010', '9100000000', '00010', '100200300', NULL, 'Appointment Type', '', 'Art imitates life.', 'UCBCONVERSION', NULL, '2017-11-02T12:00:00+00', '2017-11-02T12:00:00+00');
+
+CREATE MATERIALIZED VIEW sis_advising_notes.advising_appointments_search_index AS (
+  SELECT id, to_tsvector(
+    'english',
+    CASE
+      WHEN note_body IS NOT NULL and TRIM(note_body) != '' THEN note_body
+      WHEN note_subcategory IS NOT NULL THEN note_category || ' ' || note_subcategory
+      ELSE note_category
+    END
+  ) AS fts_index
+  FROM sis_advising_notes.advising_appointments
+);
+
+INSERT INTO sis_advising_notes.advising_appointment_advisor_names
+(uid, name)
+VALUES
+('1081940', 'LORAMPS'),
+('1081940', 'GLUB'),
+('1133398', 'CHARLIE'),
+('1133398', 'CHRISTIAN'),
+('53791', 'MILICENT'),
+('53791', 'BALTHAZAR');
+
+INSERT INTO sis_advising_notes.advising_appointment_advisors
+(uid, sid, first_name, last_name)
+VALUES
+('1081940', '100200300', 'Loramps', 'Glub'),
+('1133398', '700600500', 'Charlie', 'Christian'),
+('53791', '53791', 'Milicent', 'Balthazar');
+
 INSERT INTO sis_advising_notes.advising_notes
 (id, sid, student_note_nr, advisor_sid, appointment_id, note_category, note_subcategory, note_body, created_by, updated_by, created_at, updated_at)
 VALUES
 ('11667051-00001', '11667051', '00001', '800700600', NULL, 'Quick Question', 'Hangouts', 'Brigitte is making athletic and moral progress', NULL, NULL, '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00'),
 ('11667051-00002', '11667051', '00002', '700600500', NULL, 'Evaluation', '', 'Brigitte demonstrates a cavalier attitude toward university requirements', NULL, NULL, '2017-11-01T12:00:00+00', '2017-11-01T12:00:00+00'),
-('11667051-00003', '11667051', '00003', '600500400', NULL, 'Appointment', '', 'But the iniquity of oblivion blindely scattereth her poppy, and deals with the memory of men without distinction to merit of perpetuity. Who can but pity the founder of the Pyramids? Herostratus lives that burnt the Temple of Diana, he is almost lost that built it; Time hath spared the Epitaph of Adrians horse, confounded that of himself. In vain we compute our felicities by the advantage of our good names, since bad have equall durations; and Thersites is like to live as long as Agamenon, without the favour of the everlasting Register: Who knows whether the best of men be known? or whether there be not more remarkable persons forgot, then any that stand remembred in the known account of time? the first man had been as unknown as the last, and Methuselahs long life had been his only Chronicle.', NULL, NULL, '2017-11-05T12:00:00+00', '2017-11-06T12:00:00+00'),
+('11667051-00003', '11667051', '00003', '600500400', NULL, 'Student Request', '', 'But the iniquity of oblivion blindely scattereth her poppy, and deals with the memory of men without distinction to merit of perpetuity. Who can but pity the founder of the Pyramids? Herostratus lives that burnt the Temple of Diana, he is almost lost that built it; Time hath spared the Epitaph of Adrians horse, confounded that of himself. In vain we compute our felicities by the advantage of our good names, since bad have equall durations; and Thersites is like to live as long as Agamenon, without the favour of the everlasting Register: Who knows whether the best of men be known? or whether there be not more remarkable persons forgot, then any that stand remembred in the known account of time? the first man had been as unknown as the last, and Methuselahs long life had been his only Chronicle.', NULL, NULL, '2017-11-05T12:00:00+00', '2017-11-06T12:00:00+00'),
 ('11667051-00004', '11667051', '00004', '600500400', NULL, 'Quick Question', 'Unanswered', ' ', NULL, NULL, '2017-11-05T12:00:00+00', '2017-11-06T12:00:00+00'),
-('9000000000-00001', '9000000000', '00001', '600500400', NULL, 'Appointment', '', 'Is this student even on campus?', NULL, NULL, '2017-11-02T12:00:00+00', '2017-11-02T13:00:00+00'),
+('9000000000-00001', '9000000000', '00001', '600500400', NULL, 'Administrative', '', 'Is this student even on campus?', NULL, NULL, '2017-11-02T12:00:00+00', '2017-11-02T13:00:00+00'),
 ('9000000000-00002', '9000000000', '00002', '700600500', NULL, 'Evaluation', '', 'I am confounded by this confounding student', 'UCBCONVERSION', NULL, '2017-11-02T07:00:00+00', '2017-11-02T07:00:00+00'),
 ('9100000000-00001', '9100000000', '00001', '600500400', NULL, 'Evaluation', '', 'Met w/ stu; scheduled next appt. 2/1/2019 @ 1:30. Student continued on 2.0 prob (COP) until Sp ''19. E-mailed test@berkeley.edu: told her she''ll need to drop Eng. 123 by 1-24-19', 'UCBCONVERSION', NULL, '2017-11-02T12:00:00+00', '2017-11-02T12:00:00+00');
 

--- a/tests/test_api/test_search_controller.py
+++ b/tests/test_api/test_search_controller.py
@@ -547,16 +547,15 @@ class TestAppointmentSearch:
             assert appointment['student']['firstName']
             assert appointment['student']['lastName']
             assert appointment['studentSid']
-            assert appointment['status']
 
     def test_search_with_missing_input_no_options(self, coe_advisor, client):
         """Appointments search is nothing without input when no additional options are set."""
         _api_search(client, ' \t  ', appointments=True, expected_status_code=400)
 
     def test_search_appointments(self, coe_advisor, client):
-        """Search results include appointments ordered by rank."""
+        """Search results include both legacy and BOA-generated appointments."""
         api_json = _api_search(client, 'life', appointments=True)
-        self._assert(api_json, appointment_count=2)
+        self._assert(api_json, appointment_count=3)
 
     def test_search_by_appointment_cancel_reason(self, coe_advisor, client):
         """Appointments can be searched for by cancel reason and cancel reason explained."""
@@ -632,7 +631,7 @@ class TestAppointmentSearch:
             appointments=True,
             appointment_options={'dateFrom': '2017-11-01', 'dateTo': '2017-11-02'},
         )
-        self._assert(api_json, appointment_count=1)
+        self._assert(api_json, appointment_count=3)
 
     def test_search_excludes_appointments_unless_requested(self, coe_advisor, client):
         """Excludes appointments from search results if appointments param is false."""
@@ -697,7 +696,7 @@ class TestAppointmentSearch:
             appointments=True,
             appointment_options={'studentCsid': '11667051'},
         )
-        self._assert(api_json, appointment_count=2)
+        self._assert(api_json, appointment_count=5)
 
     def test_appointments_search_limit(self, coe_advisor, client):
         """Limits search to the first n appointments."""
@@ -717,7 +716,7 @@ class TestAppointmentSearch:
             appointments=True,
             appointment_options={'offset': '1'},
         )
-        self._assert(api_json, appointment_count=1)
+        self._assert(api_json, appointment_count=2)
 
     def test_search_appointments_no_canvas_data_access(self, client, no_canvas_access_advisor):
         """A user with no access to Canvas data can still search for appointments."""
@@ -727,7 +726,7 @@ class TestAppointmentSearch:
             appointments=True,
             appointment_options={'studentCsid': '11667051'},
         )
-        self._assert(api_json, appointment_count=2)
+        self._assert(api_json, appointment_count=5)
 
 
 class TestAdmittedStudentSearch:

--- a/tests/test_merged/test_advising_appointment.py
+++ b/tests/test_merged/test_advising_appointment.py
@@ -1,0 +1,102 @@
+"""
+Copyright ©2020. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+
+from boac.merged.advising_appointment import get_appointment_advisors, search_advising_appointments
+
+
+coe_advisor = '1133399'
+
+
+class TestMergedAdvisingAppointment:
+    """Advising appointment data, merged."""
+
+    def test_get_appointment_advisors(self, fake_auth):
+        """Returns a combined list of appointment advisors past and present."""
+        fake_auth.login(coe_advisor)
+        advisors = get_appointment_advisors(['CO'])
+        assert len(advisors) == 1
+
+        advisors = get_appointment_advisors(['C'])
+        assert len(advisors) == 3
+
+        advisors = get_appointment_advisors(['MI', 'BA'])
+        assert len(advisors) == 1
+
+    def test_search(self, fake_auth, app):
+        """Finds new and legacy appointments matching the criteria, ordered by rank."""
+        fake_auth.login(coe_advisor)
+        results = search_advising_appointments(search_phrase='life')
+        assert len(results) == 3
+        assert results[0]['advisorName'] == 'Milicent Balthazar'
+        assert results[0]['advisorRole'] == 'Advisor'
+        assert results[0]['advisorUid'] == '53791'
+        assert results[0]['advisorDeptCodes'] == ['QCADV', 'QCADVMAJ']
+        assert results[0]['deptCode'] == 'QCADV'
+        assert results[0]['details'] == 'It is not the length of life, but depth of life.'
+        assert results[0]['detailsSnippet'] == 'It is not the length of <strong>life</strong>, but depth of <strong>life</strong>.'
+        assert results[0]['cancelReason'] is None
+        assert results[0]['cancelReasonExplained'] is None
+        assert results[0]['status'] == 'checked_in'
+        assert results[0]['studentSid'] == '11667051'
+        assert results[0]['student']['uid'] == '61889'
+        assert results[0]['student']['firstName'] == 'Deborah'
+        assert results[0]['student']['lastName'] == 'Davies'
+        assert results[0]['createdAt']
+        assert results[0]['updatedAt']
+
+        assert results[1]['advisorName'] is None
+        assert results[1]['advisorRole'] is None
+        assert results[1]['advisorUid'] is None
+        assert results[1]['advisorDeptCodes'] is None
+        assert results[1]['deptCode'] == 'COENG'
+        assert results[1]['details'] == 'Life is what happens while you\'re making appointments.'
+        assert results[1]['detailsSnippet'] == '<strong>Life</strong> is what happens while you\'re making appointments.'
+        assert results[1]['cancelReason'] is None
+        assert results[1]['cancelReasonExplained'] is None
+        assert results[1]['status'] == 'waiting'
+        assert results[1]['studentSid'] == '5678901234'
+        assert results[1]['student']['uid'] == '9933311'
+        assert results[1]['student']['firstName'] == 'Sandeep'
+        assert results[1]['student']['lastName'] == 'Jayaprakash'
+        assert results[1]['createdAt']
+        assert results[1]['updatedAt']
+
+        assert results[2]['advisorName'] == 'Loramps Glub'
+        assert results[2]['advisorRole'] is None
+        assert results[2]['advisorUid'] == '1081940'
+        assert results[2]['advisorDeptCodes'] == ['UWASC']
+        assert 'deptCode' not in results[2]
+        assert results[2]['details'] == 'Art imitates life.'
+        assert results[2]['detailsSnippet'] == 'Art imitates <strong>life</strong>.'
+        assert 'cancelReason' not in results[2]
+        assert 'cancelReasonExplained' not in results[2]
+        assert 'status' not in results[2]
+        assert results[2]['studentSid'] == '9100000000'
+        assert results[2]['student']['uid'] == '300848'
+        assert results[2]['student']['firstName'] == 'Nora Stanton'
+        assert results[2]['student']['lastName'] == 'Barney'
+        assert results[2]['createdAt']
+        assert results[2]['updatedAt'] is None


### PR DESCRIPTION
- Updates search form Advisor autocomplete to include SIS appointment advisors
- Includes new SIS appointment tables in the search query
- Introduces `advising_appointment` merged model to represent both BOA and SIS appointments
- Resolves some technical debt in the notes code