### PR TITLE
BOAC-4164, speed up page load of /degrees and /degree/history with slimmer queries

### DIFF
--- a/boac/api/degree_progress_controller.py
+++ b/boac/api/degree_progress_controller.py
@@ -101,7 +101,7 @@ def get_degree_template(template_id):
 @app.route('/api/degree/templates')
 @can_read_degree_progress
 def get_degree_templates():
-    return tolerant_jsonify([template.to_api_json() for template in DegreeProgressTemplate.get_all_templates()])
+    return tolerant_jsonify(DegreeProgressTemplate.get_all_templates())
 
 
 @app.route('/api/degree/<template_id>/update', methods=['POST'])

--- a/boac/api/degree_progress_student_controller.py
+++ b/boac/api/degree_progress_student_controller.py
@@ -25,12 +25,13 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from boac.api.degree_progress_api_utils import clone_degree_template
 from boac.api.errors import BadRequestError, ResourceNotFoundError
-from boac.api.util import can_edit_degree_progress, can_read_degree_progress, get_degree_checks_json
+from boac.api.util import can_edit_degree_progress, can_read_degree_progress
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param, is_int, to_int_or_none
 from boac.models.degree_progress_category import DegreeProgressCategory
 from boac.models.degree_progress_course import DegreeProgressCourse
 from boac.models.degree_progress_note import DegreeProgressNote
+from boac.models.degree_progress_template import DegreeProgressTemplate
 from flask import current_app as app, request
 from flask_login import current_user
 
@@ -144,7 +145,7 @@ def assign_course(course_id):
 @app.route('/api/degrees/student/<sid>')
 @can_read_degree_progress
 def get_degree_checks(sid):
-    return tolerant_jsonify(get_degree_checks_json(sid))
+    return tolerant_jsonify(DegreeProgressTemplate.find_by_sid(student_sid=sid))
 
 
 @app.route('/api/degree/course/<course_id>/update', methods=['POST'])

--- a/boac/api/student_controller.py
+++ b/boac/api/student_controller.py
@@ -24,11 +24,12 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ResourceNotFoundError
-from boac.api.util import advisor_required, get_degree_checks_json, put_notifications
+from boac.api.util import advisor_required, put_notifications
 from boac.externals.data_loch import get_students_by_sids, match_students_by_name_or_sid, query_historical_sids
 from boac.lib.http import tolerant_jsonify
 from boac.merged.student import get_distinct_sids, get_student_and_terms_by_sid, get_student_and_terms_by_uid, \
     query_students
+from boac.models.degree_progress_template import DegreeProgressTemplate
 from flask import current_app as app, request
 from flask_login import current_user, login_required
 
@@ -135,4 +136,4 @@ def _student_search_result(s):
 
 def _put_degree_checks_json(student):
     if 'coeProfile' in student and current_user.can_read_degree_progress:
-        student['degreeChecks'] = get_degree_checks_json(sid=student['sid'])
+        student['degreeChecks'] = DegreeProgressTemplate.find_by_sid(student_sid=student['sid'])

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -38,12 +38,10 @@ from boac.merged.student import get_academic_standing_by_sid, get_historical_stu
 from boac.models.alert import Alert
 from boac.models.authorized_user_extension import DropInAdvisor
 from boac.models.curated_group import CuratedGroup
-from boac.models.degree_progress_template import DegreeProgressTemplate
 from boac.models.user_login import UserLogin
 from dateutil.tz import tzutc
 from flask import current_app as app, request
 from flask_login import current_user
-from sqlalchemy.sql import desc
 
 """Utility module containing standard API-feed translations of data objects."""
 
@@ -276,18 +274,6 @@ def drop_in_advisors_for_dept_code(dept_code):
             advisor['status'] = a.status
             advisors.append(advisor)
     return sorted(advisors, key=lambda u: ((u.get('firstName') or '').upper(), (u.get('lastName') or '').upper(), u.get('id')))
-
-
-def get_degree_checks_json(sid, include_courses=False):
-    api_json = []
-    # The last updated record is considered 'current'.
-    order_by = desc(DegreeProgressTemplate.updated_at)
-    for index, degree_check in enumerate(DegreeProgressTemplate.find_by_sid(student_sid=sid, order_by=order_by)):
-        api_json.append({
-            **degree_check.to_api_json(include_courses=include_courses),
-            'isCurrent': index == 0,
-        })
-    return api_json
 
 
 def put_notifications(student):

--- a/tests/test_api/test_degree_progress_controller.py
+++ b/tests/test_api/test_degree_progress_controller.py
@@ -238,18 +238,17 @@ class TestGetDegreeTemplates:
 
     def test_get_master_templates(self, client, fake_auth):
         """Returns a list of nondeleted master templates."""
-        # user_id = AuthorizedUser.get_id_per_uid(coe_advisor_read_write_uid)
         fake_auth.login(coe_advisor_read_write_uid)
         _api_create_template(client=client, name='Classical Civilizations')
         _api_create_template(client=client, name='Dutch Studies')
         api_json = _api_create_template(client=client, name='Peace & Conflict Studies')
         assert client.delete(f"/api/degree/{api_json['id']}").status_code == 200
 
-        api_json = self._api_get_templates(client)
-
         def _is_present(name):
             template = next((row for row in api_json if row['name'] == name), None)
             return template is not None
+
+        api_json = self._api_get_templates(client)
         assert _is_present('Classical Civilizations')
         assert _is_present('Dutch Studies')
         assert not _is_present('Peace & Conflict Studies')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4164

Degree template/check objects are bloated by categories, courses, etc. The listing pages only need name, id, and not much else.

