### PR TITLE
BOAC-3637, account for undefined $refs.users during Passenger Manifest page load

### DIFF
--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -12,7 +12,7 @@
               {text: 'Search', value: 'search'},
               {text: 'Filter', value: 'filter'}
             ]"
-            @change="$refs.users.refresh"></b-form-select>
+            @change="refreshUsers"></b-form-select>
         </b-col>
         <b-col v-if="filterType === 'search'" cols="10">
           <Autocomplete
@@ -36,7 +36,7 @@
                 value-field="code"
                 text-field="name"
                 aria-label="Use up and down arrows to review departments. Hit enter to select a department."
-                @change="$refs.users.refresh">
+                @change="refreshUsers">
                 <template v-slot:first>
                   <option :value="null">All</option>
                 </template>
@@ -56,7 +56,7 @@
                   {text: 'Drop-In Advisors', value: 'dropInAdvisor'},
                   {text: 'Schedulers', value: 'scheduler'}
                 ]"
-                @change="$refs.users.refresh"></b-form-select>
+                @change="refreshUsers"></b-form-select>
             </div>
             <div class="pr-2">
               <b-form-select
@@ -69,7 +69,7 @@
                   {text: 'Deleted', value: 'deleted'},
                   {text: 'Blocked', value: 'blocked'}
                 ]"
-                @change="$refs.users.refresh"></b-form-select>
+                @change="refreshUsers"></b-form-select>
             </div>
           </div>
         </b-col>
@@ -282,7 +282,6 @@ export default {
       type: Array
     },
     refresh: {
-      default: false,
       required: false,
       type: Boolean
     }
@@ -305,12 +304,12 @@ export default {
   watch: {
     refresh(value) {
       if (value) {
-        this.$refs.users.refresh();
+        this.refreshUsers();
       }
     },
     userSelection(u) {
       if (u) {
-        this.$refs.users.refresh();
+        this.refreshUsers();
       }
     }
   },
@@ -320,7 +319,7 @@ export default {
       if (this.filterType === 'search') {
         this.userSelection = profile;
       }
-      this.$refs.users.refresh();
+      this.refreshUsers();
     },
     autocompleteUsers(q) {
       return userAutocomplete(q).then(results => this.orderBy(results, 'label'));
@@ -355,7 +354,12 @@ export default {
         searchPhrase: '',
         status: 'active'
       };
-      this.$refs.users.refresh();
+      this.refreshUsers();
+    },
+    refreshUsers() {
+      if (this.$refs.users) {
+        this.$refs.users.refresh();
+      }
     },
     usersProvider() {
       this.totalUserCount = undefined;

--- a/src/views/DropInDesk.vue
+++ b/src/views/DropInDesk.vue
@@ -7,7 +7,7 @@
         variant="primary"
         class="btn-primary-color-override mr-2 pl-3 pr-3"
         aria-label="Create appointment. Modal window will open."
-        @click="$refs.dropInWaitlist.openCreateAppointmentModal">
+        @click="openCreateAppointmentModal">
         New Drop-in Appointment
       </b-btn>
       <b-btn
@@ -15,7 +15,7 @@
         variant="outline-primary"
         class="btn-primary-color-override btn-primary-color-outline-override ml-2 pl-3 pr-3"
         aria-label="Log resolved issue. Modal window will open."
-        @click="$refs.dropInWaitlist.openLogResolvedIssueModal">
+        @click="openLogResolvedIssueModal">
         Log Resolved Issue
       </b-btn>
     </div>
@@ -106,6 +106,16 @@ export default {
     onAppointmentStatusChange() {
       // We return a Promise.
       return this.loadDropInWaitlist(false);
+    },
+    openCreateAppointmentModal() {
+      if (this.$refs.dropInWaitlist) {
+        this.$refs.dropInWaitlist.openCreateAppointmentModal();
+      }
+    },
+    openLogResolvedIssueModal() {
+      if (this.$refs.dropInWaitlist) {
+        this.$refs.dropInWaitlist.openLogResolvedIssueModal();
+      }
     },
     scheduleRefreshJob() {
       // Clear previous job, if pending. The following is null-safe.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3637

I recently removed parens from `@change="$refs.users.refresh()"` per best practice.  Without parens, Vue immediately loads the pointer `$refs.users.refresh`, which bombs if `$refs.users` is not yet initialized.