### PR TITLE
BOAC-4067, fix server-side logic in get_unassigned; keep 'unassigned' courses in vuex store

### DIFF
--- a/boac/models/degree_progress_category.py
+++ b/boac/models/degree_progress_category.py
@@ -192,13 +192,16 @@ class DegreeProgressCategory(Base):
 
     def to_api_json(self):
         unit_requirements_json = [m.unit_requirement.to_api_json() for m in (self.unit_requirements or [])]
+        fulfilled_by = []
+        for c in DegreeProgressCourse.get_fulfillments(self.id):
+            fulfilled_by.append(c.to_api_json())
         return {
             'id': self.id,
             'categoryType': self.category_type,
             'courseUnits': _range_to_string(self.course_units),
             'createdAt': _isoformat(self.created_at),
             'description': self.description,
-            'fulfilledBy': [c.to_api_json() for c in DegreeProgressCourse.get_fulfillments(self.id)],
+            'fulfilledBy': fulfilled_by,
             'name': self.name,
             'parentCategoryId': self.parent_category_id,
             'position': self.position,

--- a/boac/models/degree_progress_course.py
+++ b/boac/models/degree_progress_course.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from boac import db, std_commit
 from boac.lib.berkeley import term_name_for_sis_id
+from boac.lib.util import is_int
 from boac.models.base import Base
 from dateutil.tz import tzutc
 
@@ -99,18 +100,18 @@ class DegreeProgressCourse(Base):
             section_id=section_id,
             sid=sid,
             term_id=term_id,
-            units=units,
+            units=units if is_int(units) else 0,  # TODO: Is units='E' valid? Can units value be non-numeric?
         )
         db.session.add(course)
         return course
 
     @classmethod
-    def get_fulfillments(cls, category_id):
-        return cls.query.filter_by(category_id=category_id).all()
+    def find_by_sid(cls, sid):
+        return cls.query.filter_by(sid=sid).all()
 
     @classmethod
-    def get_unassigned_by_sid(cls, sid):
-        return cls.query.filter_by(sid=sid).all()
+    def get_fulfillments(cls, category_id):
+        return cls.query.filter_by(category_id=category_id).all()
 
     @classmethod
     def update(

--- a/src/mixins/DegreeEditSession.vue
+++ b/src/mixins/DegreeEditSession.vue
@@ -28,6 +28,7 @@ export default {
       'disableButtons',
       'editMode',
       'templateId',
+      'unassignedCourses',
       'unitRequirements',
       'updatedAt',
       'updatedBy'
@@ -35,12 +36,14 @@ export default {
   },
   methods: {
     ...mapActions('degreeEditSession', [
+      'assignCourseToCategory',
       'createCategory',
       'createUnitRequirement',
       'deleteCategory',
       'deleteUnitRequirement',
       'init',
       'loadTemplate',
+      'refreshUnassignedCourses',
       'setDisableButtons',
       'setEditMode',
       'updateCategory',


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4067

Keeping `unassignedCourses` in vuex story allows us to refresh page content behind the scenes.