### PR TITLE
BOAC-3473, less sr confusion: use vue-a11y/announcer; no longer rely on Spinner for srAlerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -144,49 +143,10 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
-        },
-        "@babel/traverse": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-          "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.11.5",
-            "@babel/helper-function-name": "^7.10.4",
-            "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/parser": "^7.11.5",
-            "@babel/types": "^7.11.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.19"
-          }
-        },
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -438,17 +398,17 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+      "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
       "requires": {
-        "@babel/types": "^7.11.0"
+        "@babel/types": "^7.12.1"
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -478,23 +438,64 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
         "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/types": "^7.11.0",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "lodash": "^4.17.19"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+          "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+          "requires": {
+            "@babel/types": "^7.12.1",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+          "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
+          "requires": {
+            "@babel/types": "^7.12.1"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+          "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
+        },
+        "@babel/traverse": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+          "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.1",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -562,76 +563,51 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+      "integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
         "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-          "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
         "@babel/generator": {
-          "version": "7.11.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-          "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+          "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
           "requires": {
-            "@babel/types": "^7.11.5",
+            "@babel/types": "^7.12.1",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
         },
-        "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
         "@babel/parser": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+          "version": "7.12.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+          "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
         },
         "@babel/traverse": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-          "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+          "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.11.5",
+            "@babel/generator": "^7.12.1",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/parser": "^7.11.5",
-            "@babel/types": "^7.11.5",
+            "@babel/parser": "^7.12.1",
+            "@babel/types": "^7.12.1",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
-          },
-          "dependencies": {
-            "globals": {
-              "version": "11.12.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-              "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-            }
           }
         },
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -641,18 +617,17 @@
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
       },
       "dependencies": {
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -727,58 +702,50 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
+      "integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
       "requires": {
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+        "@babel/generator": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+          "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
           "requires": {
-            "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
+            "@babel/types": "^7.12.1",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
           }
         },
         "@babel/parser": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+          "version": "7.12.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+          "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
         },
         "@babel/traverse": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-          "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+          "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.11.5",
+            "@babel/generator": "^7.12.1",
             "@babel/helper-function-name": "^7.10.4",
             "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/parser": "^7.11.5",
-            "@babel/types": "^7.11.5",
+            "@babel/parser": "^7.12.1",
+            "@babel/types": "^7.12.1",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
           }
         },
         "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -791,7 +758,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
       "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
@@ -801,8 +767,7 @@
     "@babel/parser": {
       "version": "7.11.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
-      "dev": true
+      "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.12.1",
@@ -2225,7 +2190,6 @@
       "version": "7.11.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
       "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.11.5",
@@ -2242,7 +2206,6 @@
           "version": "7.11.5",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
           "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -3958,6 +3921,11 @@
           "dev": true
         }
       }
+    },
+    "@vue-a11y/announcer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vue-a11y/announcer/-/announcer-2.1.0.tgz",
+      "integrity": "sha512-7V1osiJQxZPBA+2duF2nZugwgbIba/yvKLsHWvGIBJGY0VZhR4vYyFH3VFyFH2Yi46tHEVBN+X+a0uQaJMhCsQ=="
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@fortawesome/free-regular-svg-icons": "5.15.1",
     "@fortawesome/free-solid-svg-icons": "5.15.1",
     "@fortawesome/vue-fontawesome": "2.0.0",
+    "@vue-a11y/announcer": "2.1.0",
     "acorn": "^7.4.0",
     "axios": "0.20.0",
     "bootstrap-vue": "2.18.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
           <b>BOA {{ getBoaEnvLabel() }} Environment</b>
         </div>
         <div>
-          {{ $config.isVueAppDebugMode ? screenReaderAlert : $config.fixedWarningOnAllPages }}
+          {{ $config.isVueAppDebugMode ? $_.get($announcer, 'data.content') || '&mdash;' : $config.fixedWarningOnAllPages }}
         </div>
         <div class="btn-wrapper ml-0 align-top">
           <b-btn

--- a/src/components/cohort/CohortHistory.vue
+++ b/src/components/cohort/CohortHistory.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <SectionSpinner :loading="loading" name="History" />
+    <SectionSpinner :loading="loading" />
     <div v-if="!loading && totalEventsCount > itemsPerPage">
       <div class="pt-3">
         <Pagination
@@ -111,11 +111,13 @@ export default {
     },
     loadEvents() {
       this.loading = true
+      this.alertScreenReader('Cohort history is loading')
       this.scrollToTop(10)
       getCohortEvents(this.cohortId, this.offset, this.itemsPerPage).then((response) => {
         this.totalEventsCount = response.count
         this.events = response.events
         this.loading = false
+        this.alertScreenReader('Cohort history has loaded')
       })
     }
   },

--- a/src/components/cohort/FilterRow.vue
+++ b/src/components/cohort/FilterRow.vue
@@ -394,16 +394,20 @@ export default {
       return this.get(this.filter, 'type.ux') === type
     },
     onClickAddButton() {
+      const announce = alert => {
+        this.alertScreenReader(alert)
+        this.$ga.cohortEvent(this.cohortId, this.cohortName || '', alert)
+      }
       switch (this.get(this.filter, 'type.ux')) {
       case 'dropdown':
-        this.alertScreenReader(`Added ${this.filter.label.primary} filter with value ${this.getDropdownSelectedLabel()}`)
+        announce(`Added ${this.filter.label.primary} filter with value ${this.getDropdownSelectedLabel()}`)
         break
       case 'boolean':
-        this.alertScreenReader(`Added ${this.filter.label.primary}`)
+        announce(`Added ${this.filter.label.primary}`)
         this.filter.value = true
         break
       case 'range':
-        this.alertScreenReader(`Added ${this.filter.label.primary} filter, ${this.range.min} to ${this.range.max}`)
+        announce(`Added ${this.filter.label.primary} filter, ${this.range.min} to ${this.range.max}`)
         this.filter.value = {
           min: this.filter.validation === 'gpa' ? this.formatGPA(this.range.min) : this.range.min.toUpperCase(),
           max: this.filter.validation === 'gpa' ? this.formatGPA(this.range.max) : this.range.max.toUpperCase()
@@ -414,7 +418,6 @@ export default {
       this.addFilter(this.filter)
       this.reset()
       this.putFocusNewFilterDropdown()
-      this.$ga.cohortEvent(this.cohortId, this.cohortName || '', this.screenReaderAlert)
     },
     onClickCancelEdit() {
       this.alertScreenReader('Cancelled')
@@ -447,8 +450,9 @@ export default {
       this.updateExistingFilter({index: this.index, updatedFilter: this.filter}).then(() => {
         this.isModifyingFilter = false
         this.setEditMode(null)
-        this.alertScreenReader(`${this.filter.label.primary} filter updated`)
-        this.$ga.cohortEvent(this.cohortId, this.cohortName, this.screenReaderAlert)
+        let alert = `${this.filter.label.primary} filter updated`
+        this.alertScreenReader(alert)
+        this.$ga.cohortEvent(this.cohortId, this.cohortName, alert)
       })
     },
     onSelectFilter(filter) {
@@ -512,11 +516,12 @@ export default {
       return snippet
     },
     remove() {
-      this.alertScreenReader(`${this.filter.label.primary} filter removed`)
       this.removeFilter(this.index)
       this.setEditMode(null)
       this.putFocusNewFilterDropdown()
-      this.$ga.cohortEvent(this.cohortId, this.cohortName || '', this.screenReaderAlert)
+      let alert = `${this.filter.label.primary} filter removed`
+      this.alertScreenReader(alert)
+      this.$ga.cohortEvent(this.cohortId, this.cohortName || '', alert)
     },
     reset() {
       this.disableUpdateButton = false

--- a/src/components/curated/CuratedGroupHeader.vue
+++ b/src/components/curated/CuratedGroupHeader.vue
@@ -235,7 +235,6 @@ export default {
       })
       this.referencingCohorts = this.$_.sortBy(this.referencingCohorts, ['name'])
     }
-    this.loaded()
     this.putFocusNextTick('curated-group-name')
   },
   methods: {

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -543,7 +543,7 @@ export default {
       this.alertScreenReader('Cancelled')
       this.messageForDelete = undefined
     },
-    close(message, screenreaderAlert) {
+    close(message, notifyScreenReader) {
       if (this.editModeNoteId) {
         return false
       }
@@ -556,7 +556,7 @@ export default {
       if (this.openMessages.length === 0) {
         this.allExpanded = false
       }
-      if (screenreaderAlert) {
+      if (notifyScreenReader) {
         this.alertScreenReader(`${this.capitalize(message.type)} closed`)
       }
     },
@@ -637,7 +637,7 @@ export default {
     onCreateNoteModalClose() {
       this.isCreateNoteModalOpen = false
     },
-    open(message, screenreaderAlert) {
+    open(message, notifyScreenReader) {
       if (message.type === 'note' && message.id === this.editModeNoteId) {
         return false
       }
@@ -648,7 +648,7 @@ export default {
       if (this.isExpandAllAvailable && this.openMessages.length === this.messagesPerType(this.filter).length) {
         this.allExpanded = true
       }
-      if (screenreaderAlert) {
+      if (notifyScreenReader) {
         this.alertScreenReader(`${this.capitalize(message.type)} opened`)
       }
     },

--- a/src/components/util/SectionSpinner.vue
+++ b/src/components/util/SectionSpinner.vue
@@ -2,19 +2,6 @@
   <div>
     <div v-if="loading" class="spinner">
       <font-awesome :size="`${faSize}x`" icon="sync" spin />
-      <span
-        role="alert"
-        aria-live="polite"
-        class="sr-only">Loading...</span>
-    </div>
-    <div v-if="!loading && !noAnnounce">
-      <span
-        v-if="name"
-        role="alert"
-        aria-live="polite"
-        class="sr-only">
-        <span>{{ name }} loaded</span>
-      </span>
     </div>
   </div>
 </template>
@@ -23,13 +10,6 @@
 export default {
   name: 'SectionSpinner',
   props: {
-    noAnnounce: {
-      type: Boolean
-    },
-    name: {
-      type: String,
-      default: undefined
-    },
     faSize: {
       type: Number,
       default: 3

--- a/src/components/util/Spinner.vue
+++ b/src/components/util/Spinner.vue
@@ -5,46 +5,11 @@
 </template>
 
 <script>
-import Context from '@/mixins/Context.vue'
 import Loading from '@/mixins/Loading.vue'
 
 export default {
-  mixins: [Context, Loading],
-  props: {
-    alertPrefix: {
-      default: undefined,
-      type: String
-    },
-    isPlural: {
-      type: Boolean
-    }
-  },
-  watch: {
-    alertPrefix() {
-      this.srAlert()
-    },
-    loading() {
-      this.srAlert()
-    }
-  },
-  data: () => ({
-    alertHistory: []
-  }),
-  created() {
-    this.srAlert()
-  },
-  methods: {
-    srAlert() {
-      if (this.alertPrefix) {
-        const alert = this.loading ? `${this.alertPrefix} ${this.isPlural ? 'are' : 'is'} loading` : `${this.alertPrefix} loaded`
-        const isRedundant = this.$_.includes(this.alertHistory, alert)
-        if (!isRedundant) {
-          this.alertScreenReader(alert)
-          this.alertHistory.push(alert)
-        }
-      }
-    }
-  }
+  name: 'Spinner',
+  mixins: [Loading],
 }
 </script>
 

--- a/src/layouts/AppointmentDropIn.vue
+++ b/src/layouts/AppointmentDropIn.vue
@@ -5,13 +5,6 @@
       <b-col id="content" class="body-text h-100 min-width-100 pb-2" sm="10">
         <ServiceAnnouncement />
         <div>
-          <span
-            v-if="screenReaderAlert"
-            class="sr-only"
-            aria-live="polite"
-            role="alert">
-            {{ screenReaderAlert }}
-          </span>
           <router-view :key="stripAnchorRef($route.fullPath)"></router-view>
         </div>
       </b-col>
@@ -39,10 +32,7 @@ export default {
     ServiceAnnouncement,
     StandardHeaderLayout
   },
-  mixins: [Context, Loading, Util],
-  created() {
-    this.loaded()
-  }
+  mixins: [Context, Loading, Util]
 }
 </script>
 

--- a/src/layouts/StandardLayout.vue
+++ b/src/layouts/StandardLayout.vue
@@ -11,16 +11,8 @@
         role="main"
         sm="10">
         <ServiceAnnouncement />
-        <div>
-          <span
-            v-if="screenReaderAlert"
-            class="sr-only"
-            aria-live="polite"
-            role="alert">
-            {{ screenReaderAlert }}
-          </span>
-          <router-view :key="stripAnchorRef($route.fullPath)"></router-view>
-        </div>
+        <VueAnnouncer />
+        <router-view :key="stripAnchorRef($route.fullPath)"></router-view>
       </b-col>
     </b-row>
     <b-row class="row-footer" no-gutters>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import router from './router'
 import store from './store'
 import VCalendar from 'v-calendar'
 import Vue from 'vue'
+import VueAnnouncer from '@vue-a11y/announcer'
 import VueHighcharts from 'vue-highcharts'
 import VueLodash from 'vue-lodash'
 import VueMoment from 'vue-moment'
@@ -34,6 +35,7 @@ Vue.config.productionTip = false
 Vue.use(BootstrapVue)
 Vue.use(CKEditor)
 Vue.use(VCalendar)
+Vue.use(VueAnnouncer)
 Vue.use(VueLodash, { lodash })
 Vue.use(VueMoment, { moment })
 

--- a/src/mixins/Context.vue
+++ b/src/mixins/Context.vue
@@ -6,8 +6,7 @@ export default {
   computed: {
     ...mapGetters('context', [
       'announcement',
-      'hasUserDismissedFooterAlert',
-      'screenReaderAlert'
+      'hasUserDismissedFooterAlert'
     ]),
     ...mapGetters('noteEditSession', [
       'disableNewNoteButton',
@@ -16,9 +15,11 @@ export default {
   },
   methods: {
     ...mapActions('context', [
-      'alertScreenReader',
       'dismissFooterAlert'
-    ])
+    ]),
+    alertScreenReader(message, politeness='polite') {
+      this.$announcer.set(message, politeness)
+    }
   }
 }
 </script>

--- a/src/mixins/Loading.vue
+++ b/src/mixins/Loading.vue
@@ -10,9 +10,9 @@ export default {
   beforeCreate: () => store.dispatch('context/loadingStart'),
   methods: {
     ...mapActions('context', ['loadingStart']),
-    loaded(pageTitle) {
-      if (!!pageTitle && store.getters['context/loading']) {
-        store.dispatch('context/alertScreenReader', `${pageTitle} page is ready`)
+    loaded(srAlert) {
+      if (srAlert) {
+        this.$announcer.polite(srAlert)
       }
       store.dispatch('context/loadingComplete')
     }

--- a/src/router.ts
+++ b/src/router.ts
@@ -288,8 +288,9 @@ const router = new Router({
 })
 
 router.afterEach((to: any) => {
-  const title = _.get(to, 'meta.title') || _.capitalize(to.name) || 'Welcome'
-  document.title = `${title} | BOA`
+  const pageTitle = _.get(to, 'meta.title')
+  document.title = `${pageTitle || _.capitalize(to.name) || 'Welcome'} | BOA`
+  Vue.prototype.$announcer.assertive(`${pageTitle || 'Page'} is loading`)
 })
 
 export default router

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -1,33 +1,25 @@
-import Vue from 'vue'
 import { getServiceAnnouncement } from '@/api/config'
 
 const state = {
   announcement: undefined,
   hasUserDismissedFooterAlert: false,
-  loading: undefined,
-  screenReaderAlert: undefined
+  loading: undefined
 }
 
 const getters = {
   announcement: (state: any): string => state.announcement,
   hasUserDismissedFooterAlert: (): boolean => state.hasUserDismissedFooterAlert,
-  loading: (state: any): boolean => state.loading,
-  screenReaderAlert: (state: any): string => state.screenReaderAlert
+  loading: (state: any): boolean => state.loading
 }
 
 const mutations = {
   dismissFooterAlert: (state: any) => state.hasUserDismissedFooterAlert = true,
   loadingComplete: (state: any) => (state.loading = false),
   loadingStart: (state: any) => (state.loading = true),
-  setScreenReaderAlert: (state: any, alert: any) => (state.screenReaderAlert = alert),
   storeAnnouncement: (state: any, data: any) => (state.announcement = data),
 }
 
 const actions = {
-  alertScreenReader: ({ commit }, alert) => {
-    commit('setScreenReaderAlert', '')
-    Vue.nextTick(() => commit('setScreenReaderAlert', alert))
-  },
   dismissFooterAlert: ({ commit }) => commit('dismissFooterAlert'),
   loadingComplete: ({ commit }) => commit('loadingComplete'),
   loadingStart: ({ commit }) => commit('loadingStart'),

--- a/src/views/AdmitStudent.vue
+++ b/src/views/AdmitStudent.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <Spinner alert-prefix="Admit profile" />
+    <Spinner />
     <div v-if="!loading" class="m-3">
       <h1
         id="admit-name-header"
@@ -352,8 +352,9 @@ export default {
     getAdmitBySid(sid).then(admit => {
       if (admit) {
         this.assign(this.admit, admit)
-        this.setPageTitle(this.$currentUser.inDemoMode ? 'Admitted Student' : this.fullName)
-        this.loaded(this.admit)
+        let pageTitle = this.$currentUser.inDemoMode ? 'Admitted Student' : this.fullName
+        this.setPageTitle(pageTitle)
+        this.loaded(`${pageTitle} has loaded`)
       } else {
         this.$router.push({ path: '/404' })
       }

--- a/src/views/AdmitStudents.vue
+++ b/src/views/AdmitStudents.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="ml-3 mt-3">
-    <Spinner alert-prefix="CE3 Admissions" />
+    <Spinner />
     <div v-if="!loading">
       <div class="d-flex flex-wrap justify-content-between">
         <h1
@@ -37,7 +37,7 @@
       </div>
       <AdmitDataWarning v-if="admits" :updated-at="get(admits, '[0].updatedAt')" />
       <hr class="filters-section-separator mr-2 mt-3" />
-      <SectionSpinner :loading="sorting" name="Admitted Students" />
+      <SectionSpinner :loading="sorting" />
       <div>
         <a
           v-if="totalAdmitCount > pagination.itemsPerPage"
@@ -169,11 +169,10 @@ export default {
       })
     },
     goToPage(page) {
-      if (page > 1) {
-        const action = `Go to page ${page}`
-        this.alertScreenReader(action)
-      }
       if (page !== this.pagination.currentPage) {
+        if (this.pagination.currentPage) {
+          this.alertScreenReader(`Loading page ${page} of this cohort's students`)
+        }
         this.pagination.currentPage = page
         this.$router.push({
           query: { ...this.$route.query, p: this.pagination.currentPage }
@@ -195,7 +194,7 @@ export default {
         if (response) {
           this.admits = this.get(response, 'students')
           this.totalAdmitCount = this.get(response, 'totalStudentCount')
-          this.loaded()
+          this.loaded(`${this.totalAdmitCount} CE3 admits loaded`)
           this.putFocusNextTick('cohort-name')
         } else {
           this.$router.push({ path: '/404' })

--- a/src/views/AllCohorts.vue
+++ b/src/views/AllCohorts.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="m-3">
-    <Spinner :is-plural="true" alert-prefix="Cohorts" />
+    <Spinner />
     <div v-if="!loading">
       <h1 ref="pageHeader" class="mb-4">Everyone's Cohorts</h1>
 
@@ -40,7 +40,7 @@ export default {
   created() {
     getUsersWithCohorts('default').then(data => {
       this.rows = data
-      this.loaded('Everyone\'s Cohorts')
+      this.loaded('Everyone\'s Cohorts page has loaded')
     })
   }
 }

--- a/src/views/AllGroups.vue
+++ b/src/views/AllGroups.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="m-3">
-    <Spinner :is-plural="true" alert-prefix="Curated groups" />
+    <Spinner />
     <div v-if="!loading">
       <h1 ref="pageHeader" class="mb-4">Everyone's Groups</h1>
 
@@ -40,7 +40,7 @@ export default {
   created() {
     getUsersWithGroups().then(data => {
       this.rows = data
-      this.loaded('Everyone\'s Groups')
+      this.loaded('Everyone\'s Groups has loaded')
     })
   }
 }

--- a/src/views/Analytics.vue
+++ b/src/views/Analytics.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-3">
-    <Spinner alert-prefix="Analytics page" />
+    <Spinner />
     <div v-if="!loading">
       <div class="d-flex justify-content-between">
         <div>
@@ -64,7 +64,7 @@ export default {
       if (this.includes(this.map(departments, 'code'), this.deptCode)) {
         this.availableDepartments = departments
         this.render()
-        this.loaded('Reports')
+        this.loaded('Reports loaded')
       } else {
         this.$router.push({ path: '/404' })
       }

--- a/src/views/Cohort.vue
+++ b/src/views/Cohort.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="ml-3 mt-3">
-    <Spinner
-      :key="$route.params.id"
-      :alert-prefix="cohortId === 'new' ? 'Create cohort page' : `Cohort ${cohortName || ''}, sorted by ${preferences.sortBy}, ${pageNumber > 1 ? `(page ${pageNumber})` : ''}`"
-    />
+    <Spinner />
     <div v-if="!loading">
       <CohortPageHeader :show-history="showHistory" :toggle-show-history="toggleShowHistory" />
       <AdmitDataWarning v-if="domain === 'admitted_students' && students" :updated-at="get(students, '[0].updatedAt')" />
@@ -20,11 +17,7 @@
         <ApplyAndSaveButtons v-if="isOwnedByCurrentUser" />
       </b-collapse>
       <hr class="filters-section-separator mr-2 mt-3" />
-      <SectionSpinner
-        :loading="editMode === 'apply'"
-        :name="domain === 'admitted_students' ? 'Admitted students' : 'Students'"
-        :no-announce="!cohortId && totalStudentCount === undefined"
-      />
+      <SectionSpinner :loading="editMode === 'apply'" />
       <div v-if="!showHistory && showStudentsSection">
         <a
           v-if="totalStudentCount > 50"
@@ -178,7 +171,7 @@ export default {
       this.showFilters = !this.isCompactView
       this.pageNumber = this.pagination.currentPage
       this.setPageTitle(this.cohortName)
-      this.loaded()
+      this.loaded(this.getLoadedAlert())
     } else {
       const domain = this.$route.query.domain || 'default'
       const id = this.toInt(this.get(this.$route, 'params.id'))
@@ -191,7 +184,7 @@ export default {
         this.pageNumber = this.pagination.currentPage
         const pageTitle = this.cohortId ? this.cohortName : 'Create Cohort'
         this.setPageTitle(pageTitle)
-        this.loaded()
+        this.loaded(this.getLoadedAlert())
         this.putFocusNextTick(this.cohortId ? 'cohort-name' : 'create-cohort-h1')
         this.$ga.cohortEvent(this.cohortId || '', this.cohortName || '', 'view')
       })
@@ -211,6 +204,13 @@ export default {
   },
   methods: {
     filterRowUniqueKey: (filter, index) => `${filter.key}-${filter.value}-${index}`,
+    getLoadedAlert() {
+      if (!this.cohortId) {
+        return 'Create cohort page has loaded'
+      } else {
+        return `Cohort ${this.cohortName || ''}, sorted by ${this.preferences.sortBy}, ${this.pageNumber > 1 ? `(page ${this.pageNumber})` : ''} has loaded`
+      }
+    },
     goToPage(page) {
       if (page > 1) {
         this.$ga.cohortEvent(this.cohortId || '', this.cohortName || '', `Go to page ${page}`)

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="course-container">
-    <Spinner alert-prefix="Course" />
+    <Spinner />
 
     <div v-if="!loading && error">
       <h1 class="page-section-header">Error</h1>
@@ -37,9 +37,7 @@
               </span>
             </div>
             <div v-if="section.title" class="course-section-title">
-              <span role="alert" aria-live="polite">
-                {{ section.title }}
-              </span>
+              {{ section.title }}
             </div>
           </div>
           <div class="course-column-schedule">
@@ -211,6 +209,9 @@ export default {
       section.students = students
       return section
     },
+    getLoadedAlert() {
+      return `${this.section.title || this.section.displayName} has loaded`
+    },
     initViewMode() {
       this.tab = this.includes(['list', 'matrix'], this.$route.query.tab)
         ? this.$route.query.tab
@@ -249,7 +250,7 @@ export default {
       ).then(data => {
         if (data) {
           this.updateCourseData(data)
-          this.loaded()
+          this.loaded(this.getLoadedAlert())
         } else {
           this.$router.push({ path: '/404' })
         }
@@ -259,7 +260,7 @@ export default {
       getSection(this.$route.params.termId, this.$route.params.sectionId).then(
         data => {
           this.updateCourseData(data)
-          this.loaded()
+          this.loaded(this.getLoadedAlert())
         }
       )
     },

--- a/src/views/CuratedGroup.vue
+++ b/src/views/CuratedGroup.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="m-3">
-    <Spinner :alert-prefix="`Curated group ${curatedGroupName || ''}, sorted by ${preferences.sortBy}, ${pageNumber > 1 ? `(page ${pageNumber})` : ''}`" />
+    <Spinner />
     <div v-if="!loading">
       <CuratedGroupHeader />
       <div v-show="mode !== 'bulkAdd'">
@@ -100,11 +100,11 @@ export default {
     this.setMode(undefined)
     this.init(parseInt(this.id)).then(group => {
       if (group) {
-        this.loaded()
+        this.loaded(this.getLoadedAlert())
         this.setPageTitle(this.curatedGroupName)
         this.putFocusNextTick('curated-group-name')
         if (this.pageNumber > 1) {
-          this.$ga.curatedEvent(this.curatedGroupId, this.curatedGroupName, this.screenReaderAlert)
+          this.$ga.curatedEvent(this.curatedGroupId, this.curatedGroupName, 'view')
         }
       } else {
         this.$router.push({ path: '/404' })
@@ -115,8 +115,8 @@ export default {
         this.loadingStart()
         this.alertScreenReader(`Sorting students by ${sortBy}`)
         this.goToPage(1).then(() => {
-          this.loaded(this.curatedGroupName)
-          this.$ga.curatedEvent(this.curatedGroupId, this.curatedGroupName, this.screenReaderAlert)
+          this.loaded(this.getLoadedAlert())
+          this.$ga.curatedEvent(this.curatedGroupId, this.curatedGroupName, `sort by ${sortBy}`)
         })
       }
     })
@@ -143,7 +143,7 @@ export default {
         })
         this.loadingStart()
         this.addStudents(sids).then(() => {
-          this.loaded(this.name)
+          this.loaded(this.getLoadedAlert())
           this.putFocusNextTick('curated-group-name')
           this.alertScreenReader(`${sids.length} students added to group '${this.name}'`)
           this.$ga.curatedEvent(this.curatedGroupId, this.curatedGroupName, 'Update curated group with bulk-add SIDs')
@@ -153,12 +153,14 @@ export default {
         this.putFocusNextTick('curated-group-name')
       }
     },
+    getLoadedAlert() {
+      return `Curated group ${this.curatedGroupName || ''}, sorted by ${this.preferences.sortBy}, ${this.pageNumber > 1 ? `(page ${this.pageNumber})` : ''} has loaded`
+    },
     onClickPagination(pageNumber) {
       this.loadingStart()
       this.goToPage(pageNumber).then(() => {
-        this.loaded(this.name)
-        this.alertScreenReader(`Page ${pageNumber} of cohort ${this.curatedGroupName}`)
-        this.$ga.curatedEvent(this.curatedGroupId, this.curatedGroupName,this.screenReaderAlert)
+        this.loaded(this.getLoadedAlert())
+        this.$ga.curatedEvent(this.curatedGroupId, this.curatedGroupName, `Page ${pageNumber}`)
       })
     }
   }

--- a/src/views/DropInAdvisorHome.vue
+++ b/src/views/DropInAdvisorHome.vue
@@ -2,7 +2,7 @@
   <div class="ml-3 mt-4 w-100">
     <h1 class="sr-only">Welcome to BOA</h1>
 
-    <Spinner alert-prefix="Drop-in Advisor homepage" />
+    <Spinner />
 
     <b-container v-if="!loading" fluid>
       <b-row no-gutters>
@@ -155,7 +155,7 @@ export default {
           }
 
           if (announceLoad) {
-            this.loaded('Appointment waitlist')
+            this.loaded('Drop-in Advisor homepage has loaded')
           }
           if (announceUpdate) {
             this.alertScreenReader('The appointment waitlist has been updated')

--- a/src/views/DropInDesk.vue
+++ b/src/views/DropInDesk.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="ml-3 mr-3 mt-3">
-    <Spinner alert-prefix="Appointment waitlist" />
+    <Spinner />
     <div v-if="!loading && !$currentUser.isAdmin" class="mb-2 pb-3 pt-3 text-center">
       <b-btn
         id="btn-create-appointment"
@@ -96,9 +96,9 @@ export default {
             this.scheduleRefreshJob()
           }
           if (announceUpdate) {
-            this.alertScreenReader('The drop-in waitlist has been updated')
+            this.alertScreenReader('The drop-in wait-list has been updated')
           } else if (response.waitlist) {
-            this.loaded('Appointment waitlist')
+            this.loaded('The Appointment wait-list has loaded')
           }
         })
       })

--- a/src/views/FlightDeck.vue
+++ b/src/views/FlightDeck.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-3">
-    <Spinner alert-prefix="The Admin page" />
+    <Spinner />
     <div v-if="!loading">
       <div class="align-items-center d-flex pb-3">
         <div class="pr-3">
@@ -104,7 +104,7 @@ export default {
       this.dropInSchedulingDepartments = departments
       getVersion().then(data => {
         this.boa = data
-        this.loaded('Flight Deck')
+        this.loaded('Flight Deck has loaded')
       })
     })
   }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="ml-3 mt-3">
     <h1 class="sr-only">Welcome to BOA</h1>
-    <Spinner alert-prefix="The BOA homepage" />
+    <Spinner />
     <div v-if="!loading" class="home-content">
       <div>
         <div id="filtered-cohorts-header-row">
@@ -54,7 +54,7 @@ export default {
   },
   mixins: [CurrentUserExtras, Loading, Scrollable, Util],
   mounted() {
-    this.loaded('Home')
+    this.loaded('BOA has loaded')
     this.scrollToTop()
   }
 }

--- a/src/views/PassengerManifest.vue
+++ b/src/views/PassengerManifest.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-3">
-    <Spinner alert-prefix="The Passenger Manifest" />
+    <Spinner />
     <div v-if="!loading">
       <div class="list-group">
         <div class="align-items-baseline d-flex mb-2 mt-2">
@@ -47,7 +47,7 @@ export default {
   created() {
     getDepartments(true).then(departments => {
       this.departments = departments
-      this.loaded('Passenger Manifest')
+      this.loaded('Passenger Manifest has loaded')
     })
   },
   methods: {

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="ml-3 mr-3 mt-3">
-    <Spinner alert-prefix="Profile page" />
+    <Spinner />
     <div v-if="!loading">
       <div class="align-items-center d-flex pb-3">
         <div class="pr-2">
@@ -59,7 +59,7 @@ export default {
         this.loaded('Profile')
       })
     } else {
-      this.loaded('Profile')
+      this.loaded('Profile page has loaded')
     }
     this.putFocusNextTick('profile-header')
   }

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -217,8 +217,7 @@ export default {
         })
       })
         .then(() => {
-          this.loaded()
-          this.describeResults()
+          this.loaded(this.describeResults())
           const totalCount =
             this.toInt(this.results.totalCourseCount, 0) +
             this.toInt(this.results.totalStudentCount, 0)
@@ -240,7 +239,7 @@ export default {
       alert += describe('course', this.results.totalCourseCount)
       alert += describe('note', this.$_.size(this.results.notes))
       alert += describe('appointment', this.$_.size(this.results.appointments))
-      this.alertScreenReader(alert)
+      return alert
     },
     fetchMoreAppointments() {
       this.appointmentOptions.offset = this.appointmentOptions.offset + this.appointmentOptions.limit

--- a/src/views/Student.vue
+++ b/src/views/Student.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <Spinner alert-prefix="Student profile" />
+    <Spinner />
     <div v-if="!loading">
       <div class="light-blue-background border-bottom">
         <StudentProfileHeader :student="student" />
@@ -86,7 +86,7 @@ export default {
         this.setPageTitle(this.$currentUser.inDemoMode ? 'Student' : student.name)
         this.assign(this.student, student)
         this.each(this.student.enrollmentTerms, this.parseEnrollmentTerm)
-        this.loaded(this.student)
+        this.loaded(`${this.student.name} loaded`)
       } else {
         this.$router.push({ path: '/404' })
       }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3473

Our home-cooked srAlert feature relies on vuex store and mixins. By replacing that with `@vue-a11y/announcer` we get less code and a couple nice features (eg, politeness control). Also, having the Spinner component manage "page has loaded" alerts is not elegant and often results in double-voicing alerts.