### PR TITLE
BOAC-1476, screen reader tells us if filter option is disabled

### DIFF
--- a/src/components/cohort/CohortPageHeader.vue
+++ b/src/components/cohort/CohortPageHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="!cohortId && totalStudentCount === undefined" class="mb-2">
+    <div v-if="!cohortId && totalStudentCount === undefined" class="pb-3">
       <h1
         id="create-cohort-h1"
         class="page-section-header"

--- a/src/components/cohort/FilterRow.vue
+++ b/src/components/cohort/FilterRow.vue
@@ -13,7 +13,6 @@
       v-if="isModifyingFilter && !isExistingFilter"
       :id="filterRowPrimaryDropdownId(filterRowIndex)"
       class="filter-row-column-01 mt-1 pr-2">
-      <span :id="`new-filter-${index}-label`" class="sr-only">Filter options:</span>
       <b-dropdown
         id="new-filter-button"
         :aria-labelledby="`new-filter-${index}-label`"
@@ -36,28 +35,35 @@
           :id="`primary-filter-group-${filterRowIndex}-${mIndex}`"
           :key="mIndex"
         >
-          <b-dropdown-item-button
-            v-for="(subCategory, sIndex) in category"
-            :id="`dropdown-primary-menuitem-${subCategory.key}-${filterRowIndex}`"
-            :key="subCategory.key"
-            :aria-disabled="subCategory.disabled"
-            class="font-size-16 h-100"
-            :class="{
-              'pb-1': mIndex === menu.length - 1 && sIndex === category.length - 1,
-              'pt-1': !mIndex && !sIndex
-            }"
-            :disabled="subCategory.disabled"
-            @click="onSelectFilter(subCategory)"
-            @focusin.prevent.stop
-            @mouseover.prevent.stop
-          >
-            <span
+          <div v-for="(subCategory, sIndex) in category" :key="subCategory.key">
+            <b-dropdown-item-button v-if="subCategory.disabled" :aria-disabled="true" class="sr-only sr-only-focusable">
+              '{{ subCategory.label.primary }}' is disabled.
+            </b-dropdown-item-button>
+            <b-dropdown-item-button
+              :id="`dropdown-primary-menuitem-${subCategory.key}-${filterRowIndex}`"
+              :aria-disabled="subCategory.disabled"
+              :aria-hidden="subCategory.disabled"
+              class="font-size-16 h-100"
               :class="{
-                'font-weight-light pointer-default text-muted': subCategory.disabled,
-                'font-weight-normal text-dark': !subCategory.disabled
+                'pb-1': mIndex === menu.length - 1 && sIndex === category.length - 1,
+                'pt-1': !mIndex && !sIndex
               }"
-              class="font-size-16">{{ subCategory.label.primary }}</span>
-          </b-dropdown-item-button>
+              :disabled="subCategory.disabled"
+              @click="onSelectFilter(subCategory)"
+              @focusin.prevent.stop
+              @mouseover.prevent.stop
+            >
+              <span
+                :class="{
+                  'font-weight-light pointer-default text-muted': subCategory.disabled,
+                  'font-weight-normal text-dark': !subCategory.disabled
+                }"
+                class="font-size-16"
+              >
+                {{ subCategory.label.primary }}
+              </span>
+            </b-dropdown-item-button>
+          </div>
           <b-dropdown-divider v-if="mIndex !== (menu.length - 1)" />
         </b-dropdown-group>
       </b-dropdown>
@@ -96,6 +102,9 @@
             <div v-for="(options, name, gIndex) in groupObjectsBy(filter.options, 'group')" :key="name">
               <b-dropdown-group :id="`${filter.label.primary}-dropdown-group-${name}`" :header="name">
                 <div v-for="(option, oIndex) in options" :key="option.key">
+                  <b-dropdown-item-button v-if="option.disabled" :aria-disabled="true" class="sr-only sr-only-focusable">
+                    '{{ option.name }}' is disabled.
+                  </b-dropdown-item-button>
                   <b-dropdown-item-button
                     v-if="option.value !== 'divider'"
                     :id="`${filter.label.primary}-${option.value}`"
@@ -124,6 +133,9 @@
           </div>
           <div v-if="!isGrouped(filter.options)">
             <div v-for="(option, fIndex) in filter.options" :key="option.key">
+              <b-dropdown-item-button v-if="option.disabled" :aria-disabled="true" class="sr-only sr-only-focusable">
+                '{{ option.name }}' is disabled.
+              </b-dropdown-item-button>
               <b-dropdown-item-button
                 v-if="option.value !== 'divider'"
                 :id="`${filter.label.primary}-${option.value}`"

--- a/src/views/Cohort.vue
+++ b/src/views/Cohort.vue
@@ -7,7 +7,7 @@
       <b-collapse
         id="show-hide-filters"
         v-model="showFilters"
-        class="mr-3 my-3">
+        class="mr-3 mb-3">
         <FilterRow
           v-for="(filter, index) in filters"
           :key="filterRowUniqueKey(filter, index)"


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-1476

If a button has `disabled=true` then focus cannot be put on it and its label is not announced. If we toss out `disabled=true` and have only `aria-disabled=true` then sighted users can click on it. This is a [known issue w.r.t screen-readers and disabled buttons](https://ux.stackexchange.com/questions/103239/should-disabled-elements-be-focusable-for-accessibility-purposes).

I have cheated a bit. If menu option is disabled then a sr-only `aria-disabled` button is put under the hood. The screen-reader voices the button content and sighted users see no difference.

