### PR TITLE
BOAC-4229, fix dragContext value when dragging from junk -> unassigned

### DIFF
--- a/src/components/degree/student/UnassignedCourses.vue
+++ b/src/components/degree/student/UnassignedCourses.vue
@@ -143,7 +143,7 @@ export default {
       return course.sectionId === this.$_.get(this.courseForEdit, 'sectionId')
     },
     onStartDraggingCourse(courseId) {
-      this.onDragStart({courseId: courseId, dragContext: 'unassigned'})
+      this.onDragStart({courseId: courseId, dragContext: this.key})
     }
   }
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4229

I missed this line when turning `UnassignedCourses` into shared component.