### PR TITLE
BOAC-4352, response.data when 403 in axios.interceptors.response.use

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -104,8 +104,8 @@ axios.interceptors.response.use(
     const errorStatus = _.get(error, 'response.status')
     if (_.includes([401, 403], errorStatus)) {
       // Refresh user in case his/her session expired.
-      return axios.get(`${apiBaseUrl}/api/profile/my`).then(data => {
-        Vue.prototype.$currentUser = data
+      return axios.get(`${apiBaseUrl}/api/profile/my`).then(response => {
+        Vue.prototype.$currentUser = response.data
         axiosErrorHandler(error)
         return Promise.reject(error)
       })


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4352

We recently fixed the API path used to refresh user "in case session expired." The fix surfaced a new bug, fixed here.