### PR TITLE
BOAC-4172, drag (and drop) gotta have style

### DIFF
--- a/src/components/degree/CoursesTable.vue
+++ b/src/components/degree/CoursesTable.vue
@@ -25,7 +25,7 @@
             <b-tr
               :id="`course-${bundle.category.id}-table-row-${index}`"
               :key="`tr-${index}`"
-              class="font-size-16 p-1"
+              class="font-size-16"
               :class="{
                 'draggable-tr': bundle.course && isUserDragging(bundle.course.id),
                 'drop-zone-on': isDroppable(bundle.category) && draggingOverCategoryId === bundle.category.id,
@@ -157,11 +157,16 @@
           </template>
           <b-tr
             v-if="!items.length"
+            :class="{
+              'drop-zone-on': draggingOverCategoryId === -1,
+              'drop-zone-off-large': draggingOverCategoryId !== -1
+            }"
+            @dragenter="onDrag($event, 'enter')"
+            @dragleave="onDrag($event, 'leave')"
+            @dragover="onDrag($event, 'over')"
             @drop="onDropEmptyTable"
-            @dragenter.prevent
-            @dragover.prevent
           >
-            <b-td class="pl-0" :class="{'pb-3': !student}" colspan="6">
+            <b-td class="p-2" :class="{'pb-3': !student}" colspan="6">
               <span class="faint-text font-italic font-size-16">No completed requirements</span>
             </b-td>
           </b-tr>
@@ -311,7 +316,7 @@ export default {
         break
       case 'enter':
       case 'over':
-        this.draggingOverCategoryId = this.$_.get(bundle.category, 'id')
+        this.draggingOverCategoryId = bundle ? this.$_.get(bundle.category, 'id') : -1
         event.preventDefault()
         break
       case 'leave':
@@ -353,7 +358,7 @@ export default {
     isDroppable(category) {
       return category
         && this.draggingOverCategoryId
-        && !this.$_.includes(category.courseIds, this.draggingContext.courseId)
+        && !category.courseIds.length
         && category.id === this.draggingOverCategoryId
     },
     isEditable(bundle) {
@@ -375,7 +380,8 @@ export default {
       this.draggingOverCategoryId = null
       return false
     },
-    onDropEmptyTable() {
+    onDropEmptyTable(event) {
+      event.preventDefault()
       this.onDrop({category: this.parentCategory, context: 'assigned'})
     }
   }
@@ -397,11 +403,13 @@ th:last-child {
 .drop-zone-on {
   background-color: #ecf5fb;
   border-color: #8bbdda;
-  border-style: dashed solid;
+  border-style: dashed;
 }
 .drop-zone-off {
-  border-color: transparent;
-  border-style: dashed solid;
+  border: 1px solid transparent;
+}
+.drop-zone-off-large {
+  border: 3px solid transparent;
 }
 .ellipsis-if-overflow {
   overflow: hidden;

--- a/src/store/modules/degree-edit-session.ts
+++ b/src/store/modules/degree-edit-session.ts
@@ -202,11 +202,14 @@ const actions = {
       const done = (srAlert: string, noActionTaken?: boolean) => {
         Vue.prototype.$announcer.polite(srAlert)
         if (!noActionTaken) {
-          $_debug(`From ${actionByUser}: dragged courseId: ${courseId} (${dragContext}) to category ${_.get(category, 'id')} (${context})`)
+          if (context === 'unassigned') {
+            $_debug(`Course ${courseId} (${dragContext}) dragged to unassigned section.`)
+          } else {
+            $_debug(`From ${actionByUser}: course ${courseId} (${dragContext}) dragged to category ${_.get(category, 'id')} (${context})`)
+          }
         }
         resolve()
       }
-
       const valid = _.includes(VALID_DRAG_DROP_CONTEXTS, dragContext) && _.includes(VALID_DRAG_DROP_CONTEXTS, context)
       if (valid) {
         switch (actionByUser) {

--- a/src/views/degree/StudentDegreeCheck.vue
+++ b/src/views/degree/StudentDegreeCheck.vue
@@ -31,7 +31,7 @@
             @dragover="onDrag($event,'over')"
             @drop="dropToUnassign"
           >
-            <h2 class="font-size-20 font-weight-bold pb-0 text-nowrap">Unassigned Courses</h2>
+            <h2 class="font-size-20 font-weight-bold pb-0 pl-2 text-nowrap">Unassigned Courses</h2>
             <UnassignedCourses :student="student" />
           </div>
         </div>
@@ -140,11 +140,10 @@ export default {
 .drop-zone-on {
   background-color: #ecf5fb;
   border-color: #8bbdda;
-  border-style: dashed solid;
+  border-style: dashed;
 }
 .drop-zone-off {
-  border-color: transparent;
-  border-style: dashed solid;
+  border: 3px solid transparent;
 }
 .section-separator {
   border-bottom: 1px #999 solid;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4172

CSS to highlight drop-zones without shakiness in DOM elements.