### PR TITLE
BOAC-3596, ALTER TABLE alerts ADD COLUMN deleted_at (and drop 'active' column)

### DIFF
--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -223,7 +223,7 @@ class CohortFilter(Base):
                 JOIN cohort_filters
                     ON alerts.sid = ANY(cohort_filters.sids)
                     AND alerts.key LIKE :key
-                    AND alerts.active IS TRUE
+                    AND alerts.deleted_at IS NULL
                     AND cohort_filters.owner_id = :owner_id
                 LEFT JOIN alert_views
                     ON alert_views.alert_id = alerts.id

--- a/scripts/db/migrate/2020/20201211-BOAC-3596/pre_deploy_01_put_deleted_at_on_alerts.sql
+++ b/scripts/db/migrate/2020/20201211-BOAC-3596/pre_deploy_01_put_deleted_at_on_alerts.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE alerts ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE alerts SET deleted_at = updated_at WHERE active IS FALSE;
+
+ALTER TABLE alerts DROP COLUMN active;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -60,7 +60,7 @@ CREATE TABLE alerts (
     alert_type character varying(80) NOT NULL,
     key character varying(255) NOT NULL,
     message text NOT NULL,
-    active boolean DEFAULT true NOT NULL,
+    deleted_at timestamp with time zone,
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL
 );

--- a/tests/test_api/test_reports_controller.py
+++ b/tests/test_api/test_reports_controller.py
@@ -64,14 +64,14 @@ class TestAlertsLogExport:
         assert 'csv' in response.content_type
         csv = str(response.data)
         for snippets in [
-            ['sid,term,key,type,active,created_at'],
-            ['11667051', 'Fall 2017', 'academic_standing,true'],
-            ['11667051', 'Spring 2017', 'late_assignment,true'],
-            ['11667051', 'Fall 2017', 'late_assignment,true'],
-            ['11667051', 'Fall 2017', 'missing_assignment,true'],
-            ['2345678901', 'Fall 2017', 'late_assignment,true'],
-            ['11667051', 'Fall 2017', 'midterm,true'],
-            ['3456789012', 'Fall 2017', 'no_activity,true'],
+            ['sid,term,key,type,is_active,active_duration_hours,created_at,deleted_at'],
+            ['11667051', 'Fall 2017', 'academic_standing'],
+            ['11667051', 'Spring 2017', 'late_assignment'],
+            ['11667051', 'Fall 2017', 'late_assignment'],
+            ['11667051', 'Fall 2017', 'missing_assignment'],
+            ['2345678901', 'Fall 2017', 'late_assignment'],
+            ['11667051', 'Fall 2017', 'midterm'],
+            ['3456789012', 'Fall 2017', 'no_activity'],
         ]:
             for snippet in snippets:
                 assert snippet in csv, f'Failed on snippet: {snippet}'

--- a/tests/test_models/test_alert.py
+++ b/tests/test_models/test_alert.py
@@ -136,7 +136,7 @@ class TestAlert:
         inactive_alert_1 = (Alert.query.
                             filter(Alert.sid == '11667051').
                             filter(Alert.key.startswith('2178_')).
-                            filter(Alert.active == False).  # noqa: E712
+                            filter(Alert.deleted_at != None).  # noqa: E711
                             first()
                             )
         inactivation_timestamp = inactive_alert_1.updated_at
@@ -146,7 +146,7 @@ class TestAlert:
         inactive_alert_2 = (Alert.query.
                             filter(Alert.sid == '3456789012').
                             filter(Alert.key.startswith('2178_%')).
-                            filter(Alert.active == False).  # noqa: E712
+                            filter(Alert.deleted_at != None).  # noqa: E711
                             first()
                             )
         assert inactive_alert_1.updated_at == inactivation_timestamp


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3596

To fulfill the request for "alert duration" (see latest comment in Jira above) we convert the 'active' column to 'deleted_at' and then do the math to determine: how long was it active?  The 'deleted_at' value will often be flipped off and on during `update_all_alerts` job and that's okay.