### PR TITLE
[QA] BOAC-3799 Fix unwanted in-component caching of note authors

### DIFF
--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -229,6 +229,7 @@ export default {
     },
     note() {
       this.resetAttachments()
+      this.setAuthor()
     }
   },
   created() {
@@ -237,7 +238,15 @@ export default {
   },
   methods: {
     setAuthor() {
-      const requiresLazyLoad = this.isOpen && (!this.$_.get(this.note, 'author.name') || !this.$_.get(this.note, 'author.role'))
+      const requiresLazyLoad = (
+        this.isOpen &&
+        (
+          !this.$_.get(this.note, 'author.name') ||
+          !this.$_.get(this.note, 'author.role') ||
+          this.$_.get(this.author, 'uid') !== this.$_.get(this.note, 'author.uid') ||
+          this.$_.get(this.author, 'sid') !== this.$_.get(this.note, 'author.sid')
+        )
+      )
       if (requiresLazyLoad) {
         const hasIdentifier = this.$_.get(this.note, 'author.uid') || this.$_.get(this.note, 'author.sid')
         if (hasIdentifier) {


### PR DESCRIPTION
I believe this clears up the blocker issue in https://jira.ets.berkeley.edu/jira/browse/BOAC-3799, but our whole caching setup for note authors has gotten pretty unruly and seems due for a rethink.