### PR TITLE
BOAC-3912, keypress.enter.prevent=noop for input-autocomplete widget

### DIFF
--- a/src/components/search/InputAutocomplete.vue
+++ b/src/components/search/InputAutocomplete.vue
@@ -8,6 +8,7 @@
     :placeholder="placeholder"
     :search="search"
     :type="type"
+    @keypress.enter.prevent="$_.noop"
     @submit="handleSubmit"
   />
 </template>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3912

The existing `@submit` will handle key-press events.