### PR TITLE
BOAC-4355, degree progress schema change for manual course creation

### DIFF
--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -59,6 +59,7 @@ ALTER TABLE IF EXISTS ONLY public.degree_progress_course_unit_requirements DROP 
 ALTER TABLE IF EXISTS ONLY public.degree_progress_course_unit_requirements DROP CONSTRAINT IF EXISTS degree_progress_course_unit_reqts_course_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.degree_progress_courses DROP CONSTRAINT IF EXISTS degree_progress_courses_category_id_fkey;
 ALTER TABLE IF EXISTS ONLY public.degree_progress_courses DROP CONSTRAINT IF EXISTS degree_progress_courses_degree_check_id_fkey;
+ALTER TABLE IF EXISTS ONLY public.degree_progress_courses DROP CONSTRAINT IF EXISTS degree_progress_courses_manually_created_by_fkey;
 ALTER TABLE IF EXISTS ONLY public.degree_progress_templates DROP CONSTRAINT IF EXISTS degree_progress_templates_updated_by_fkey;
 ALTER TABLE IF EXISTS ONLY public.degree_progress_templates DROP CONSTRAINT IF EXISTS degree_progress_templates_created_by_fkey;
 ALTER TABLE IF EXISTS ONLY public.degree_progress_templates DROP CONSTRAINT IF EXISTS degree_progress_templates_parent_template_id_fkey;

--- a/scripts/db/migrate/2021/20210726-BOAC-4199/pre_deploy_01_course_manually_created_by.sql
+++ b/scripts/db/migrate/2021/20210726-BOAC-4199/pre_deploy_01_course_manually_created_by.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+ALTER TABLE ONLY degree_progress_courses ALTER COLUMN section_id DROP NOT NULL;
+ALTER TABLE ONLY degree_progress_courses ALTER COLUMN term_id DROP NOT NULL;
+
+ALTER TABLE degree_progress_courses ADD COLUMN accent_color VARCHAR(255);
+ALTER TABLE degree_progress_courses ADD COLUMN manually_created_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE degree_progress_courses ADD COLUMN manually_created_by INTEGER;
+
+ALTER TABLE ONLY degree_progress_courses
+    ADD CONSTRAINT degree_progress_courses_manually_created_by_fkey
+    FOREIGN KEY (manually_created_by) REFERENCES authorized_users(id) ON DELETE CASCADE;
+
+ALTER TABLE IF EXISTS ONLY degree_progress_courses
+  DROP CONSTRAINT IF EXISTS degree_progress_courses_category_id_course_unique_constraint;
+
+ALTER TABLE ONLY degree_progress_courses
+    ADD CONSTRAINT degree_progress_courses_category_id_course_unique_constraint
+    UNIQUE (category_id, degree_check_id, display_name, section_id, sid, term_id);
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -445,15 +445,18 @@ CREATE INDEX degree_progress_categories_id_idx ON degree_progress_categories USI
 
 CREATE TABLE degree_progress_courses (
   id integer NOT NULL,
+  accent_color VARCHAR(255),
   category_id INTEGER,
   degree_check_id INTEGER,
+  display_name VARCHAR(255) NOT NULL,
   grade VARCHAR(50) NOT NULL,
-  display_name character varying(255) NOT NULL,
   ignore BOOLEAN NOT NULL,
+  manually_created_at TIMESTAMP WITH TIME ZONE,
+  manually_created_by INTEGER,
   note text,
-  section_id INTEGER NOT NULL,
+  section_id INTEGER,
   sid VARCHAR(80) NOT NULL,
-  term_id INTEGER NOT NULL,
+  term_id INTEGER,
   units NUMERIC NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL
@@ -471,8 +474,11 @@ ALTER TABLE ONLY degree_progress_courses ALTER COLUMN id SET DEFAULT nextval('de
 ALTER TABLE ONLY degree_progress_courses
     ADD CONSTRAINT degree_progress_courses_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY degree_progress_courses
+    ADD CONSTRAINT degree_progress_courses_manually_created_by_fkey
+    FOREIGN KEY (manually_created_by) REFERENCES authorized_users(id) ON DELETE CASCADE;
+ALTER TABLE ONLY degree_progress_courses
     ADD CONSTRAINT degree_progress_courses_category_id_course_unique_constraint
-    UNIQUE (category_id, degree_check_id, section_id, sid, term_id);
+    UNIQUE (category_id, degree_check_id, display_name, section_id, sid, term_id);
 
 --
 


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4355

Note:
* We drop the 'NOT NULL' constraint on `section_id` and `term_id` because manually created course may have neither value. And `display_name` added to unique-constraint because manually created courses must be unique in name.
* You'll notice that `accent_color` is not an enum. The mapping of color name to hex will be done in code. 
* Release instructions updated