### PR TITLE
BOAC-3828, BOAC-3842, BOAC-3837: Displays relevant empty terms

### DIFF
--- a/boac/lib/berkeley.py
+++ b/boac/lib/berkeley.py
@@ -405,12 +405,12 @@ BERKELEY_DEPT_CODE_TO_PROGRAM_AFFILIATIONS = {
 
 def academic_year_for_term_name(term_name):
     if term_name:
-        match = re.match(r'\A(Spring|Summer|Fall|Winter) (\d{4})\Z', term_name)
+        match = re.match(r'\A(Spring|Summer|Fall) (\d{4})\Z', term_name)
         if not match or len(match.groups()) != 2:
-            return term_name
+            return None
         if match.group(1) == 'Fall':
-            return f'{term_name} - Summer {int(match.group(2)) + 1}'
-        return f'Fall {int(match.group(2)) - 1} - Summer {match.group(2)}'
+            return str(int(match.group(2)) + 1)
+        return match.group(2)
 
 
 def previous_term_id(term_id):

--- a/src/components/student/profile/StudentCourse.vue
+++ b/src/components/student/profile/StudentCourse.vue
@@ -3,12 +3,12 @@
     <div role="row" :class="{'student-course-expanded': detailsVisible}" class="student-course-row">
       <div role="cell" class="student-course-column-name">
         <b-btn
-          :id="`term-${term.termId}-course-${index}-toggle`"
-          v-b-toggle="`course-details-${term.termId}-${index}`"
+          :id="`term-${termId}-course-${index}-toggle`"
+          v-b-toggle="`course-details-${termId}-${index}`"
           class="d-flex flex-row-reverse justify-content-between student-course-collapse-button"
           variant="link"
           :aria-expanded="detailsVisible ? 'true' : 'false'"
-          :aria-controls="`course-details-${term.termId}-${index}`"
+          :aria-controls="`course-details-${termId}-${index}`"
           @click="detailsVisible = !detailsVisible"
         >
           <span class="mx-2">{{ course.displayName }}</span>
@@ -19,7 +19,7 @@
         </b-btn>
         <div
           v-if="course.waitlisted"
-          :id="`waitlisted-for-${term.termId}-${course.sections.length ? course.sections[0].ccn : course.displayName}`"
+          :id="`waitlisted-for-${termId}-${course.sections.length ? course.sections[0].ccn : course.displayName}`"
           class="red-flag-status text-uppercase font-size-14 mt-1"
         >
           Waitlisted
@@ -52,7 +52,7 @@
       </div>
     </div>
     <b-collapse
-      :id="`course-details-${term.termId}-${index}`"
+      :id="`course-details-${termId}-${index}`"
       role="row"
       class="student-course-details"
     >
@@ -65,9 +65,9 @@
           <span v-if="section.displayName">
             <span v-if="sectionIndex === 0"></span><!--
               --><router-link
-            v-if="section.isViewableOnCoursePage"
-            :id="`term-${term.termId}-section-${section.ccn}`"
-            :to="`/course/${term.termId}/${section.ccn}?u=${student.uid}`"
+              v-if="section.isViewableOnCoursePage"
+              :id="`term-${termId}-section-${section.ccn}`"
+              :to="`/course/${termId}/${section.ccn}?u=${student.uid}`"
             ><span class="sr-only">Link to {{ course.displayName }}, </span>{{ section.displayName }}</router-link><!--
               --><span v-if="!section.isViewableOnCoursePage">{{ section.displayName }}</span><!--
               --><span v-if="sectionIndex < course.sections.length - 1"> | </span><!--
@@ -184,7 +184,7 @@
                 </div>
               </td>
             </tr>
-            <tr v-if="$config.currentEnrollmentTermId === parseInt(term.termId)">
+            <tr v-if="$config.currentEnrollmentTermId === parseInt(termId, 10)">
               <th class="student-bcourses-legend" scope="row">
                 Last bCourses Activity
               </th>
@@ -232,9 +232,9 @@ export default {
       required: true,
       type: Object
     },
-    term: {
+    termId: {
       required: true,
-      type: Object
+      type: String
     }
   },
   data: () => ({
@@ -264,7 +264,7 @@ export default {
   vertical-align: top;
 }
 .student-bcourses-legend {
-  color: #999;
+  color: #666;
   font-weight: normal;
   white-space: nowrap;
   width: 15em;

--- a/src/components/student/profile/StudentEnrollmentTerm.vue
+++ b/src/components/student/profile/StudentEnrollmentTerm.vue
@@ -23,9 +23,9 @@
           <div role="columnheader" class="student-course-column-units">Units</div>
         </div>
       </div>
-      <div role="rowgroup">
+      <div role="rowgroup" class="pt-2">
         <div v-if="$_.isEmpty(term.enrollments)" role="row">
-          <div class="font-italic text-muted" role="cell">{{ `No ${term.termName} enrollments` }}</div>
+          <div class="student-term-empty" role="cell">{{ `No ${term.termName} enrollments` }}</div>
         </div>
         <div
           v-for="(course, courseIndex) in term.enrollments"
@@ -35,7 +35,7 @@
             :course="course"
             :index="courseIndex"
             :student="student"
-            :term="term"
+            :term-id="term.termId"
           />
         </div>
         <div>
@@ -99,7 +99,7 @@ export default {
   margin: 0;
 }
 .student-course-dropped {
-  color: #999;
+  color: #666;
   font-weight: 500;
   line-height: 1.1;
   padding: 8px 15px;
@@ -112,7 +112,7 @@ export default {
   padding: 8px 0;
 }
 .student-course-label {
-  color: #999;
+  color: #666;
   font-size: 12px;
   font-weight: 700;
   text-transform: uppercase;
@@ -126,6 +126,10 @@ export default {
 .student-term-current {
   border: 1px #999 solid!important;
   border-radius: 0;
+}
+.student-term-empty {
+  color: #666;
+  font-style: italic;
 }
 .student-term-header {
   align-items: baseline;

--- a/src/mixins/Berkeley.vue
+++ b/src/mixins/Berkeley.vue
@@ -139,6 +139,26 @@ export default {
           course.waitlisted || section.enrollmentStatus === 'W'
       })
     },
+    sisIdForTermName(termName) {
+      let words = _.words(termName)
+      const season = words[0]
+      const year = words[1]
+      let termId = ''
+      switch (season) {
+      case 'Fall':
+        termId = year.slice(0, 2) + year.slice(3, 4) + '8'
+        break
+      case 'Spring':
+        termId = year.slice(0, 2) + year.slice(3, 4) + '2'
+        break
+      case 'Summer':
+        termId = year.slice(0, 2) + year.slice(3, 4) + '5'
+        break
+      default:
+        break
+      }
+      return termId
+    },
     termNameForSisId(termId) {
       let termName = ''
       if (termId) {

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -168,25 +168,25 @@ class TestStudent:
         for student in [student_by_sid, student_by_uid]:
             assert len(student['enrollmentTerms']) == 4
             assert student['enrollmentTerms'][0]['termName'] == 'Spring 2018'
-            assert student['enrollmentTerms'][0]['academicYear'] == 'Fall 2017 - Summer 2018'
+            assert student['enrollmentTerms'][0]['academicYear'] == '2018'
             assert student['enrollmentTerms'][0]['enrolledUnits'] == 3
             assert student['enrollmentTerms'][0]['termGpa']['gpa'] == 2.9
             assert student['enrollmentTerms'][0]['academicStanding']['status'] == 'GST'
             assert len(student['enrollmentTerms'][0]['enrollments']) == 1
             assert student['enrollmentTerms'][1]['termName'] == 'Fall 2017'
-            assert student['enrollmentTerms'][1]['academicYear'] == 'Fall 2017 - Summer 2018'
+            assert student['enrollmentTerms'][1]['academicYear'] == '2018'
             assert student['enrollmentTerms'][1]['enrolledUnits'] == 12.5
             assert student['enrollmentTerms'][1]['termGpa']['gpa'] == 1.8
             assert student['enrollmentTerms'][1]['academicStanding']['status'] == 'PRO'
             assert len(student['enrollmentTerms'][1]['enrollments']) == 5
             assert student['enrollmentTerms'][2]['termName'] == 'Spring 2017'
-            assert student['enrollmentTerms'][2]['academicYear'] == 'Fall 2016 - Summer 2017'
+            assert student['enrollmentTerms'][2]['academicYear'] == '2017'
             assert student['enrollmentTerms'][2]['enrolledUnits'] == 10
             assert student['enrollmentTerms'][2]['termGpa']['gpa'] == 2.7
             assert len(student['enrollmentTerms'][2]['enrollments']) == 3
             assert student['enrollmentTerms'][2]['academicStanding']['status'] == 'GST'
             assert student['enrollmentTerms'][3]['termName'] == 'Spring 2016'
-            assert student['enrollmentTerms'][3]['academicYear'] == 'Fall 2015 - Summer 2016'
+            assert student['enrollmentTerms'][3]['academicYear'] == '2016'
             assert student['enrollmentTerms'][3]['enrolledUnits'] == 0
             assert student['enrollmentTerms'][3]['termGpa']['gpa'] == 3.8
             assert student['enrollmentTerms'][3]['academicStanding']['status'] == 'GST'

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -99,10 +99,10 @@ class TestAcademicYearForTermName:
     """Matches a term name to its academic year."""
 
     def test_academic_year_for_term_name(self):
-        assert berkeley.academic_year_for_term_name('Fall 1990') == 'Fall 1990 - Summer 1991'
-        assert berkeley.academic_year_for_term_name('Winter 1971') == 'Fall 1970 - Summer 1971'
-        assert berkeley.academic_year_for_term_name('Spring 2025') == 'Fall 2024 - Summer 2025'
-        assert berkeley.academic_year_for_term_name('Summer 2007') == 'Fall 2006 - Summer 2007'
+        assert berkeley.academic_year_for_term_name('Fall 1990') == '1991'
+        assert berkeley.academic_year_for_term_name('Winter 1971') is None
+        assert berkeley.academic_year_for_term_name('Spring 2025') == '2025'
+        assert berkeley.academic_year_for_term_name('Summer 2007') == '2007'
         assert berkeley.academic_year_for_term_name('') is None
-        assert berkeley.academic_year_for_term_name('Septober 2007') == 'Septober 2007'
-        assert berkeley.academic_year_for_term_name('Fall2007') == 'Fall2007'
+        assert berkeley.academic_year_for_term_name('Septober 2007') is None
+        assert berkeley.academic_year_for_term_name('Fall2007') is None


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3828
https://jira.ets.berkeley.edu/jira/browse/BOAC-3842
https://jira.ets.berkeley.edu/jira/browse/BOAC-3837

For every academic year in which the student is enrolled in at least one term, all three terms (Fall, Spring, and Summer) will be shown.  The current academic year will be expanded by default.