### PR TITLE
BOAC-3656, disable create/edit note when BOA session expires, with messaging

### DIFF
--- a/src/components/note/SessionExpired.vue
+++ b/src/components/note/SessionExpired.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="faint-text">
+    <div class="pb-1 session-expired-header">
+      <font-awesome icon="exclamation-triangle" class="pr-1 text-warning" />
+      Uh oh, your session timed out!
+    </div>
+    <div>
+      To continue, you will need to refresh the page and reauthenticate via CalNet. Your edits will be lost unless you
+      copy them to a text editor or the clipboard and paste or reenter them when the page reloads.
+    </div>
+    <div class="pb-2 pt-1">
+      Thank you.
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'SessionExpired'
+}
+</script>
+
+<style scoped>
+.session-expired-header {
+  font-size: 18px;
+}
+</style>

--- a/src/components/note/create/BatchNoteFeatures.vue
+++ b/src/components/note/create/BatchNoteFeatures.vue
@@ -28,7 +28,7 @@
     <div>
       <BatchNoteAddStudent
         :add-sid="addStudentBySid"
-        :disabled="isSaving"
+        :disabled="isSaving || boaSessionExpired"
         :on-esc-form-input="cancel"
         :remove-sid="removeSid"
         dropdown-class="position-relative" />
@@ -37,7 +37,7 @@
       <BatchNoteAddCohort
         v-if="myCohorts && myCohorts.length"
         :add-object="addCohortToBatch"
-        :disabled="isSaving"
+        :disabled="isSaving || boaSessionExpired"
         :is-curated-groups-mode="false"
         :objects="myCohorts"
         :remove-object="removeCohortFromBatch" />
@@ -46,7 +46,7 @@
       <BatchNoteAddCohort
         v-if="myCuratedGroups && myCuratedGroups.length"
         :add-object="addCuratedGroupToBatch"
-        :disabled="isSaving"
+        :disabled="isSaving || boaSessionExpired"
         :is-curated-groups-mode="true"
         :objects="myCuratedGroups"
         :remove-object="removeCuratedGroupFromBatch" />

--- a/src/components/note/create/CreateNoteFooter.vue
+++ b/src/components/note/create/CreateNoteFooter.vue
@@ -1,45 +1,57 @@
 <template>
-  <div class="d-flex flex-wrap-reverse mt-1 mr-3 mb-0 ml-3">
-    <div class="flex-grow-1">
-      <b-btn
-        v-if="mode !== 'editTemplate'"
-        id="btn-save-as-template"
-        :disabled="isSaving || !trim(model.subject)"
-        variant="link"
-        @click="saveAsTemplate">
-        Save as template
-      </b-btn>
+  <div class="mt-1 mr-3 mb-0 ml-3">
+    <div
+      v-if="boaSessionExpired"
+      id="uh-oh-session-time-out"
+      aria-live="polite"
+      class="pl-3 pr-3"
+      role="alert">
+      <SessionExpired />
     </div>
-    <div v-if="mode === 'editTemplate'">
-      <b-btn
-        id="btn-update-template"
-        :disabled="isSaving || !model.subject"
-        class="btn-primary-color-override"
-        aria-label="Update note template"
-        variant="primary"
-        @click.prevent="updateTemplate">
-        Update Template
-      </b-btn>
-    </div>
-    <div v-if="mode !== 'editTemplate'">
-      <b-btn
-        id="create-note-button"
-        :disabled="isSaving || !completeSidSet.length || !trim(model.subject)"
-        class="btn-primary-color-override"
-        aria-label="Create note"
-        variant="primary"
-        @click.prevent="createNote">
-        Save
-      </b-btn>
-    </div>
-    <div>
-      <b-btn
-        id="create-note-cancel"
-        :disabled="isSaving"
-        variant="link"
-        @click.prevent="cancel">
-        Cancel
-      </b-btn>
+    <div v-if="!boaSessionExpired">
+      <div class="d-flex flex-wrap-reverse">
+        <div class="flex-grow-1">
+          <b-btn
+            v-if="mode !== 'editTemplate'"
+            id="btn-save-as-template"
+            :disabled="isSaving || !trim(model.subject)"
+            variant="link"
+            @click="saveAsTemplate">
+            Save as template
+          </b-btn>
+        </div>
+        <div v-if="mode === 'editTemplate'">
+          <b-btn
+            id="btn-update-template"
+            :disabled="isSaving || !model.subject"
+            class="btn-primary-color-override"
+            aria-label="Update note template"
+            variant="primary"
+            @click.prevent="updateTemplate">
+            Update Template
+          </b-btn>
+        </div>
+        <div v-if="mode !== 'editTemplate'">
+          <b-btn
+            id="create-note-button"
+            :disabled="isSaving || !completeSidSet.length || !trim(model.subject)"
+            class="btn-primary-color-override"
+            aria-label="Create note"
+            variant="primary"
+            @click.prevent="createNote">
+            Save
+          </b-btn>
+        </div>
+        <div>
+          <b-btn
+            id="create-note-cancel"
+            :disabled="isSaving"
+            variant="link"
+            @click.prevent="cancel">
+            Cancel
+          </b-btn>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -47,11 +59,13 @@
 <script>
 import Context from '@/mixins/Context'
 import NoteEditSession from '@/mixins/NoteEditSession'
+import SessionExpired from '@/components/note/SessionExpired'
 import Util from '@/mixins/Util'
 
 export default {
   name: 'CreateNoteFooter',
-  mixins: [Context, NoteEditSession, Util],
+  components: {SessionExpired},
+  mixins: [Context, NoteEditSession, SessionExpired, Util],
   props: {
     cancel: {
       required: true,

--- a/src/components/note/create/CreateNoteHeader.vue
+++ b/src/components/note/create/CreateNoteHeader.vue
@@ -8,7 +8,7 @@
       <b-dropdown
         v-if="mode !== 'editTemplate'"
         id="my-templates-button"
-        :disabled="isSaving"
+        :disabled="isSaving || boaSessionExpired"
         text="Templates"
         aria-label="Select a note template"
         variant="primary"

--- a/src/components/note/create/CreateNoteModal.vue
+++ b/src/components/note/create/CreateNoteModal.vue
@@ -46,7 +46,7 @@
               <input
                 id="create-note-subject"
                 :value="model.subject"
-                :disabled="isSaving"
+                :disabled="isSaving || boaSessionExpired"
                 :class="{'bg-light': isSaving}"
                 aria-labelledby="create-note-subject-label"
                 class="cohort-create-input-name"
@@ -63,7 +63,7 @@
               <RichTextEditor
                 id="create-note-body"
                 :initial-value="model.body || ''"
-                :disabled="isSaving"
+                :disabled="isSaving || boaSessionExpired"
                 :is-in-modal="true"
                 :on-value-update="setBody" />
             </div>
@@ -71,14 +71,14 @@
           <div>
             <AdvisingNoteTopics
               :key="mode"
-              :disabled="isSaving"
+              :disabled="isSaving || boaSessionExpired"
               :function-add="addTopic"
               :function-remove="removeTopic"
               :topics="model.topics"
               class="mt-2 mr-3 mb-1 ml-3" />
             <AdvisingNoteAttachments
               :add-attachment="addAttachment"
-              :disabled="isSaving"
+              :disabled="isSaving || boaSessionExpired"
               :existing-attachments="model.attachments"
               :remove-attachment="removeAttachment"
               class="mt-2 mr-3 mb-1 ml-3" />
@@ -178,6 +178,9 @@ export default {
     this.setMode(this.isBatchFeature ? 'batch' : 'create')
     this.putFocusNextTick(this.isBatchFeature ? 'create-note-add-student-input' : 'create-note-subject')
     this.alertScreenReader(this.isBatchFeature ? 'Create batch note form is open.' : 'Create note form is open')
+    this.$eventHub.$on('user-session-expired', () => {
+      this.onBoaSessionExpires()
+    })
   },
   methods: {
     cancelRequested() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,13 @@ axios.get(`${apiBaseUrl}/api/profile/my`).then(response => {
 
     if (Vue.prototype.$config.pingFrequency) {
       // Keep session alive with periodic requests
-      setInterval(() => axios.get(`${apiBaseUrl}/api/ping`), Vue.prototype.$config.pingFrequency)
+      setInterval(() => {
+        axios.get(`${apiBaseUrl}/api/profile/my`).then(response => {
+          if (!response.data.isAuthenticated) {
+            Vue.prototype.$eventHub.$emit('user-session-expired')
+          }
+        })
+      }, Vue.prototype.$config.pingFrequency)
     }
     // The 'core' functions strictly manage state changes in $currentUser and other "prototype" objects.
     // For example, core functions might be invoked after a successful dev-auth login.

--- a/src/mixins/NoteEditSession.vue
+++ b/src/mixins/NoteEditSession.vue
@@ -9,6 +9,7 @@ export default {
     ...mapGetters('noteEditSession', [
       'addedCohorts',
       'addedCuratedGroups',
+      'boaSessionExpired',
       'completeSidSet',
       'isFocusLockDisabled',
       'isSaving',
@@ -27,6 +28,7 @@ export default {
       'addTopic',
       'createAdvisingNotes',
       'exitSession',
+      'onBoaSessionExpires',
       'removeAttachment',
       'removeCohort',
       'removeCuratedGroup',

--- a/src/store/modules/note-edit-session.ts
+++ b/src/store/modules/note-edit-session.ts
@@ -31,6 +31,7 @@ const $_recalculateStudentCount = ({ commit, state }) => {
 const state = {
   addedCohorts: [],
   addedCuratedGroups: [],
+  boaSessionExpired: false,
   completeSidSet: [],
   isFocusLockDisabled: undefined,
   isSaving: false,
@@ -43,6 +44,7 @@ const state = {
 const getters = {
   addedCohorts: (state: any): any[] => state.addedCohorts,
   addedCuratedGroups: (state: any): any[] => state.addedCuratedGroups,
+  boaSessionExpired: (state: any): any[] => state.boaSessionExpired,
   disableNewNoteButton: (state: any): boolean => !!state.mode,
   isFocusLockDisabled: (state: any): boolean => state.isFocusLockDisabled,
   isSaving: (state: any): boolean => state.isSaving,
@@ -60,6 +62,7 @@ const mutations = {
   addCuratedGroup: (state: any, curatedGroup: any) => state.addedCuratedGroups.push(curatedGroup),
   addSid: (state: any, sid: string) => state.sids.push(sid),
   addTopic: (state: any, topic: string) => (state.model.topics.push(topic)),
+  onBoaSessionExpires: (state: any) => (state.boaSessionExpired = true),
   exitSession: (state: any) => {
     state.addedCohorts = []
     state.addedCuratedGroups = []
@@ -135,6 +138,7 @@ const actions = {
     $_recalculateStudentCount({ commit, state })
   },
   addTopic: ({ commit }, topic: string) => commit('addTopic', topic),
+  onBoaSessionExpires: ({ commit }) => commit('onBoaSessionExpires'),
   createAdvisingNotes: ({commit, state}) => {
     return new Promise(resolve => {
       commit('setBody', _.trim(state.model.body))


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3656

This UI change does not perfectly match design in https://jira.ets.berkeley.edu/jira/browse/BOAC-3628 but it serves its purpose. QA and UX can state their opinions after merge.

Use `?w=1`

In screenshot below, notice that buttons are gone and alert is shown. Plus, all form elements are disabled.

![image](https://user-images.githubusercontent.com/7606442/92950345-5a032b80-f411-11ea-854d-e2d8b360dbfd.png)
