### PR TITLE
BOAC-3819, no more concurrent jobs in travis.yml; use tox --parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,14 @@ install:
   - npm install
   - pip3 install tox
 
-jobs:
-  include:
-    - stage: test
-      script:
-        - psql -c 'create database boac_test;' -U postgres
-        - psql -c 'create database boac_loch_test;' -U postgres
-        - psql boac_test -c 'create extension pg_trgm;' -U postgres
-        - psql boac_test -c 'create role boac superuser login; alter schema public owner to boac;' -U postgres
-        - psql boac_loch_test -c 'create extension pg_trgm;' -U postgres
-        - psql boac_loch_test -c 'alter schema public owner to boac;' -U postgres
-        - pip install google-compute-engine
-        - pip3 install -r requirements.txt
-        - pip3 install pandas==0.23.3
-        - tox -e test || travis_terminate 1;
-    - # Python lint
-      script: tox -e lint-py
-    - # Vue.js lint
-      script: tox -e lint-vue
-    - # Vue.js build to verify TypeScript
-      script: tox -e build-vue
+script:
+  - psql -c 'create database boac_test;' -U postgres
+  - psql -c 'create database boac_loch_test;' -U postgres
+  - psql boac_test -c 'create extension pg_trgm;' -U postgres
+  - psql boac_test -c 'create role boac superuser login; alter schema public owner to boac;' -U postgres
+  - psql boac_loch_test -c 'create extension pg_trgm;' -U postgres
+  - psql boac_loch_test -c 'alter schema public owner to boac;' -U postgres
+  - pip install google-compute-engine
+  - pip3 install -r requirements.txt
+  - pip3 install pandas==0.23.3
+  - tox --parallel || travis_terminate 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pytz==2020.1
 # For testing
 
 moto==1.3.6
-pytest==6.0.1
-pytest-flask==1.0.0
-responses==0.11.0
-tox==3.19.0
+pytest==6.2.1
+pytest-flask==1.1.0
+responses==0.12.1
+tox==3.21.1


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3819

Travis concurrency is not free and `tox --parallel` is.