### PR TITLE
BOAC-3967, cache_utils + create_or_restore_user() will keep custom degree-progress perm

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -178,6 +178,7 @@ def refresh_department_memberships():
                 created_by='0',
                 can_access_advising_data=membership['can_access_advising_data'],
                 can_access_canvas_data=membership['can_access_canvas_data'],
+                degree_progress_permission='read' if dept.dept_code == 'COENG' else None,
             )
             if user:
                 UniversityDeptMember.create_or_update_membership(

--- a/boac/api/degree_progress_controller.py
+++ b/boac/api/degree_progress_controller.py
@@ -23,7 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 from boac.api.errors import BadRequestError, ForbiddenRequestError
-from boac.api.util import advisor_required
+from boac.api.util import can_edit_degree_progress
 from boac.lib.berkeley import dept_codes_where_advising
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param
@@ -33,7 +33,7 @@ from flask_login import current_user
 
 
 @app.route('/api/degree/new', methods=['POST'])
-@advisor_required
+@can_edit_degree_progress
 def create_degree():
     params = request.get_json()
     name = get_param(params, 'degreeTemplateName', None)

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -161,7 +161,8 @@ class AuthorizedUser(Base):
                 existing_user.can_access_advising_data = can_access_advising_data
                 existing_user.can_access_canvas_data = can_access_canvas_data
                 existing_user.created_by = created_by
-                existing_user.degree_progress_permission = degree_progress_permission
+                if not existing_user.degree_progress_permission:
+                    existing_user.degree_progress_permission = degree_progress_permission
                 existing_user.deleted_at = None
             # If the user currently exists in a non-deleted state, attributes passed in as True
             # should replace existing attributes set to False, but not vice versa.
@@ -170,7 +171,7 @@ class AuthorizedUser(Base):
                     existing_user.can_access_advising_data = True
                 if can_access_canvas_data and not existing_user.can_access_canvas_data:
                     existing_user.can_access_canvas_data = True
-                if degree_progress_permission is not None:
+                if not existing_user.degree_progress_permission:
                     existing_user.degree_progress_permission = degree_progress_permission
                 if is_admin and not existing_user.is_admin:
                     existing_user.is_admin = True

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -112,7 +112,6 @@ _test_users = [
         'inDemoMode': False,
         'canAccessAdvisingData': True,
         'canAccessCanvasData': True,
-        'degreeProgressPermission': 'read_write',
         'firstName': 'Milicent',
         'lastName': 'Balthazar',
     },
@@ -163,6 +162,7 @@ _test_users = [
         'inDemoMode': False,
         'canAccessAdvisingData': True,
         'canAccessCanvasData': True,
+        'degreeProgressPermission': 'read_write',
         'firstName': 'Joni',
         'lastName': 'Mitchell',
     },
@@ -191,6 +191,7 @@ _test_users = [
         'inDemoMode': False,
         'canAccessAdvisingData': False,
         'canAccessCanvasData': True,
+        'degreeProgressPermission': 'read_write',
     },
     {
         'uid': '6972201',
@@ -317,7 +318,7 @@ _university_depts = {
                 'automate_membership': True,
             },
             {
-                'uid': '13',
+                'uid': no_calnet_record_for_uid,
                 'role': 'advisor',
                 'isDropInAdvisor': False,
                 'automate_membership': True,

--- a/fixtures/loch/loch.sql
+++ b/fixtures/loch/loch.sql
@@ -657,7 +657,8 @@ VALUES
 ('100100600', '242881', 'MAJ', 'Major Advisor', 'ADV', 'Advisor Only', 'UCLS', 'Undergrad Letters & Science', 'UC_CS_AA_CURRICULAR_ADVISOR'),
 ('600500400', '1133397', 'MIN', 'Minor Advisor', 'ADV', 'Advisor Only', 'UCLS', 'Undergrad Letters & Science', 'UC_CS_AA_CURRICULAR_ADVISOR'),
 ('111111111', '1', NULL, NULL, NULL, NULL, NULL, NULL, 'UC_CS_AA_CURRICULAR_ADVISOR'),
-('222222222', '2', NULL, NULL, NULL, NULL, 'UBUS', 'Undergrad Business', 'UC_CS_AA_CO_CURRICULAR_ADVISOR');
+('222222222', '2', NULL, NULL, NULL, NULL, 'UBUS', 'Undergrad Business', 'UC_CS_AA_CO_CURRICULAR_ADVISOR'),
+('333333333', '1234567', 'COLL', 'College Advisor', 'ADV', 'Advisor Only', 'UCOE', 'Undergrad Engineering', 'UC_CS_AA_ADVISOR_VIEW');
 
 INSERT INTO boac_advisor.advisor_students
 (advisor_sid, student_sid, student_uid, advisor_type_code, advisor_type, academic_program_code, academic_program, academic_plan_code, academic_plan)

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -66,10 +66,10 @@ class TestUserProfile:
     def test_current_user_profile(self, client, fake_auth):
         """Includes user profile info from Canvas."""
         with override_config(app, 'FEATURE_FLAG_DEGREE_CHECK', True):
-            fake_auth.login(l_s_college_drop_in_advisor_uid)
+            fake_auth.login(coe_advisor_uid)
             api_json = self._api_my_profile(client)
             assert api_json['isAuthenticated'] is True
-            assert api_json['uid'] == l_s_college_drop_in_advisor_uid
+            assert api_json['uid'] == coe_advisor_uid
             assert 'csid' in api_json
             assert 'firstName' in api_json
             assert 'lastName' in api_json

--- a/tests/test_externals/test_data_loch.py
+++ b/tests/test_externals/test_data_loch.py
@@ -37,7 +37,7 @@ class TestDataLoch:
     def test_get_advisor_uids_for_affiliations(self, app):
         """Returns one or more rows for each advisor in the program."""
         advisors = data_loch.get_advisor_uids_for_affiliations('UCOE', None)
-        assert len(advisors) == 6
+        assert len(advisors) == 7
 
         uids = [a['uid'] for a in advisors]
         advisors_by_uid = {uid: [a for a in advisors if a['uid'] == uid] for uid in uids}

--- a/tests/test_models/test_university_dept.py
+++ b/tests/test_models/test_university_dept.py
@@ -33,11 +33,11 @@ class TestUniversityDept:
         """Aggregates role and privilege data from the loch for each of its members."""
         dept_coe = UniversityDept.query.filter_by(dept_code='COENG').first()
         advisors = dept_coe.memberships_from_loch()
-        assert len(advisors) == 5
+        assert len(advisors)
         uids = [a['uid'] for a in advisors]
         advisors_by_uid = {uid: [a for a in advisors if a['uid'] == uid] for uid in uids}
-        assert advisors_by_uid['13'] == [{'uid': '13', 'can_access_advising_data': True, 'can_access_canvas_data': False}]
-        assert advisors_by_uid['90412'] == [{'uid': '90412', 'can_access_advising_data': True, 'can_access_canvas_data': True}]
-        assert advisors_by_uid['1022796'] == [{'uid': '1022796', 'can_access_advising_data': False, 'can_access_canvas_data': False}]
-        assert advisors_by_uid['1133399'] == [{'uid': '1133399', 'can_access_advising_data': True, 'can_access_canvas_data': True}]
-        assert advisors_by_uid['211159'] == [{'uid': '211159', 'can_access_advising_data': True, 'can_access_canvas_data': True}]
+        assert advisors_by_uid.get('13') == [{'uid': '13', 'can_access_advising_data': True, 'can_access_canvas_data': False}]
+        assert advisors_by_uid.get('90412') == [{'uid': '90412', 'can_access_advising_data': True, 'can_access_canvas_data': True}]
+        assert advisors_by_uid.get('1022796') == [{'uid': '1022796', 'can_access_advising_data': False, 'can_access_canvas_data': False}]
+        assert advisors_by_uid.get('1133399') == [{'uid': '1133399', 'can_access_advising_data': True, 'can_access_canvas_data': True}]
+        assert advisors_by_uid.get('211159') == [{'uid': '211159', 'can_access_advising_data': True, 'can_access_canvas_data': True}]


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-3967

BOA's test data is becoming technical debt. Add a mock user and you get a handful of failures. 