### PR TITLE
BOAC-4434: Adds SIS eForms to Acad Timeline as a type of note

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -662,6 +662,18 @@ def get_sis_advising_appointments(sid):
     return safe_execute_rds(sql, sid=sid)
 
 
+def get_sis_late_drop_eforms(sid):
+    sql = f"""
+        SELECT
+            id, course_display_name, course_title, created_at, eform_id, eform_status, eform_type, grading_basis_code,
+            grading_basis_description, requested_action, requested_grading_basis_code, requested_grading_basis_description,
+            section_id, section_num, sid, student_name, term_id, units_taken, updated_at
+        FROM {sis_advising_notes_schema()}.student_late_drop_eforms
+        WHERE sid=:sid
+        ORDER BY created_at, updated_at, id"""
+    return safe_execute_rds(sql, sid=sid)
+
+
 def get_ycbm_advising_appointments(sid):
     sql = f"""
         SELECT

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -77,6 +77,8 @@ def get_advising_notes(sid):
     notes_by_id.update(get_e_i_advising_notes(sid))
     benchmark('begin non legacy advising notes query')
     notes_by_id.update(get_non_legacy_advising_notes(sid))
+    benchmark('begin SIS late drop eforms  query')
+    notes_by_id.update(get_sis_late_drop_eforms(sid))
     if not notes_by_id.values():
         return None
     notes_read = NoteRead.get_notes_read_by_user(current_user.get_id(), notes_by_id.keys())
@@ -159,6 +161,15 @@ def get_non_legacy_advising_notes(sid):
             topics=[t.to_api_json() for t in row.topics if not t.deleted_at],
         )
     return notes_by_id
+
+
+def get_sis_late_drop_eforms(sid):
+    eforms_by_id = {}
+    for eform in data_loch.get_sis_late_drop_eforms(sid):
+        eform_id = eform['id']
+        eforms_by_id[eform_id] = note_to_compatible_json(eform)
+        eforms_by_id[eform_id]['legacySource'] = 'SIS'
+    return eforms_by_id
 
 
 def search_advising_notes(

--- a/fixtures/loch/loch.sql
+++ b/fixtures/loch/loch.sql
@@ -368,6 +368,30 @@ CREATE TABLE sis_advising_notes.advising_note_topic_mappings (
   sis_topic VARCHAR NOT NULL
 );
 
+CREATE TABLE sis_advising_notes.student_late_drop_eforms (
+    id VARCHAR,
+    career_code VARCHAR,
+    course_display_name VARCHAR,
+    course_title VARCHAR,
+    created_at TIMESTAMP WITH TIME ZONE,
+    edl_load_date VARCHAR,
+    eform_id INTEGER,
+    eform_status VARCHAR,
+    eform_type VARCHAR,
+    grading_basis_code VARCHAR,
+    grading_basis_description VARCHAR,
+    requested_action VARCHAR,
+    requested_grading_basis_code VARCHAR,
+    requested_grading_basis_description VARCHAR,
+    section_id INTEGER,
+    section_num VARCHAR,
+    sid VARCHAR NOT NULL,
+    student_name VARCHAR,
+    term_id VARCHAR(4),
+    units_taken VARCHAR,
+    updated_at TIMESTAMP WITH TIME ZONE
+);
+
 CREATE TABLE sis_data.enrolled_primary_sections
 (
     term_id VARCHAR NOT NULL,
@@ -827,6 +851,14 @@ VALUES
 ('9000000000-00002', '9000000000', 1, '2017-10-31', '4567', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '9000000000_00002_1.pdf', 'dog_eaten_homework.pdf', TRUE),
 ('9100000000-00010', '9100000000', 1, '2017-10-31', '8901', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '9100000000_00010_1.pdf', 'not_a_virus.exe', TRUE),
 ('11667051-00010', '11667051', 1, '2017-10-31', 'UCBCONVERSION', '2017-10-31T12:00:00+00', '2017-10-31T12:00:00+00', '11667051-00010_1.pdf', '11667051-00010_1.pdf', TRUE);
+
+INSERT INTO sis_advising_notes.student_late_drop_eforms
+(id, career_code, course_display_name, course_title, created_at, edl_load_date, eform_id, eform_status, eform_type, grading_basis_code, grading_basis_description, requested_action, requested_grading_basis_code, requested_grading_basis_description, section_id, section_num, sid, student_name, term_id, units_taken, updated_at)
+VALUES
+('eform-10096', 'UGRD', 'MATH 16A', 'ANAL GEO & CALCULUS', '2020-12-05 00:00:00+00', '2021-09-01', 468999, 'Executed', 'SRLATEDROP', 'CPN', 'Pass/No Pass College Adjust', 'Undefined', ' ', ' ', 22335, '001', '11667051', 'Deborah Davies', '2208', '3', '2020-12-08 10:32:08+00'), 
+('eform-10098', 'UGRD', 'PSYCH 110', 'INTROD BIOL PSYCH', '2020-12-05 00:00:00+00', '2021-09-01', 469118, 'In Error', 'SRLATEDROP', 'EPN', 'Elective Pass/No Pass', 'Late Grading Basis Change', 'GRD', 'Graded', 24460, '001', '9000000000', 'Wolfgang Pauli-O''Rourke', '2208', '3', '2020-12-05 00:02:57+00'), 
+('eform-10099', 'UGRD', 'EECS 16A', 'DESIGN INFO DEV I', '2020-12-05 00:00:00+00', '2021-09-01', 469242, 'Executed', 'SRLATEDROP', 'GRD', 'Graded', 'Late Grading Basis Change', 'EPN', 'Elective Pass/No Pass', 31262, '001', '11667051', 'Deborah Davies', '2208', '4', '2020-12-05 00:00:07+00'), 
+('eform-101', 'UGRD', 'PBHLTH 126', 'HEALTH ECONOMICS', '2020-04-15 00:00:00+00', '2021-09-01', 378785, 'Executed', 'SRLATEDROP', ' ', 'DefaultPNP', 'Late Drop', ' ', ' ', 10589, '001', '11667051', 'Deborah Davies', '2202', '3', '2020-04-15 12:46:01+00');
 
 CREATE TABLE boac_advising_notes.advising_notes AS (
 SELECT sis.sid, sis.id, sis.note_body, sis.advisor_sid,

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -498,7 +498,7 @@ class TestMarkNoteRead:
         """Marks a note as read."""
         fake_auth.login(coe_advisor_uid)
         all_notes_unread = _get_notes(client, 61889)
-        assert len(all_notes_unread) == 9
+        assert len(all_notes_unread) == 12
         for note in all_notes_unread:
             assert note['read'] is False
 
@@ -516,9 +516,12 @@ class TestMarkNoteRead:
         # E&I note
         response = client.post('/api/notes/11667051-151620/mark_read')
         assert response.status_code == 201
+        # SIS eForm
+        response = client.post('/api/notes/eform-10096/mark_read')
+        assert response.status_code == 201
 
         all_notes_after_read = _get_notes(client, 61889)
-        assert len(all_notes_after_read) == 9
+        assert len(all_notes_after_read) == 12
         assert all_notes_after_read[0]['id'] == '11667051-00001'
         assert all_notes_after_read[0]['read'] is True
         assert all_notes_after_read[1]['id'] == '11667051-00002'
@@ -537,6 +540,12 @@ class TestMarkNoteRead:
         assert all_notes_after_read[7]['read'] is True
         assert all_notes_after_read[8]['id'] == '11667051-151620'
         assert all_notes_after_read[8]['read'] is True
+        assert all_notes_after_read[9]['id'] == 'eform-101'
+        assert all_notes_after_read[9]['read'] is False
+        assert all_notes_after_read[10]['id'] == 'eform-10099'
+        assert all_notes_after_read[10]['read'] is False
+        assert all_notes_after_read[11]['id'] == 'eform-10096'
+        assert all_notes_after_read[11]['read'] is True
 
 
 class TestUpdateNotes:

--- a/tests/test_externals/test_data_loch.py
+++ b/tests/test_externals/test_data_loch.py
@@ -173,6 +173,13 @@ class TestDataLoch:
         assert appointments[1]['id'] == '11667051-00011'
         assert appointments[2]['id'] == '11667051-00012'
 
+    def test_get_sis_late_drop_eforms(self):
+        eforms = data_loch.get_sis_late_drop_eforms('11667051')
+        assert len(eforms) == 3
+        assert eforms[0]['id'] == 'eform-101'
+        assert eforms[1]['id'] == 'eform-10099'
+        assert eforms[2]['id'] == 'eform-10096'
+
     def test_get_students_ordering_default(self):
         o, o_secondary, o_tertiary, o_direction, supplemental_query_tables = data_loch.get_students_ordering(
             '2202',

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -453,11 +453,12 @@ class TestMergedAdvisingNote:
             assert contents['dog_eaten_homework.pdf'] == b'When in the course of human events, it becomes necessarf arf woof woof woof'
             today = localize_datetime(utc_now()).strftime('%Y%m%d')
             csv_rows = contents[f"advising_notes_wolfgang_pauli-o'rourke_{today}.csv"].decode('utf-8').strip().split('\r\n')
-            assert len(csv_rows) == 3
+            assert len(csv_rows) == 4
             assert csv_rows[0] == 'date_created,student_sid,student_name,author_uid,author_csid,author_name,subject,topics,attachments,body'
             assert csv_rows[1] ==\
                 "2017-11-02,9000000000,Wolfgang Pauli-O'Rourke,,700600500,,,,dog_eaten_homework.pdf,I am confounded by this confounding student"
             assert csv_rows[2] == "2017-11-02,9000000000,Wolfgang Pauli-O'Rourke,,600500400,,,Ne Scéaw,,Is this student even on campus?"
+            assert csv_rows[3] == "2020-12-04,9000000000,Wolfgang Pauli-O'Rourke,,,,,,,"
 
 
 def _create_coe_advisor_note(


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/BOAC-4434

eForm displays as an empty note. A subsequent PR will fill in the details.