### PR TITLE
BOAC-4491, fix chown command in deploy_boac_config.sh

### DIFF
--- a/scripts/deploy_boac_config.sh
+++ b/scripts/deploy_boac_config.sh
@@ -42,13 +42,13 @@ echo "Use CTRL-C to abort..."; echo
 sleep 5
 
 AWS_REGION=us-west-2 aws s3 cp ${config_location} "${local_config}"
-chown wsgi "${local_config}"
+chown webapp "${local_config}"
 chmod 400 "${local_config}"
 
 # Add EB_ENVIRONMENT to new config file
 printf "\nEB_ENVIRONMENT = '${eb_env}'\n\n" >> "${local_config}"
 
 echo; echo "Done!"; echo
-echo "Restart BOAC to pick up new configs. Have a nice day!"; echo
+echo "Restart BOA to pick up new configs. Have a nice day!"; echo
 
 exit 0


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4491

In the new AL2 environment, the script errors on the `chown wsgi ...` command (fixed in this PR) and aborts. Thus, the subsequent command where we append EB_ENVIRONMENT is never reached.