### PR TITLE
BOAC-4199, second db-modify script for manually-created courses (grade is nullable, tweak uniqueness constraint)

### DIFF
--- a/scripts/db/migrate/2021/20210727-BOAC-4199/pre_deploy_01_degree_course_constraints.sql
+++ b/scripts/db/migrate/2021/20210727-BOAC-4199/pre_deploy_01_degree_course_constraints.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE ONLY degree_progress_courses ALTER COLUMN grade DROP NOT NULL;
+
+ALTER TABLE IF EXISTS ONLY degree_progress_courses
+  DROP CONSTRAINT IF EXISTS degree_progress_courses_category_id_course_unique_constraint;
+
+ALTER TABLE ONLY degree_progress_courses
+    ADD CONSTRAINT degree_progress_courses_category_id_course_unique_constraint
+    UNIQUE (category_id, degree_check_id, manually_created_at, manually_created_by, section_id, sid, term_id);
+
+COMMIT;


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4199

I delayed this PR in case requirements changed again, requiring schema tweaks. Note: we're changing the uniqueness constraint because duplicate names are allowed in manually-created courses. 