### PR TITLE
BOAC-4198, copied-course can be moved and, in the process, its placeholder category is deleted

### DIFF
--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -46,7 +46,7 @@ def app_config():
         'boacEnv': app.config['BOAC_ENV'],
         'currentEnrollmentTerm': current_term_name(),
         'currentEnrollmentTermId': int(current_term_id()),
-        'degreeCategoryTypeOptions': degree_progress_category_type.enums,
+        'degreeCategoryTypeOptions': list(filter(lambda t: 'Placeholder' not in t, degree_progress_category_type.enums)),
         'disableMatrixViewThreshold': app.config['DISABLE_MATRIX_VIEW_THRESHOLD'],
         'devAuthEnabled': app.config['DEVELOPER_AUTH_ENABLED'],
         'ebEnvironment': app.config['EB_ENVIRONMENT'] if 'EB_ENVIRONMENT' in app.config else None,

--- a/boac/models/degree_progress_category.py
+++ b/boac/models/degree_progress_category.py
@@ -37,6 +37,7 @@ degree_progress_category_type = ENUM(
     'Category',
     'Subcategory',
     'Course Requirement',
+    'Placeholder: Course Copy',
     name='degree_progress_category_types',
     create_type=False,
 )
@@ -128,8 +129,8 @@ class DegreeProgressCategory(Base):
 
     @classmethod
     def delete(cls, category_id):
-        for u in DegreeProgressCategoryUnitRequirement.find_by_category_id(category_id):
-            db.session.delete(u.unit_requirement_id)
+        for unit_requirement in DegreeProgressCategoryUnitRequirement.find_by_category_id(category_id):
+            db.session.delete(unit_requirement)
         for course in DegreeProgressCourse.find_by_category_id(category_id):
             db.session.delete(course)
         category = cls.query.filter_by(id=category_id).first()

--- a/scripts/db/migrate/2021/20210608-BOAC-4198/pre_deploy_degree_progress_category_type_add_value.sql
+++ b/scripts/db/migrate/2021/20210608-BOAC-4198/pre_deploy_degree_progress_category_type_add_value.sql
@@ -1,0 +1,2 @@
+
+ALTER TYPE degree_progress_category_types ADD VALUE 'Placeholder: Course Copy';

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -404,7 +404,12 @@ ALTER TABLE ONLY degree_progress_templates
 
 --
 
-CREATE TYPE degree_progress_category_types AS ENUM ('Category', 'Subcategory', 'Course Requirement');
+CREATE TYPE degree_progress_category_types AS ENUM (
+    'Category',
+    'Subcategory',
+    'Course Requirement',
+    'Placeholder: Course Copy'
+);
 
 CREATE TABLE degree_progress_categories (
     id integer NOT NULL,

--- a/src/components/degree/CoursesTable.vue
+++ b/src/components/degree/CoursesTable.vue
@@ -39,7 +39,7 @@
               @drop="onDropCourse($event, bundle.category, 'requirement')"
             >
               <td v-if="assignedCourseCount && canEdit" class="td-course-assignment-menu">
-                <div v-if="bundle.course && !bundle.course.isCopy && !isUserDragging(bundle.course.id)">
+                <div v-if="bundle.course && !isUserDragging(bundle.course.id)">
                   <CourseAssignmentMenu
                     v-if="bundle.course.categoryId"
                     :course="bundle.course"
@@ -131,7 +131,7 @@
                     v-if="isEditable(bundle)"
                     :id="`column-${position}-edit-category-${bundle.category.id}-btn`"
                     class="p-0"
-                    :class="{'pr-0': sid && !$_.get(bundle.course, 'isCopy'), 'pr-1': !sid || (bundle.course && bundle.course.isCopy)}"
+                    :class="{'pr-0': sid, 'pr-1': !sid}"
                     :disabled="disableButtons"
                     size="sm"
                     variant="link"
@@ -141,7 +141,7 @@
                     <span class="sr-only">Edit {{ bundle.name }}</span>
                   </b-btn>
                   <b-btn
-                    v-if="!sid || (bundle.course && bundle.course.isCopy)"
+                    v-if="!sid"
                     :id="`column-${position}-delete-course-${bundle.category.id}-btn`"
                     class="p-0"
                     :disabled="disableButtons"
@@ -256,7 +256,7 @@ export default {
     },
     assignedCourseCount() {
       let count = 0
-      this.$_.each(this.categoryCourseBundles, bundle => bundle.course && !bundle.course.isCopy && count++)
+      this.$_.each(this.categoryCourseBundles, bundle => bundle.course && count++)
       return count
     },
     categoryCourseBundles() {
@@ -369,7 +369,6 @@ export default {
         && this.assignedCourseCount
         && this.canEdit
         && bundle.course
-        && !bundle.course.isCopy
       return !!draggable
     },
     isDroppable(category) {

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -65,6 +65,9 @@ class TestConfigController:
         assert data['maxAttachmentsPerNote'] > 0
         assert data['pingFrequency'] == 900000
         assert data['timezone'] == 'America/Los_Angeles'
+        category_type_options = data['degreeCategoryTypeOptions']
+        assert len(category_type_options) == 3
+        assert 'Placeholder' not in ''.join(category_type_options)
 
     def test_anonymous_version_request(self, client):
         """Returns a well-formed response."""

--- a/tests/test_api/test_degree_progress_student_controller.py
+++ b/tests/test_api/test_degree_progress_student_controller.py
@@ -605,8 +605,14 @@ class TestCopyCourse:
         copy_of_course = _copy_course(category_id=subcategory.id)
         children = DegreeProgressCategory.find_by_parent_category_id(subcategory.id)
         assert len(children) == child_count + 1
-        assert children[0].category_type == 'Course Requirement'
+        assert children[0].category_type == 'Placeholder: Course Copy'
         assert copy_of_course['categoryId'] == children[0].id
+
+        # Assign the copied course to an actual Course Requirement and verify that "placeholder" category is deleted.
+        course_requirement = _create_category(category_type='Course Requirement', parent_category_id=subcategory.id)
+        placeholder_category_id = copy_of_course['categoryId']
+        _api_assign_course(category_id=course_requirement.id, client=client, course_id=copy_of_course['id'])
+        assert DegreeProgressCategory.find_by_id(placeholder_category_id) is None
 
         # Finally, we create a copy for a separate category and expect success.
         copy_of_course = _copy_course(category_id=category_2.id)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4198

The db.migrate script adds a new category_type to identify “copied” courses. Read the Jira for more detail.