### PR TITLE
BOAC-3746, remove 'nvm use'; build phase has expected node version

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,7 +16,6 @@ phases:
   build:
     commands:
       - node -v
-      - nvm use
       - npm run build-vue
 
   post_build:


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3746

`nvm` is not in $PATH but we were able to verify that proper node version is in use. Let's run another build to test the recent removal of `npm install -g @vue/cli`. 