### PR TITLE
BOAC-3638, fix b-table sort icon after bootstrap upgrade

### DIFF
--- a/src/assets/styles/bootstrap-overrides.css
+++ b/src/assets/styles/bootstrap-overrides.css
@@ -35,6 +35,34 @@ legend {
   min-width: 160px !important;
   width: 160px !important;
 }
+.b-table th[aria-sort] div::after {
+  display: inline !important;
+  font-family: "Font Awesome 5 Free";
+  padding-left: 8px !important;
+  position: inherit !important;
+}
+.b-table th::before {
+  content: '' !important;
+}
+.table.b-table>tfoot>tr>[aria-sort=none],
+.table.b-table>thead>tr>[aria-sort=none],
+.table.b-table>tfoot>tr>[aria-sort=ascending],
+.table.b-table>thead>tr>[aria-sort=ascending],
+.table.b-table>tfoot>tr>[aria-sort=descending],
+.table.b-table>thead>tr>[aria-sort=descending]
+{
+  background-image: none !important;
+}
+.b-table th[aria-sort="none"] div::after {
+  color: transparent;
+  content: '\25b2' !important;
+}
+.b-table th[aria-sort="ascending"] div::after {
+  content: "\25b2" !important;
+}
+.b-table th[aria-sort="descending"] div::after {
+  content: "\25bc" !important;
+}
 .btn-primary-color-override {
   background-color: #337ab7 !important;
   border-color: #2e6da4 !important;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3638

Restore fragment removed in [PR 2565](https://github.com/ets-berkeley-edu/boac/pull/2565/files#diff-877d6aefac3ef44a76822e86b083ab39) and tweak the CSS, adding `div::after`.