### PR TITLE
Revert "BOAC-3527: Locks down @apollographql/apollo-tools version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "serve-vue": "vue-cli-service serve --open"
   },
   "dependencies": {
-    "@apollographql/apollo-tools": "0.4.2",
     "@babel/core": "7.6.4",
     "@babel/runtime": "7.6.3",
     "@ckeditor/ckeditor5-basic-styles": "11.1.1",


### PR DESCRIPTION
Reverts ets-berkeley-edu/boac#2479

https://jira.ets.berkeley.edu/jira/browse/BOAC-3527