### PR TITLE
BOAC-3621, recommend 'tox --parallel' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ export BOAC_LOCAL_CONFIGS=/Volumes/XYZ/boac_config
 
 We use [Tox](https://tox.readthedocs.io) for continuous integration. Under the hood, you'll find [PyTest](https://docs.pytest.org), [Flake8](http://flake8.pycqa.org) and [ESLint](https://eslint.org/). Please install NPM dependencies (see above) before running tests.
 ```
-# Run all tests and linters
-tox
+# Run all tests and linters with Tox's parallel mode:
+tox -p
 
 # Pytest
 tox -e test


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3621

A complete run of BOA tests and linters in parallel mode is ~60 seconds faster than standard Tox mode.

Use `tox -p` instead of `tox`.