### PR TITLE
BOAC-3630, academic_standing alerts: use action_date for created_at and preserve

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -372,7 +372,7 @@ def extract_valid_sids(sids):
 
 
 def get_academic_standing(sids):
-    sql = f"""SELECT sid, term_id, acad_standing_status as status
+    sql = f"""SELECT acad_standing_status as status, action_date, sid, term_id
         FROM {student_schema()}.academic_standing
         WHERE sid = ANY(:sids)
         ORDER BY sid, term_id DESC"""

--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -307,8 +307,16 @@ def summarize_profile(profile, enrollments=None, academic_standing=None, term_gp
         profile['termGpa'] = term_gpas.get(profile['sid'])
 
 
-def _academic_standing_to_feed(standing):
-    return [{'termId': str(r['term_id']), 'termName': term_name_for_sis_id(r['term_id']), 'status': r['status']} for r in standing]
+def _academic_standing_to_feed(rows):
+    def _row_to_json(row):
+        return {
+            'actionDate': row['action_date'],
+            'sid': row['sid'],
+            'status': row['status'],
+            'termId': str(row['term_id']),
+            'termName': term_name_for_sis_id(row['term_id']),
+        }
+    return [_row_to_json(row) for row in rows]
 
 
 def get_academic_standing_by_sid(sids, as_dicts=False):

--- a/tests/test_api/test_alerts_controller.py
+++ b/tests/test_api/test_alerts_controller.py
@@ -89,13 +89,13 @@ class TestAlertsController:
         fake_auth.login(admin_uid)
         advisor_1_alerts = self._get_alerts(client, 61889)
         assert len(advisor_1_alerts) == 3
-        assert advisor_1_alerts[0]['key'] == '2178_500600700'
+        assert next((a for a in advisor_1_alerts if a['key'] == '2178_500600700'), None)
         assert len(self._get_dismissed(advisor_1_alerts)) == 0
 
         fake_auth.login(coe_advisor)
         advisor_2_alerts = self._get_alerts(client, 61889)
         assert len(advisor_2_alerts) == 3
-        assert advisor_2_alerts[0]['key'] == '2178_500600700'
+        assert next((a for a in advisor_2_alerts if a['key'] == '2178_500600700'), None)
         assert len(self._get_dismissed(advisor_1_alerts)) == 0
 
     def test_alert_dismissal_updates_cohort_alert_counts(self, db, create_alerts, fake_auth, client):

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -314,8 +314,20 @@ class TestCohortById:
         assert response.status_code == 200
         deborah = next(m for m in response.json['students'] if m['firstName'] == 'Deborah')
         assert len(deborah['academicStanding']) == 5
-        assert deborah['academicStanding'][0] == {'termId': '2182', 'termName': 'Spring 2018', 'status': 'GST'}
-        assert deborah['academicStanding'][1] == {'termId': '2178', 'termName': 'Fall 2017', 'status': 'PRO'}
+        assert deborah['academicStanding'][0] == {
+            'actionDate': '2018-05-31',
+            'sid': '11667051',
+            'status': 'GST',
+            'termId': '2182',
+            'termName': 'Spring 2018',
+        }
+        assert deborah['academicStanding'][1] == {
+            'actionDate': '2017-12-30',
+            'sid': '11667051',
+            'status': 'PRO',
+            'termId': '2178',
+            'termName': 'Fall 2017',
+        }
 
     def test_includes_cohort_member_athletics_asc(self, asc_advisor_login, asc_owned_cohort, client):
         """Includes athletic data custom cohort members for ASC advisors."""

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -145,8 +145,20 @@ class TestGetCuratedGroup:
         students = api_json['students']
         deborah = next(s for s in students if s['firstName'] == 'Deborah')
         assert len(deborah['academicStanding']) == 5
-        assert deborah['academicStanding'][0] == {'termId': '2182', 'termName': 'Spring 2018', 'status': 'GST'}
-        assert deborah['academicStanding'][1] == {'termId': '2178', 'termName': 'Fall 2017', 'status': 'PRO'}
+        assert deborah['academicStanding'][0] == {
+            'actionDate': '2018-05-31',
+            'sid': '11667051',
+            'status': 'GST',
+            'termId': '2182',
+            'termName': 'Spring 2018',
+        }
+        assert deborah['academicStanding'][1] == {
+            'actionDate': '2017-12-30',
+            'termId': '2178',
+            'termName': 'Fall 2017',
+            'sid': '11667051',
+            'status': 'PRO',
+        }
 
     def test_view_permitted_shared_dept(self, asc_curated_groups, asc_and_coe_advisor, client):
         """Advisor can view group if they share the group owner's department memberships."""

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -196,8 +196,20 @@ class TestStudent:
         student_by_uid = self._api_student_by_uid(client=client, uid=uid)
         for student in [student_by_sid, student_by_uid]:
             assert len(student['academicStanding']) == 5
-            assert student['academicStanding'][0] == {'termId': '2182', 'termName': 'Spring 2018', 'status': 'GST'}
-            assert student['academicStanding'][1] == {'termId': '2178', 'termName': 'Fall 2017', 'status': 'PRO'}
+            assert student['academicStanding'][0] == {
+                'actionDate': '2018-05-31',
+                'sid': '11667051',
+                'status': 'GST',
+                'termId': '2182',
+                'termName': 'Spring 2018',
+            }
+            assert student['academicStanding'][1] == {
+                'actionDate': '2017-12-30',
+                'termId': '2178',
+                'termName': 'Fall 2017',
+                'sid': '11667051',
+                'status': 'PRO',
+            }
 
     def test_user_feed_earliest_term_cutoff(self, client, coe_advisor_login):
         """Ignores terms before the configured earliest term."""
@@ -682,24 +694,24 @@ class TestAlerts:
         fake_auth.login(self.admin_uid)
         alerts = self._get_alerts(client, 61889)
         assert len(alerts) == 4
-        assert alerts[0]['alertType'] == 'late_assignment'
-        assert alerts[0]['key'] == '2178_800900300'
-        assert alerts[0]['message'] == 'Week 5 homework in RUSSIAN 13 is late.'
+        assert alerts[0]['alertType'] == 'academic_standing'
+        assert alerts[0]['key'] == '2178_2017-12-30_academic_standing_PRO'
+        assert alerts[0]['message'] == "Student's academic standing is 'Probation'."
         assert not alerts[0]['dismissed']
 
-        assert alerts[1]['alertType'] == 'missing_assignment'
-        assert alerts[1]['key'] == '2178_500600700'
-        assert alerts[1]['message'] == 'Week 6 homework in PORTUGUESE 12 is missing.'
+        assert alerts[1]['alertType'] == 'late_assignment'
+        assert alerts[1]['key'] == '2178_800900300'
+        assert alerts[1]['message'] == 'Week 5 homework in RUSSIAN 13 is late.'
         assert not alerts[1]['dismissed']
 
-        assert alerts[2]['alertType'] == 'midterm'
-        assert alerts[2]['key'] == '2178_90100'
-        assert alerts[2]['message'] == 'BURMESE 1A midpoint deficient grade of D+.'
+        assert alerts[2]['alertType'] == 'missing_assignment'
+        assert alerts[2]['key'] == '2178_500600700'
+        assert alerts[2]['message'] == 'Week 6 homework in PORTUGUESE 12 is missing.'
         assert not alerts[2]['dismissed']
 
-        assert alerts[3]['alertType'] == 'academic_standing'
-        assert alerts[3]['key'] == '2178_academic_standing_PRO'
-        assert alerts[3]['message'] == "Student's academic standing is 'Probation'."
+        assert alerts[3]['alertType'] == 'midterm'
+        assert alerts[3]['key'] == '2178_90100'
+        assert alerts[3]['message'] == 'BURMESE 1A midpoint deficient grade of D+.'
         assert not alerts[3]['dismissed']
 
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3630

In this scheme for `academic_standing` alerts, we set `created_at = action_date` and then leverage `preserve_creation_date`. But, with a fixed `created_at` date we run up against the uniqueness constraint of the `alerts` table: if we `create_or_activate()` twice then we hit uniqueness violation. We work around this by adding (1) `action_date` to the key and (2) optional `create_or_activate(... force_use_existing)` arg – for now, used solely by `academic_standing` alerts.

I'll submit QA PR if/when this is merged.