### PR TITLE
BOAC-3635, upgrade bootstrap-vue from to 2.4.0 to 2.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6982,17 +6982,17 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
-      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.2.tgz",
+      "integrity": "sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A=="
     },
     "bootstrap-vue": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.4.0.tgz",
-      "integrity": "sha512-mRhqlhJscUY4O+R2X4IRVZReWPj/2KBOTzsB6sPgLcp6s/VHf1L6VS5Etw6HREFPAu8U6Czh+jJAq/KPH/zUdA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.16.0.tgz",
+      "integrity": "sha512-gLETwPmeRHCe5WHmhGxzb5PtTEuKqQPGl0TFvZ2Odbkg/7UuIHdqIexrJRerpnomP4ZzDQ+qYGL91Ls9lcQsJQ==",
       "requires": {
         "@nuxt/opencollective": "^0.3.0",
-        "bootstrap": ">=4.4.1 <5.0.0",
+        "bootstrap": ">=4.5.0 <5.0.0",
         "popper.js": "^1.16.1",
         "portal-vue": "^2.1.7",
         "vue-functional-data-merge": "^3.1.0"
@@ -8548,9 +8548,9 @@
       "dev": true
     },
     "consola": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.11.3.tgz",
-      "integrity": "sha512-aoW0YIIAmeftGR8GSpw6CGQluNdkWMWh3yEFjH/hmynTYnMtibXszii3lxCXmk8YxJtI3FAK5aTiquA5VH68Gw=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+      "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
     },
     "console-browserify": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/vue-fontawesome": "0.1.9",
     "acorn": "^7.2.0",
     "axios": "0.19.2",
-    "bootstrap-vue": "2.4.0",
+    "bootstrap-vue": "2.16.0",
     "d3": "5.9.7",
     "highcharts": "6.2.0",
     "js-file-download": "0.4.9",


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3635

https://bootstrap-vue.org/docs/reference/changelog
