### PR TITLE
BOAC-4028, fix rename validation: int(id) needed when comparing ids

### DIFF
--- a/boac/api/degree_progress_controller.py
+++ b/boac/api/degree_progress_controller.py
@@ -122,6 +122,7 @@ def get_degree_templates():
 @can_edit_degree_progress
 def update_degree_template(template_id):
     name = request.get_json().get('name')
+    template_id = int(template_id)
     _validate_template_upsert(name=name, template_id=template_id)
     template = DegreeProgressTemplate.update(name=name, template_id=template_id)
     return tolerant_jsonify(template.to_api_json())

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,7 +11,7 @@ import Course from '@/views/Course.vue'
 import CreateCuratedGroup from '@/views/CreateCuratedGroup.vue'
 import CreateDegreeTemplate from '@/views/degree/CreateDegreeTemplate.vue'
 import CuratedGroup from '@/views/CuratedGroup.vue'
-import DegreeChecks from '@/views/degree/DegreeChecks.vue'
+import ManageDegreeChecks from '@/views/degree/ManageDegreeChecks.vue'
 import DegreeTemplate from '@/views/degree/DegreeTemplate.vue'
 import DropInAdvisorHome from '@/views/DropInAdvisorHome.vue'
 import DropInDesk from '@/views/DropInDesk.vue'
@@ -239,7 +239,7 @@ const router = new Router({
       children: [
         {
           path: '/degrees',
-          component: DegreeChecks,
+          component: ManageDegreeChecks,
           meta: {
             title: 'Managing Degree Checks'
           }

--- a/src/views/degree/ManageDegreeChecks.vue
+++ b/src/views/degree/ManageDegreeChecks.vue
@@ -192,7 +192,7 @@ import Util from '@/mixins/Util'
 import {deleteDegreeTemplate, getDegreeTemplates, updateDegreeTemplate} from '@/api/degree'
 
 export default {
-  name: 'DegreeChecks',
+  name: 'ManageDegreeChecks',
   components: {AreYouSureModal, CloneTemplateModal, Spinner},
   mixins: [Context, Loading, Util],
   data: () => ({


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4028

And I renamed `DegreeChecks.vue` to `ManageDegreeChecks.vue`.