### PR TITLE
BOAC-3746, buildspec: 'nvm use' before vue-cli build, in case wrong node version

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,7 +15,8 @@ phases:
 
   build:
     commands:
-      - npm install -g @vue/cli
+      - node -v
+      - nvm use
       - npm run build-vue
 
   post_build:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3746

I want to rule out shifting node versions as a cause. 