### PR TITLE
BOAC-3662, downgrade ldap3 from 2.8 to 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask==1.1.2
 google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.0
-ldap3==2.8
+ldap3==2.7
 names==0.3.0
 nltk==3.5
 psycopg2-binary==2.8.5


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3662
