### PR TITLE
BOAC-3697: Hides attachments from SR when note is collapsed

### DIFF
--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -83,7 +83,7 @@
       :show-modal="showConfirmDeleteAttachment"
       button-label-confirm="Delete"
       modal-header="Delete Attachment" />
-    <div>
+    <div v-if="isOpen">
       <ul class="pill-list pl-0 mt-3">
         <li
           v-for="(attachment, index) in existingAttachments"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3697