### PR TITLE
BOAC-3626, better communication between create-note transaction and AcademicTimeline

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -36,9 +36,8 @@ from boac.api.util import (
 from boac.lib.berkeley import dept_codes_where_advising
 from boac.lib.http import tolerant_jsonify
 from boac.lib.sis_advising import get_legacy_attachment_stream
-from boac.lib.util import get as get_param, is_int, process_input_from_rich_text_editor
+from boac.lib.util import is_int, process_input_from_rich_text_editor
 from boac.merged.advising_note import (
-    get_batch_distinct_sids,
     get_boa_attachment_stream,
     get_zip_stream_for_sid,
     note_to_compatible_json,
@@ -113,22 +112,6 @@ def create_notes():
                 template_attachment_ids=template_attachment_ids,
             ),
         )
-
-
-@app.route('/api/notes/batch/distinct_student_count', methods=['POST'])
-@advising_data_access_required
-def distinct_student_count():
-    params = request.get_json()
-    sids = get_param(params, 'sids', None)
-    cohort_ids = get_param(params, 'cohortIds', None)
-    curated_group_ids = get_param(params, 'curatedGroupIds', None)
-    if cohort_ids or curated_group_ids:
-        count = len(get_batch_distinct_sids(sids, cohort_ids, curated_group_ids))
-    else:
-        count = len(sids)
-    return tolerant_jsonify({
-        'count': count,
-    })
 
 
 @app.route('/api/notes/update', methods=['POST'])

--- a/boac/api/student_controller.py
+++ b/boac/api/student_controller.py
@@ -27,7 +27,8 @@ from boac.api.errors import BadRequestError, ResourceNotFoundError
 from boac.api.util import advisor_required, put_notifications
 from boac.externals.data_loch import match_students_by_name_or_sid, query_historical_sids
 from boac.lib.http import tolerant_jsonify
-from boac.merged.student import get_student_and_terms_by_sid, get_student_and_terms_by_uid, query_students
+from boac.merged.student import get_distinct_sids, get_student_and_terms_by_sid, get_student_and_terms_by_uid, \
+    query_students
 from flask import current_app as app, request
 from flask_login import login_required
 
@@ -50,6 +51,19 @@ def get_student_by_uid(uid):
         raise ResourceNotFoundError('Unknown student')
     put_notifications(student)
     return tolerant_jsonify(student)
+
+
+@app.route('/api/students/distinct_sids', methods=['POST'])
+@login_required
+def distinct_student_count():
+    params = request.get_json()
+    sids = params.get('sids')
+    cohort_ids = params.get('cohortIds')
+    curated_group_ids = params.get('curatedGroupIds')
+    all_sids = get_distinct_sids(sids, cohort_ids, curated_group_ids) if cohort_ids or curated_group_ids else sids
+    return tolerant_jsonify({
+        'sids': list(all_sids),
+    })
 
 
 @app.route('/api/students/find_by_name_or_sid', methods=['GET'])

--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -3,12 +3,6 @@ import axios from 'axios';
 import utils from '@/api/api-utils';
 import Vue from 'vue';
 
-export function getDistinctStudentCount(sids: string[], cohortIds: number[], curatedGroupIds: number[]) {
-  return axios
-    .post(`${utils.apiBaseUrl()}/api/notes/batch/distinct_student_count`, {sids, cohortIds, curatedGroupIds})
-    .then(response => response.data, () => null);
-}
-
 export function getNote(noteId) {
   return axios
     .get(`${utils.apiBaseUrl()}/api/note/${noteId}`)

--- a/src/api/student.ts
+++ b/src/api/student.ts
@@ -7,6 +7,12 @@ export function dismissStudentAlert(alertId: string) {
     .then(response => response.data, () => null);
 }
 
+export function getDistinctSids(sids: string[], cohortIds: number[], curatedGroupIds: number[]) {
+  return axios
+    .post(`${utils.apiBaseUrl()}/api/students/distinct_sids`, {sids, cohortIds, curatedGroupIds})
+    .then(response => response.data, () => null);
+}
+
 export function getStudentByUid(uid: string) {
   return axios
     .get(`${utils.apiBaseUrl()}/api/student/by_uid/${uid}`)

--- a/src/components/note/create/BatchNoteFeatures.vue
+++ b/src/components/note/create/BatchNoteFeatures.vue
@@ -3,14 +3,14 @@
     <div>
       <span aria-live="polite" role="alert">
         <span
-          v-if="targetStudentCount"
+          v-if="completeSidSet.length"
           id="target-student-count-alert"
-          :class="{'has-error': targetStudentCount >= 250, 'font-weight-bolder': targetStudentCount >= 500}"
+          :class="{'has-error': completeSidSet.length >= 250, 'font-weight-bolder': completeSidSet.length >= 500}"
           class="font-italic">
-          Note will be added to {{ pluralize('student record', targetStudentCount) }}.
-          <span v-if="targetStudentCount >= 500">Are you sure?</span>
+          Note will be added to {{ pluralize('student record', completeSidSet.length) }}.
+          <span v-if="completeSidSet.length >= 500">Are you sure?</span>
         </span>
-        <span v-if="!targetStudentCount && (addedCohorts.length || addedCuratedGroups.length)" class="font-italic">
+        <span v-if="!completeSidSet.length && (addedCohorts.length || addedCuratedGroups.length)" class="font-italic">
           <span
             v-if="addedCohorts.length && !addedCuratedGroups.length"
             id="no-students-per-cohorts-alert">There are no students in the {{ pluralize('cohort', addedCohorts.length, {1: ' '}) }}.</span>

--- a/src/components/note/create/CreateNoteFooter.vue
+++ b/src/components/note/create/CreateNoteFooter.vue
@@ -24,7 +24,7 @@
     <div v-if="mode !== 'editTemplate'">
       <b-btn
         id="create-note-button"
-        :disabled="isSaving || !targetStudentCount || !trim(model.subject)"
+        :disabled="isSaving || !completeSidSet.length || !trim(model.subject)"
         class="btn-primary-color-override"
         aria-label="Create note"
         variant="primary"

--- a/src/components/note/create/CreateNoteModal.vue
+++ b/src/components/note/create/CreateNoteModal.vue
@@ -144,7 +144,7 @@ import NoteEditSession from '@/mixins/NoteEditSession';
 import RichTextEditor from '@/components/util/RichTextEditor';
 import store from "@/store";
 import Util from '@/mixins/Util';
-import Vue from "vue"
+import Vue from "vue";
 import { createNoteTemplate, updateNoteTemplate } from '@/api/note-templates';
 
 export default {
@@ -227,9 +227,8 @@ export default {
       this.putFocusNextTick('create-note-subject');
     },
     createNote() {
-      if (this.model.subject && this.targetStudentCount) {
+      if (this.model.subject && this.completeSidSet.length) {
         this.setIsSaving(true);
-        this.onCreateNoteStart(this.model.subject);
         if (this.model.attachments.length) {
           // File upload might take time; alert will be overwritten when API call is done.
           this.showAlert('Creating note...', 60);
@@ -238,16 +237,11 @@ export default {
         this.createAdvisingNotes().then(data => {
           this.setIsSaving(false);
           this.exit();
-          // After modal is closed...
-          this.onCreateNoteSuccess();
-          this.alertScreenReader(this.isBatchFeature ? `Note created for ${this.targetStudentCount} students.` : "New note saved.");
-          const uid = this.$currentUser.uid;
+          this.alertScreenReader(this.isBatchFeature ? `Note created for ${this.completeSidSet.length} students.` : "New note saved.");
           if (this.isBatchFeature) {
-            Vue.prototype.$eventHub.$emit('batch-of-notes-created', data);
-            Vue.prototype.$ga.noteEvent(data.id, `Advisor ${uid} created a batch of notes`, 'batch_create');
+            Vue.prototype.$ga.noteEvent(data.id, `Advisor ${this.$currentUser.uid} created a batch of notes`, 'batch_create');
           } else {
-            Vue.prototype.$eventHub.$emit('advising-note-created', data);
-            Vue.prototype.$ga.noteEvent(data.id, `Advisor ${uid} created a note`, 'create');
+            Vue.prototype.$ga.noteEvent(data.id, `Advisor ${this.$currentUser.uid} created a note`, 'create');
           }
         });
       }

--- a/src/mixins/NoteEditSession.vue
+++ b/src/mixins/NoteEditSession.vue
@@ -9,14 +9,13 @@ export default {
     ...mapGetters('noteEditSession', [
       'addedCohorts',
       'addedCuratedGroups',
+      'completeSidSet',
       'isFocusLockDisabled',
-      'creatingNoteWithSubject',
       'isSaving',
       'mode',
       'model',
       'noteTemplates',
-      'sids',
-      'targetStudentCount'
+      'sids'
     ])
   },
   methods: {
@@ -28,8 +27,6 @@ export default {
       'addTopic',
       'createAdvisingNotes',
       'exitSession',
-      'onCreateNoteStart',
-      'onCreateNoteSuccess',
       'removeAttachment',
       'removeCohort',
       'removeCuratedGroup',


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3626

`/api/notes/batch/distinct_student_count` is now `/api/students/distinct_sids` because (1) there's nothing note specific about it, and (2) speeds up client-side by having complete-sids-set instead of just a count.