### PR TITLE
NOJIRA, upgrade tox and flake8 to avoid weird lint-py errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pytz==2019.3
 # For testing
 
 moto==1.3.6
-pytest==5.3.5
-pytest-flask==0.15.1
-responses==0.10.9
-tox==3.15.0
+pytest==5.4.3
+pytest-flask==1.0.0
+responses==0.10.15
+tox==3.15.2

--- a/tox.ini
+++ b/tox.ini
@@ -27,14 +27,14 @@ commands = pytest {posargs: -p no:warnings tests}
 # Bottom of file has Flake8 settings
 commands = flake8 {posargs:boac config consoler.py scripts tests run.py}
 deps =
-    flake8>=3.8.0
-    flake8-builtins>=1.5.2
+    flake8>=3.8.3
+    flake8-builtins>=1.5.3
     flake8-colors>=0.1.6
     flake8-commas>=2.0.0
     flake8-docstrings>=1.5.0
     flake8-import-order>=0.18.1
     flake8-pytest>=1.3
-    flake8-quotes>=3.0.0
+    flake8-quotes>=3.2.0
     flake8-strict>=0.2.1
     flake8-tidy-imports>=4.1.0
     pep8-naming>=0.10.0


### PR DESCRIPTION
Travis failed on PR #2508 due to mysterious flake8 error. I'm bumping up related deps to avoid a repeat.  