### PR TITLE
BOAC-3700: Prevents arrow keys from breaking out of create note modal

### DIFF
--- a/src/components/note/create/CreateNoteModal.vue
+++ b/src/components/note/create/CreateNoteModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div role="dialog">
     <FocusLock
       :disabled="isFocusLockDisabled"
       class="create-note-container">


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3700