### PR TITLE
BOAC-4251, new rules for copied courses (eg, pay attention to category_type of assignment)

### DIFF
--- a/boac/models/degree_progress_category.py
+++ b/boac/models/degree_progress_category.py
@@ -215,7 +215,7 @@ class DegreeProgressCategory(Base):
         return {
             'id': self.id,
             'categoryType': self.category_type,
-            'courseIds': [c.id for c in DegreeProgressCourse.find_by_category_id(category_id=self.id)],
+            'courses': [c.to_api_json() for c in DegreeProgressCourse.find_by_category_id(category_id=self.id)],
             'createdAt': _isoformat(self.created_at),
             'description': self.description,
             'name': self.name,

--- a/src/api/degree.ts
+++ b/src/api/degree.ts
@@ -65,6 +65,10 @@ export function deleteDegreeCategory(categoryId: number) {
   return axios.delete(`${utils.apiBaseUrl()}/api/degree/category/${categoryId}`)
 }
 
+export function deleteDegreeCourse(courseId: number) {
+  return axios.delete(`${utils.apiBaseUrl()}/api/degree/course/${courseId}`)
+}
+
 export function deleteDegreeTemplate(templateId: number) {
   return axios.delete(`${utils.apiBaseUrl()}/api/degree/${templateId}`)
 }

--- a/src/components/degree/Category.vue
+++ b/src/components/degree/Category.vue
@@ -139,7 +139,9 @@ export default {
       this.onClickEdit(this.category)
     },
     isDroppable() {
-      return this.category.id === this.draggingContext.target && !this.$_.size(this.category.subcategories)
+      return this.category.id === this.draggingContext.target
+        && !this.$_.size(this.category.subcategories)
+        && !this.categoryHasCourse(this.category, this.draggingContext.course)
     },
     onDrag(event, stage) {
       switch (stage) {

--- a/src/components/degree/student/AddCourseToCategory.vue
+++ b/src/components/degree/student/AddCourseToCategory.vue
@@ -107,9 +107,8 @@ export default {
   }),
   computed: {
     options() {
-      const getKey = course => `${course.termId}-${course.sectionId}`
-      const keysAdded = this.$_.map(this.coursesAlreadyAdded, course => getKey(course))
-      return this.$_.filter(this.courses.assigned, c => !c.isCopy && !keysAdded.includes(getKey(c)))
+      const keysAdded = this.$_.map(this.coursesAlreadyAdded, course => this.getCourseKey(course))
+      return this.$_.filter(this.courses.assigned, c => !c.isCopy && !keysAdded.includes(this.getCourseKey(c)))
     }
   },
   methods: {

--- a/src/components/degree/student/CourseAssignmentMenu.vue
+++ b/src/components/degree/student/CourseAssignmentMenu.vue
@@ -75,9 +75,9 @@ export default {
   computed: {
     options() {
       const put = option => {
-        option.disabled = (option.categoryType === 'Course Requirement' && !!option.courseIds.length)
+        option.disabled = (option.categoryType === 'Course Requirement' && !!option.courses.length)
           || (option.categoryType === 'Category' && !!option.subcategories.length)
-          || option.courseIds.includes(this.course.id)
+          || this.categoryHasCourse(option, this.course)
         options.push(option)
       }
       const options = []

--- a/src/components/degree/student/UnassignedCourses.vue
+++ b/src/components/degree/student/UnassignedCourses.vue
@@ -33,7 +33,7 @@
               :class="{'tr-while-dragging': isUserDragging(course.id)}"
               :draggable="!disableButtons && $currentUser.canEditDegreeProgress"
               @dragend="onDragEnd"
-              @dragstart="onStartDraggingCourse(course.id)"
+              @dragstart="onStartDraggingCourse(course)"
             >
               <td v-if="$currentUser.canEditDegreeProgress" class="td-course-assignment-menu">
                 <div v-if="!isUserDragging(course.id)">
@@ -142,8 +142,8 @@ export default {
     isEditing(course) {
       return course.sectionId === this.$_.get(this.courseForEdit, 'sectionId')
     },
-    onStartDraggingCourse(courseId) {
-      this.onDragStart({courseId: courseId, dragContext: this.key})
+    onStartDraggingCourse(course) {
+      this.onDragStart({course, dragContext: this.key})
     }
   }
 }

--- a/src/mixins/DegreeEditSession.vue
+++ b/src/mixins/DegreeEditSession.vue
@@ -52,6 +52,7 @@ export default {
       'createCategory',
       'createUnitRequirement',
       'deleteCategory',
+      'deleteCourse',
       'deleteUnitRequirement',
       'dismissAlert',
       'init',
@@ -66,6 +67,9 @@ export default {
       'updateNote',
       'updateUnitRequirement'
     ]),
+    categoryHasCourse(category, course) {
+      return _.map(category.courses, this.getCourseKey).includes(this.getCourseKey(course))
+    },
     findCategoriesByTypes(types, position) {
       return _.filter($_flatten(this.categories), c => c.position === position && _.includes(types, c.categoryType))
     },
@@ -75,16 +79,16 @@ export default {
     getCourse(courseId) {
       return _.find(this.courses.assigned.concat(this.courses.unassigned), ['id', courseId])
     },
+    getCourseKey: course => course && `${course.termId}-${course.sectionId}`,
     getCourses(category) {
       if (this.courses) {
-        const courses = _.filter(this.courses.assigned.concat(this.courses.unassigned), c => _.includes(category.courseIds, c.id))
+        const categoryCourseIds = _.map(category.courses, 'id')
+        const predicate = c => _.includes(categoryCourseIds, c.id)
+        const courses = _.filter(this.courses.assigned.concat(this.courses.unassigned), predicate)
         return courses.concat(category.courseRequirements)
       } else {
         return category.courseRequirements
       }
-    },
-    getFlattenedCategories() {
-      return $_flatten(this.categories)
     },
     isValidUnits: $_isValidUnits,
     unitsWereEdited: course => {


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4251

Previously, we would simply delete the placeholder-category and rely on Postgres to cascade-delete. Now we need custom logic to inspect the assignment and protect courses which are _not_ copies.