### PR TITLE
BOAC-4352, experimental fix by removing strict=true from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "strict": true,
     "importHelpers": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4352

This is an experiment. I will either roll it back or bring back a subset of strict-type configs: https://www.typescriptlang.org/tsconfig#strict

Why I think this is worth a try:
https://github.com/VincentGarreau/particles.js/issues/123