### PR TITLE
BOAC-3676, reasons are not topics; remove obsolete putFocus calls

### DIFF
--- a/src/components/admin/EditUserProfileModal.vue
+++ b/src/components/admin/EditUserProfileModal.vue
@@ -246,7 +246,6 @@ export default {
       this.showEditUserModal = false
     },
     openEditUserModal() {
-      this.putFocusNextTick(this.profile.id ? 'modal-header' : 'uid-input')
       this.userProfile = {
         id: this.profile.id,
         uid: this.profile.uid,

--- a/src/components/appointment/AppointmentCancellationModal.vue
+++ b/src/components/appointment/AppointmentCancellationModal.vue
@@ -148,7 +148,6 @@ export default {
   },
   created() {
     this.showCancellationModal = this.showModal
-    this.putFocusNextTick('cancellation-reason')
     this.alertScreenReader('Cancel appointment modal is open')
   },
   methods: {

--- a/src/components/appointment/AppointmentTopics.vue
+++ b/src/components/appointment/AppointmentTopics.vue
@@ -15,7 +15,7 @@
             v-model="selected"
             :disabled="disabled"
             role="listbox"
-            aria-label="Use up and down arrows to review topics. Hit enter to select a topic."
+            aria-label="Use up and down arrows to review reasons. Hit enter to select a topic."
             @input="add"
           >
             <template v-slot:first>

--- a/src/components/appointment/AppointmentUpdateModal.vue
+++ b/src/components/appointment/AppointmentUpdateModal.vue
@@ -11,7 +11,7 @@
   >
     <div>
       <ModalHeader text="Drop-in Update" />
-      <div id="appointment-update-modal-body" class="modal-body">
+      <div class="modal-body">
         {{ appointmentUpdate.statusBy.name }} recently updated the status of this drop-in appointment to
         <strong>{{ appointmentUpdate.status.replace('_', ' ') }}</strong>.
       </div>
@@ -63,7 +63,6 @@ export default {
   created() {
     this.showUpdateModal = this.showModal
     this.alertScreenReader('Drop-in Update')
-    this.putFocusNextTick('appointment-update-modal-body')
   }
 }
 </script>

--- a/src/components/appointment/CreateAppointmentModal.vue
+++ b/src/components/appointment/CreateAppointmentModal.vue
@@ -191,7 +191,6 @@ export default {
     this.reset()
     this.updateAvailableAdvisors()
     this.showCreateAppointmentModal = this.showModal
-    this.putFocusNextTick('appointment-student-input')
     this.alertScreenReader('Create appointment form is open')
   },
   methods: {

--- a/src/components/appointment/LogResolvedIssueModal.vue
+++ b/src/components/appointment/LogResolvedIssueModal.vue
@@ -147,7 +147,6 @@ export default {
   created() {
     this.reset()
     this.showLogResolvedIssueModal = this.showModal
-    this.putFocusNextTick('log-resolved-issue-student-input')
     this.alertScreenReader('Log resolved issue form is open')
   },
   methods: {

--- a/src/components/topics/EditTopicModal.vue
+++ b/src/components/topics/EditTopicModal.vue
@@ -135,7 +135,6 @@ export default {
   },
   created() {
     this.showEditTopicModal = true
-    this.putFocusNextTick('topic-label')
   },
   methods: {
     cancel() {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3676

These `putFocus` calls are superseded by the recent `@shown=putFocus('modal-header')` fix.