### PR TITLE
BOAC-1476, local env: sr-alert in dismissible footer was not updating

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,71 +2,20 @@
   <div id="app" class="fill-viewport">
     <VueAnnouncer />
     <router-view></router-view>
-    <div v-if="$config.fixedWarningOnAllPages && !hasUserDismissedFooterAlert" id="fixed_bottom">
-      <div id="fixed-warning-on-all-pages" class="d-flex fixed-bottom fixed-warning">
-        <div class="flex-grow-1">
-          <b>BOA {{ getBoaEnvLabel() }} Environment</b>
-        </div>
-        <div v-if="$config.isVueAppDebugMode">
-          {{ $_.get($announcer.data, 'content') }}
-        </div>
-        <div v-if="!$config.isVueAppDebugMode">
-          <span aria-live="polite" role="alert">{{ $config.fixedWarningOnAllPages }}</span>
-        </div>
-        <div class="btn-wrapper ml-0 align-top">
-          <b-btn
-            id="speedbird"
-            class="btn-dismiss pl-2 pt-0 text-white"
-            variant="link"
-            aria-label="Dismiss warning about BOA environment type"
-            @click="dismissTheWarning">
-            <font-awesome icon="plane-departure" />
-          </b-btn>
-        </div>
-      </div>
-    </div>
+    <DismissibleFooterAlert />
   </div>
 </template>
 
 <script>
-import Context from '@/mixins/Context'
+import DismissibleFooterAlert from '@/components/util/DismissibleFooterAlert'
 
 export default {
   name: 'App',
-  mixins: [Context],
-  methods: {
-    dismissTheWarning() {
-      this.dismissFooterAlert()
-      this.alertScreenReader('Warning message dismissed')
-    },
-    getBoaEnvLabel() {
-      return this.$config.ebEnvironment ? this.$config.ebEnvironment.replace('boac-', '').toUpperCase() : 'Test'
-    }
-  }
+  components: {DismissibleFooterAlert}
 }
 </script>
 
 <style>
 @import './assets/styles/bootstrap-overrides.css';
 @import './assets/styles/boac-global.css';
-</style>
-
-<style scoped>
-.btn-dismiss {
-  font-size: 14px;
-}
-.btn-wrapper {
-  line-height: inherit;
-  max-height: 16px;
-  vertical-align: top;
-}
-.fixed-warning {
-  background-color: #3b7ea5;
-  border-color: #000;
-  border-style: solid;
-  border-width: 2px 0 0;
-  color: #fff;
-  opacity: 0.8;
-  padding: 15px;
-}
 </style>

--- a/src/components/util/DismissibleFooterAlert.vue
+++ b/src/components/util/DismissibleFooterAlert.vue
@@ -1,0 +1,63 @@
+<template>
+  <div v-if="$config.fixedWarningOnAllPages && !hasUserDismissedFooterAlert" id="fixed_bottom">
+    <div id="fixed-warning-on-all-pages" class="d-flex fixed-bottom fixed-warning">
+      <div class="flex-grow-1">
+        <b>BOA {{ getBoaEnvLabel() }} Environment</b>
+      </div>
+      <div v-if="$config.isVueAppDebugMode">
+        {{ $_.get($announcer, 'data.content') }}
+      </div>
+      <div v-if="!$config.isVueAppDebugMode">
+        <span aria-live="polite" role="alert">{{ $config.fixedWarningOnAllPages }}</span>
+      </div>
+      <div class="btn-wrapper ml-0 align-top">
+        <b-btn
+          id="speedbird"
+          class="btn-dismiss pl-2 pt-0 text-white"
+          variant="link"
+          aria-label="Dismiss warning about BOA environment type"
+          @click="dismissTheWarning">
+          <font-awesome icon="plane-departure" />
+        </b-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Context from '@/mixins/Context'
+
+export default {
+  name: 'DismissibleFooterAlert',
+  mixins: [Context],
+  methods: {
+    dismissTheWarning() {
+      this.dismissFooterAlert()
+      this.alertScreenReader('Warning message dismissed')
+    },
+    getBoaEnvLabel() {
+      return this.$config.ebEnvironment ? this.$config.ebEnvironment.replace('boac-', '').toUpperCase() : 'Test'
+    }
+  }
+}
+</script>
+
+<style scoped>
+.btn-dismiss {
+  font-size: 14px;
+}
+.btn-wrapper {
+  line-height: inherit;
+  max-height: 16px;
+  vertical-align: top;
+}
+.fixed-warning {
+  background-color: #3b7ea5;
+  border-color: #000;
+  border-style: solid;
+  border-width: 2px 0 0;
+  color: #fff;
+  opacity: 0.8;
+  padding: 15px;
+}
+</style>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1476

When devs are running BOA in local env, sr-alerts are visible in footer. But, in App.vue, `$announcer.data.content` changes were not rendering. Having a dedicated component fixed the prob. Cleaner.