### PR TITLE
BOAC-4175, upgrade flask-cors to move past vulnerability; includes Flask upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,24 @@
 autolink==0.1.2
 boto3==1.7.84
-cx_Oracle==7.1.3
 decorator==4.4.2
-Flask-Caching==1.9.0
-Flask-Cors==3.0.8
+Flask-Caching==1.10.1
+Flask-Cors==3.0.10
 Flask-Login==0.5.0
-Flask-SQLAlchemy==2.4.4
-Flask==1.1.2
+Flask-SQLAlchemy==2.5.1
+Flask==2.0.0
 google-api-python-client==1.7.9
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.0
 ldap3==2.7
 names==0.3.0
 nltk==3.5
-psycopg2-binary==2.8.5
-requests==2.24.0
+psycopg2-binary==2.8.6
+requests==2.25.1
 simplejson==3.17.2
 smart-open==1.8.3
-SQLAlchemy==1.3.23
+SQLAlchemy==1.3.24
 titlecase==1.1.1
-Werkzeug==1.0.1
+Werkzeug==2.0.0
 xmltodict==0.12.0
 zipstream-new==1.1.7
 https://github.com/python-cas/python-cas/archive/master.zip
@@ -30,12 +29,12 @@ https://github.com/python-cas/python-cas/archive/master.zip
 
 numpy==1.19.1
 python-dateutil==2.8.1
-pytz==2020.1
+pytz==2021.1
 
 # For testing
 
 moto==1.3.6
-pytest==6.2.2
+pytest==6.2.4
 pytest-flask==1.2.0
-responses==0.13.1
-tox==3.23.0
+responses==0.13.3
+tox==3.23.1


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4175

Flask 2: https://flask.palletsprojects.com/en/2.0.x/