### PR TITLE
BOAC-4337, screen readers skip input placeholder; add the same text to sr-only label

### DIFF
--- a/src/components/sidebar/SearchForm.vue
+++ b/src/components/sidebar/SearchForm.vue
@@ -269,6 +269,7 @@
         Search for students, courses, or notes.
         {{ searchInputRequired ? 'Input is required.' : '' }}
         {{ searchHistory.length ? 'Expect auto-suggest of previous searches.' : '' }}
+        (Type / to put focus in the search input field.)
       </span>
       <div class="d-flex" :class="{'pb-3': showNoteFilters}">
         <div class="flex-grow-1">
@@ -278,7 +279,7 @@
             :disabled="disabledSearch"
             :get-suggestions="filterSuggestions"
             :on-submit="search"
-            placeholder="'/' to search"
+            placeholder="/ to search"
             :required="searchInputRequired"
             type="search"
           />


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4337

According to https://www.w3.org/WAI/tutorials/forms/instructions/#placeholder-text, "placeholder text is not broadly supported across assistive technologies."