### PR TITLE
BOAC-4409, after assign junk/unassigned course, put focus on component header

### DIFF
--- a/src/components/degree/CoursesTable.vue
+++ b/src/components/degree/CoursesTable.vue
@@ -54,6 +54,7 @@
                 >
                   <CourseAssignmentMenu
                     v-if="bundle.course.categoryId"
+                    :after-course-assignment="course => $putFocusNextTick(`assign-course-${course.id}-dropdown`, 'button')"
                     :course="bundle.course"
                   />
                 </div>

--- a/src/components/degree/student/CourseAssignmentMenu.vue
+++ b/src/components/degree/student/CourseAssignmentMenu.vue
@@ -77,6 +77,11 @@ export default {
     course: {
       required: true,
       type: Object
+    },
+    afterCourseAssignment: {
+      default: () => {},
+      required: false,
+      type: Function
     }
   },
   data: () => ({
@@ -113,7 +118,7 @@ export default {
       this.assignCourseToCategory({course: this.course, category, ignore}).then(courseAssigned => {
         this.setDisableButtons(false)
         this.$announcer.polite(category ? `${category.name} selected for ${this.course.name}` : 'Course unassigned')
-        this.$putFocusNextTick(`assign-course-${courseAssigned.id}-dropdown`, 'button')
+        this.afterCourseAssignment(courseAssigned)
       })
     }
   }

--- a/src/components/degree/student/UnassignedCourses.vue
+++ b/src/components/degree/student/UnassignedCourses.vue
@@ -51,7 +51,7 @@
             >
               <td v-if="$currentUser.canEditDegreeProgress" class="td-course-assignment-menu">
                 <div v-if="!isUserDragging(course.id)">
-                  <CourseAssignmentMenu :course="course" />
+                  <CourseAssignmentMenu :after-course-assignment="() => $putFocusNextTick(`${key}-header`)" :course="course" />
                 </div>
               </td>
               <td class="td-name">

--- a/src/views/degree/StudentDegreeCheck.vue
+++ b/src/views/degree/StudentDegreeCheck.vue
@@ -31,7 +31,7 @@
                 @dragstart="onDrag($event,'start', 'ignored')"
                 @drop="dropToUnassign($event, 'ignored')"
               >
-                <h3 class="font-size-20 font-weight-bold pb-0 text-nowrap">Free Electives</h3>
+                <h3 id="ignored-header" class="font-size-20 font-weight-bold pb-0 text-nowrap" tabindex="-1">Free Electives</h3>
                 <UnassignedCourses :ignored="true" />
               </div>
             </b-col>
@@ -48,7 +48,7 @@
                 @dragstart="onDrag($event,'start', 'unassigned')"
                 @drop="dropToUnassign($event, 'unassigned')"
               >
-                <h3 class="font-size-20 font-weight-bold pb-0 text-nowrap">Unassigned Courses</h3>
+                <h3 id="unassigned-header" class="font-size-20 font-weight-bold pb-0 text-nowrap" tabindex="-1">Unassigned Courses</h3>
                 <div v-if="$currentUser.canEditDegreeProgress" class="pb-2">
                   <CreateCourseModal :student="student" />
                 </div>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4409

Give and take w.r.t accessibility. After course assignment, the 'Unassigned' header is the only feasible focus target. Thus, the h3 gets tabindex="-1".  Same for 'Free Electives'.