### PR TITLE
NOJIRA, buildspec: npm install -g @vue/cli

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,6 +10,7 @@ phases:
 
   build:
     commands:
+      - npm install -g @vue/cli
       - npm --verbose run build-vue
 
   post_build:


### PR DESCRIPTION
Explicit global install of `vue/cli` should not be necessary – in fact, CodePipeline has had success without it. And yet, Nessie and Diablo buildspecs have it. Perhaps it will end our random failures.