### PR TITLE
BOAC-3624, discard deprecated Vue.prototype.$eventHub.emit pattern

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16218,6 +16218,11 @@
         "through2": "^2.0.0"
       }
     },
+    "mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "js-file-download": "0.4.12",
     "lodash": "4.17.20",
     "lodash.merge": "4.6.2",
+    "mitt": "2.1.0",
     "moment-timezone": "0.5.31",
     "numeral": "2.0.6",
     "v-calendar": "1.0.8",

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -26,7 +26,7 @@ export function getUserProfile() {
     .then(response => {
       const user = response.data
       if (!user.isAuthenticated) {
-        Vue.prototype.$eventHub.$emit('user-session-expired')
+        Vue.prototype.$eventHub.emit('user-session-expired')
       }
       return user
     }, () => null)

--- a/src/components/appointment/DropInWaitlist.vue
+++ b/src/components/appointment/DropInWaitlist.vue
@@ -238,7 +238,7 @@ export default {
     this.linkToStudentProfiles = this.$currentUser.isAdmin || !this.$_.isEmpty(this.currentUserDropInStatus)
     this.now = this.$moment()
     if (this.isHomepage) {
-      this.$eventHub.$on('drop-in-status-change', newAttributes => {
+      this.$eventHub.on('drop-in-status-change', newAttributes => {
         this.updateDropInAttributes(newAttributes)
       })
       this.updateDropInAttributes(this.$_.find(currentUserDropInStatus, {'deptCode': this.deptCode.toUpperCase()}))

--- a/src/components/cohort/ApplyAndSaveButtons.vue
+++ b/src/components/cohort/ApplyAndSaveButtons.vue
@@ -82,7 +82,7 @@ export default {
   },
   methods: {
     apply() {
-      this.$eventHub.$emit('cohort-apply-filters')
+      this.$eventHub.emit('cohort-apply-filters')
       this.isPerforming = 'search'
       this.applyFilters(this.$_.get(this.preferences, this.domain === 'admitted_students' ? 'admitSortBy' : 'sortBy')).then(() => {
         this.putFocusNextTick('cohort-results-header')

--- a/src/components/curated/CuratedGroupSelector.vue
+++ b/src/components/curated/CuratedGroupSelector.vue
@@ -130,11 +130,11 @@ export default {
     }
   },
   created() {
-    this.$eventHub.$on('curated-group-checkbox-checked', sid => {
+    this.$eventHub.on('curated-group-checkbox-checked', sid => {
       this.sids.push(sid)
       this.refresh()
     })
-    this.$eventHub.$on('curated-group-checkbox-unchecked', sid => {
+    this.$eventHub.on('curated-group-checkbox-unchecked', sid => {
       this.sids = this.remove(this.sids, s => s !== sid)
       this.refresh()
     })
@@ -143,12 +143,12 @@ export default {
     toggle(checked) {
       if (checked) {
         this.sids = this.map(this.students, 'sid')
-        this.$eventHub.$emit('curated-group-select-all')
+        this.$eventHub.emit('curated-group-select-all')
         this.putFocusNextTick('curated-group-dropdown-select', 'button')
         this.alertScreenReader('All students on this page selected.')
       } else {
         this.sids = []
-        this.$eventHub.$emit('curated-group-deselect-all')
+        this.$eventHub.emit('curated-group-deselect-all')
         this.alertScreenReader('All students on this page deselected.')
       }
     },
@@ -166,7 +166,7 @@ export default {
         this.alertScreenReader(`${this.sids.length} student${this.sids.length === 1 ? '' : 's'} added to Curated Group "${group.name}".`)
         this.sids = []
         this.isSelectAllChecked = this.indeterminate = false
-        this.$eventHub.$emit('curated-group-deselect-all')
+        this.$eventHub.emit('curated-group-deselect-all')
         this.$ga.curatedEvent(group.id, group.name, `${this.contextDescription}: add students to Curated Group`)
       }
       const done = () => (this.isSaving = false)

--- a/src/components/curated/CuratedStudentCheckbox.vue
+++ b/src/components/curated/CuratedStudentCheckbox.vue
@@ -29,15 +29,15 @@ export default {
     }
   },
   created() {
-    this.$eventHub.$on('curated-group-select-all', () => (this.status = true))
-    this.$eventHub.$on(
+    this.$eventHub.on('curated-group-select-all', () => (this.status = true))
+    this.$eventHub.on(
       'curated-group-deselect-all',
       () => (this.status = false)
     )
   },
   methods: {
     toggle(checked) {
-      this.$eventHub.$emit(
+      this.$eventHub.emit(
         checked
           ? 'curated-group-checkbox-checked'
           : 'curated-group-checkbox-unchecked',

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -131,7 +131,7 @@ export default {
       this.putFocusNextTick('edit-note-subject')
       this.alertScreenReader('Edit note form is open.')
     })
-    this.$eventHub.$on('user-session-expired', () => {
+    this.$eventHub.on('user-session-expired', () => {
       this.onBoaSessionExpires()
     })
   },

--- a/src/components/note/create/CreateNoteModal.vue
+++ b/src/components/note/create/CreateNoteModal.vue
@@ -176,7 +176,7 @@ export default {
     this.setMode(this.isBatchFeature ? 'batch' : 'create')
     this.alertScreenReader(this.isBatchFeature ? 'Create batch note form is open.' : 'Create note form is open')
     this.putFocusNextTick(this.isBatchFeature ? 'create-note-add-student-input' : 'create-note-subject')
-    this.$eventHub.$on('user-session-expired', () => {
+    this.$eventHub.on('user-session-expired', () => {
       this.onBoaSessionExpires()
     })
   },

--- a/src/components/student/SortBy.vue
+++ b/src/components/student/SortBy.vue
@@ -75,7 +75,7 @@ export default {
   created() {
     this.optionGroups = this.getSortByOptionGroups(this.domain)
     this.sortByKey = this.domain === 'admitted_students' ? 'admitSortBy' : 'sortBy'
-    this.$eventHub.$on(`${this.sortByKey}-user-preference-change`, v => this.sortBy = v)
+    this.$eventHub.on(`${this.sortByKey}-user-preference-change`, v => this.sortBy = v)
     this.sortBy = this.$_.get(this.preferences, this.sortByKey)
     this.dropdownLabel = this.getSortByOptionLabel(this.optionGroups, this.sortBy)
     this.isReady = true

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -496,13 +496,13 @@ export default {
       this.creatingNoteEvent = null
     }
     if (this.$currentUser.canAccessAdvisingData) {
-      this.$eventHub.$on('begin-note-creation', event => {
+      this.$eventHub.on('begin-note-creation', event => {
         if (this.$_.includes(event.completeSidSet, this.student.sid)) {
           this.creatingNoteEvent = event
         }
       })
-      this.$eventHub.$on('advising-note-created', onCreateNewNote)
-      this.$eventHub.$on('batch-of-notes-created', noteIdsBySid => {
+      this.$eventHub.on('advising-note-created', onCreateNewNote)
+      this.$eventHub.on('batch-of-notes-created', noteIdsBySid => {
         const noteId = noteIdsBySid[this.student.sid]
         if (noteId) {
           getNote(noteId).then(note => onCreateNewNote(note))

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import core from './core'
 import Highcharts from 'highcharts'
 import HighchartsMore from 'highcharts/highcharts-more'
 import lodash from 'lodash'
+import mitt from 'mitt'
 import moment from 'moment-timezone'
 import router from './router'
 import store from './store'
@@ -46,8 +47,8 @@ Vue.directive('accessibleGrade', {
   bind: (el, binding) => el.innerHTML = binding.value && binding.value.replace('-', '&minus;').replace('+', '&plus;')
 })
 
-// Emit, and listen for, events via hub
-Vue.prototype.$eventHub = new Vue()
+// Emit and listen for events
+Vue.prototype.$eventHub = mitt()
 
 // Lodash
 Vue.prototype.$_ = _
@@ -87,7 +88,7 @@ axios.get(`${apiBaseUrl}/api/profile/my`).then(response => {
       setInterval(() => {
         axios.get(`${apiBaseUrl}/api/profile/my`).then(response => {
           if (!response.data.isAuthenticated) {
-            Vue.prototype.$eventHub.$emit('user-session-expired')
+            Vue.prototype.$eventHub.emit('user-session-expired')
           }
         })
       }, Vue.prototype.$config.pingFrequency)

--- a/src/store/modules/current-user-extras.ts
+++ b/src/store/modules/current-user-extras.ts
@@ -68,14 +68,14 @@ const mutations = {
     if (dropInAdvisorStatus) {
       dropInAdvisorStatus.available = available
       dropInAdvisorStatus.status = status
-      Vue.prototype.$eventHub.$emit('drop-in-status-change', dropInAdvisorStatus)
+      Vue.prototype.$eventHub.emit('drop-in-status-change', dropInAdvisorStatus)
     }
   },
   setIncludeAdmits: (state: any, includeAdmits: Boolean) => state.includeAdmits = includeAdmits,
   setUserPreference: (state: any, {key, value}) => {
     if (_.has(state.preferences, key)) {
       state.preferences[key] = value
-      Vue.prototype.$eventHub.$emit(`${key}-user-preference-change`, value)
+      Vue.prototype.$eventHub.emit(`${key}-user-preference-change`, value)
     } else {
       throw new TypeError('Invalid user preference type: ' + key)
     }

--- a/src/store/modules/note-edit-session.ts
+++ b/src/store/modules/note-edit-session.ts
@@ -158,7 +158,7 @@ const actions = {
         result[a.noteTemplateId ? 0 : 1].push(a)
         return result
       }, [[], []])
-      Vue.prototype.$eventHub.$emit('begin-note-creation', {
+      Vue.prototype.$eventHub.emit('begin-note-creation', {
         completeSidSet: state.completeSidSet,
         subject: state.model.subject
       })
@@ -173,7 +173,7 @@ const actions = {
         _.map(state.addedCuratedGroups, 'id')
       ).then(data => {
         const eventType = state.completeSidSet.length > 1 ? 'batch-of-notes-created' : 'advising-note-created'
-        Vue.prototype.$eventHub.$emit(eventType, data)
+        Vue.prototype.$eventHub.emit(eventType, data)
         resolve(data)
       })
     })

--- a/src/views/AdmitStudents.vue
+++ b/src/views/AdmitStudents.vue
@@ -146,8 +146,8 @@ export default {
     this.loadAdmits()
   },
   created() {
-    this.$eventHub.$off('admitSortBy-user-preference-change')
-    this.$eventHub.$on('admitSortBy-user-preference-change', sortBy => {
+    this.$eventHub.off('admitSortBy-user-preference-change')
+    this.$eventHub.on('admitSortBy-user-preference-change', sortBy => {
       this.sorting = true
       this.loadAdmits()
       if (!this.loading) {

--- a/src/views/Cohort.vue
+++ b/src/views/Cohort.vue
@@ -192,10 +192,10 @@ export default {
   },
   created() {
     const domain = this.$route.query.domain || 'default'
-    this.$eventHub.$on('cohort-apply-filters', () => {
+    this.$eventHub.on('cohort-apply-filters', () => {
       this.setPagination(1)
     })
-    this.$eventHub.$on(`${domain === 'admitted_students' ? 'admitSortBy' : 'sortBy'}-user-preference-change`, sortBy => {
+    this.$eventHub.on(`${domain === 'admitted_students' ? 'admitSortBy' : 'sortBy'}-user-preference-change`, sortBy => {
       if (!this.loading) {
         this.goToPage(1)
         this.$ga.cohortEvent(this.cohortId || '', this.cohortName || '', `Sort ${domain === 'admitted_students' ? 'admitted ' : ''}students by ${sortBy}`)

--- a/src/views/CuratedGroup.vue
+++ b/src/views/CuratedGroup.vue
@@ -96,7 +96,7 @@ export default {
     anchor: () => location.hash
   },
   created() {
-    this.$eventHub.$off('sortBy-user-preference-change')
+    this.$eventHub.off('sortBy-user-preference-change')
     this.setMode(undefined)
     this.init(parseInt(this.id)).then(group => {
       if (group) {
@@ -110,7 +110,7 @@ export default {
         this.$router.push({ path: '/404' })
       }
     })
-    this.$eventHub.$on('sortBy-user-preference-change', sortBy => {
+    this.$eventHub.on('sortBy-user-preference-change', sortBy => {
       if (!this.loading) {
         this.loadingStart()
         this.alertScreenReader(`Sorting students by ${sortBy}`)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3624

This event-listening pattern is one of the [few breaking changes on path to Vue 3 upgrade](https://medium.com/js-dojo/vue-3-new-features-breaking-changes-a-migration-path-e075a9b3d3d5). This change seems low risk and now is a good time for it, with full-regression testing scheduled on accessibility work. (Link above has details on "replace Event bus usages with mitt library.")