### PR TITLE
BOAC-3521, force AWS CodeBuild failure to test Slack integration

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,7 @@ phases:
   build:
     commands:
       - npm install -g @vue/cli
-      - npm run build-vue
+      - npm run build-vue__FORCE-PIPELINE-FAILURE-TO-TEST-NOTIFICATIONS
 
   post_build:
     commands:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3521

In Jira above, Darlene asks, "Is there a way to trigger a build failure to see if the CodePipeline notification rule catches it?"

Yes there is...