### PR TITLE
BOAC-3678, sr-only header above service-announce; refresh alert on dev-auth

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import axios from 'axios'
+import store from '@/store'
 import utils from '@/api/api-utils'
 import Vue from 'vue'
 
@@ -13,6 +14,7 @@ export function devAuthLogIn(uid: string, password: string) {
       Vue.prototype.$currentUser = response.data
       Vue.prototype.$core.initializeCurrentUser().then(_.noop)
       Vue.prototype.$core.mountGoogleAnalytics().then(_.noop)
+      store.dispatch('context/loadServiceAnnouncement').then(_.noop)
       return Vue.prototype.$currentUser
     }, error => error)
 }

--- a/src/layouts/shared/ServiceAnnouncement.vue
+++ b/src/layouts/shared/ServiceAnnouncement.vue
@@ -3,6 +3,7 @@
     <div
       v-if="!dismissedServiceAnnouncement"
       class="d-inline-block pt-3 pb-0 px-3 service-announcement w-100">
+      <div class="sr-only" role="heading">BOA Service Alert</div>
       <span
         id="service-announcement-banner"
         aria-live="polite"

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,6 +99,6 @@ axios.get(`${apiBaseUrl}/api/profile/my`).then(response => {
     Vue.prototype.$core.initializeCurrentUser().then(_.noop)
     Vue.prototype.$core.mountGoogleAnalytics().then(_.noop)
     // The following non-core function(s) do not involve "prototype" objects.
-    store.dispatch('context/loadServiceAnnouncement')
+    store.dispatch('context/loadServiceAnnouncement').then(_.noop)
   })
 })

--- a/src/store/modules/context.ts
+++ b/src/store/modules/context.ts
@@ -20,7 +20,7 @@ const mutations = {
   loadingComplete: (state: any) => (state.loading = false),
   loadingStart: (state: any) => (state.loading = true),
   restoreServiceAnnouncement: (state: any) => state.dismissedServiceAnnouncement = false,
-  storeAnnouncement: (state: any, data: any) => (state.announcement = data),
+  setAnnouncement: (state: any, data: any) => (state.announcement = data),
 }
 
 const actions = {
@@ -28,7 +28,7 @@ const actions = {
   dismissServiceAnnouncement: ({ commit }) => commit('dismissServiceAnnouncement'),
   loadingComplete: ({ commit }) => commit('loadingComplete'),
   loadingStart: ({ commit }) => commit('loadingStart'),
-  loadServiceAnnouncement: ({ commit }) => new Promise(() => getServiceAnnouncement().then(data => commit('storeAnnouncement', data))),
+  loadServiceAnnouncement: ({ commit }) => getServiceAnnouncement().then(data => commit('setAnnouncement', data)),
   restoreServiceAnnouncement: ({ commit }) => commit('restoreServiceAnnouncement')
 }
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3678

Fixed bug in which service-announcement is not loaded after dev-auth login. This would not impact real users because CAS login forces page refresh. Nonetheless, a bug. 