### PR TITLE
BOAC-3965, authorized_user table gets degree_progress_permission (read, read_write)

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -489,6 +489,7 @@ def _update_or_create_authorized_user(profile, include_deleted=False):
     user_id = profile.get('id')
     can_access_canvas_data = to_bool_or_none(profile.get('canAccessCanvasData'))
     can_access_advising_data = to_bool_or_none(profile.get('canAccessAdvisingData'))
+    degree_progress_permission = profile.get('degreeProgressPermission')
     is_admin = to_bool_or_none(profile.get('isAdmin'))
     is_blocked = to_bool_or_none(profile.get('isBlocked'))
     if user_id:
@@ -496,6 +497,7 @@ def _update_or_create_authorized_user(profile, include_deleted=False):
             user_id=user_id,
             can_access_advising_data=can_access_advising_data,
             can_access_canvas_data=can_access_canvas_data,
+            degree_progress_permission=degree_progress_permission,
             is_admin=is_admin,
             is_blocked=is_blocked,
             include_deleted=include_deleted,
@@ -514,6 +516,7 @@ def _update_or_create_authorized_user(profile, include_deleted=False):
                 is_blocked=is_blocked,
                 can_access_advising_data=can_access_advising_data,
                 can_access_canvas_data=can_access_canvas_data,
+                degree_progress_permission=degree_progress_permission,
             )
         else:
             raise errors.BadRequestError('Invalid UID')

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -127,6 +127,32 @@ def ce3_required(func):
     return _ce3_required
 
 
+def can_edit_degree_progress(func):
+    @wraps(func)
+    def _qualifies(*args, **kw):
+        is_authorized = app.config['FEATURE_FLAG_DEGREE_CHECK'] and current_user.is_authenticated \
+            and current_user.can_edit_degree_progress
+        if is_authorized or _api_key_ok():
+            return func(*args, **kw)
+        else:
+            app.logger.warning(f'Unauthorized request to {request.path}')
+            return app.login_manager.unauthorized()
+    return _qualifies
+
+
+def can_read_degree_progress(func):
+    @wraps(func)
+    def _qualifies(*args, **kw):
+        is_authorized = app.config['FEATURE_FLAG_DEGREE_CHECK'] and current_user.is_authenticated \
+            and current_user.can_read_degree_progress
+        if is_authorized or _api_key_ok():
+            return func(*args, **kw)
+        else:
+            app.logger.warning(f'Unauthorized request to {request.path}')
+            return app.login_manager.unauthorized()
+    return _qualifies
+
+
 def director_advising_data_access_required(func):
     @wraps(func)
     def _director_advising_data_access_required(*args, **kw):

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -112,6 +112,7 @@ _test_users = [
         'inDemoMode': False,
         'canAccessAdvisingData': True,
         'canAccessCanvasData': True,
+        'degreeProgressPermission': 'read_write',
         'firstName': 'Milicent',
         'lastName': 'Balthazar',
     },
@@ -198,6 +199,7 @@ _test_users = [
         'inDemoMode': False,
         'canAccessAdvisingData': True,
         'canAccessCanvasData': False,
+        'degreeProgressPermission': 'read',
     },
     {
         'uid': '1015674',
@@ -505,6 +507,7 @@ def _create_users():
                 in_demo_mode=test_user['inDemoMode'],
                 can_access_advising_data=test_user['canAccessAdvisingData'],
                 can_access_canvas_data=test_user['canAccessCanvasData'],
+                degree_progress_permission=test_user.get('degreeProgressPermission'),
                 search_history=test_user.get('searchHistory', []),
             )
             if test_user.get('deleted'):

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -229,5 +229,6 @@ DROP TYPE IF EXISTS public.appointment_types;
 DROP TYPE IF EXISTS public.cohort_filter_event_types;
 DROP TYPE IF EXISTS public.cohort_domain_types;
 DROP TYPE IF EXISTS public.drop_in_advisor_status_types;
+DROP TYPE IF EXISTS public.generic_permission_types;
 DROP TYPE IF EXISTS public.university_dept_member_role_types;
 DROP TYPE IF EXISTS public.weekday_types;

--- a/scripts/db/migrate/2021/20210406-BOAC-3965/pre_deploy_01_add_degree_progress_permission.sql
+++ b/scripts/db/migrate/2021/20210406-BOAC-3965/pre_deploy_01_add_degree_progress_permission.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE TYPE generic_permission_types AS ENUM ('read', 'read_write');
+
+ALTER TABLE authorized_users ADD COLUMN degree_progress_permission generic_permission_types;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -250,19 +250,24 @@ CREATE INDEX appointments_read_viewer_id_idx ON appointments_read USING btree (v
 
 --
 
+CREATE TYPE generic_permission_types AS ENUM ('read', 'read_write');
+
+--
+
 CREATE TABLE authorized_users (
-    id integer NOT NULL,
-    uid character varying(255) NOT NULL,
-    is_admin boolean,
-    in_demo_mode boolean DEFAULT false NOT NULL,
     can_access_advising_data boolean DEFAULT true NOT NULL,
     can_access_canvas_data boolean DEFAULT true NOT NULL,
-    search_history CHARACTER VARYING[],
     created_at timestamp with time zone NOT NULL,
     created_by character varying(255) NOT NULL,
-    updated_at timestamp with time zone NOT NULL,
+    degree_progress_permission generic_permission_types,
     deleted_at timestamp with time zone,
-    is_blocked boolean DEFAULT false NOT NULL
+    id integer NOT NULL,
+    in_demo_mode boolean DEFAULT false NOT NULL,
+    is_admin boolean,
+    is_blocked boolean DEFAULT false NOT NULL,
+    search_history CHARACTER VARYING[],
+    uid character varying(255) NOT NULL,
+    updated_at timestamp with time zone NOT NULL
 );
 ALTER TABLE authorized_users OWNER TO boac;
 CREATE SEQUENCE authorized_users_id_seq

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -60,16 +60,20 @@ class TestUserProfile:
         api_json = self._api_my_profile(client)
         assert api_json['isAuthenticated'] is False
         assert not api_json['uid']
+        assert api_json['canEditDegreeProgress'] is None
+        assert api_json['canReadDegreeProgress'] is None
 
-    def test_includes_canvas_profile_if_available(self, client, fake_auth):
+    def test_current_user_profile(self, client, fake_auth):
         """Includes user profile info from Canvas."""
-        fake_auth.login(admin_uid)
+        fake_auth.login(l_s_college_drop_in_advisor_uid)
         api_json = self._api_my_profile(client)
         assert api_json['isAuthenticated'] is True
-        assert api_json['uid'] == admin_uid
+        assert api_json['uid'] == l_s_college_drop_in_advisor_uid
         assert 'csid' in api_json
         assert 'firstName' in api_json
         assert 'lastName' in api_json
+        assert api_json['canEditDegreeProgress'] is True
+        assert api_json['canReadDegreeProgress'] is True
 
     def test_user_with_no_dept_membership(self, client, fake_auth):
         """Returns zero or more departments."""
@@ -85,6 +89,8 @@ class TestUserProfile:
         assert api_json['isAdmin'] is False
         assert api_json['canAccessAdvisingData'] is True
         assert api_json['canAccessCanvasData'] is False
+        assert api_json['canEditDegreeProgress'] is False
+        assert api_json['canReadDegreeProgress'] is True
         assert not api_json['dropInAdvisorStatus']
         departments = api_json['departments']
         assert len(departments) == 1
@@ -115,9 +121,12 @@ class TestUserProfile:
     def test_other_user_profile(self, client, fake_auth):
         fake_auth.login(admin_uid)
         response = client.get('/api/profile/6446')
-        assert response.json['uid'] == '6446'
-        assert 'firstName' in response.json
-        assert 'lastName' in response.json
+        api_json = response.json
+        assert api_json['uid'] == '6446'
+        assert 'firstName' in api_json
+        assert 'lastName' in api_json
+        assert 'canEditDegreeProgress' not in api_json
+        assert 'canReadDegreeProgress' not in api_json
 
     def test_other_user_profile_not_found(self, client, fake_auth):
         fake_auth.login(admin_uid)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3965

The `authorized_users` table is modified as below and yet the `user_session` object has aliased properties: `can_edit_degree_progress` and `can_read_degree_progress`.

```
CREATE TYPE generic_permission_types AS ENUM ('read', 'read_write');
ALTER TABLE authorized_users ADD COLUMN degree_progress_permission generic_permission_types;
```
Constructive criticism is welcome.
