### PR TITLE
BOAC-4466, tweak logic on who can edit a private note

### DIFF
--- a/src/components/student/profile/AcademicTimelineTable.vue
+++ b/src/components/student/profile/AcademicTimelineTable.vue
@@ -111,7 +111,7 @@
               v-if="isEditable(message) && !editModeNoteId && $_.includes(openMessages, message.transientId)"
               class="mt-2"
             >
-              <div v-if="$currentUser.uid === message.author.uid">
+              <div v-if="$currentUser.uid === message.author.uid && (!message.isPrivate || $currentUser.canAccessPrivateNotes)">
                 <b-btn
                   :id="`edit-note-${message.id}-button`"
                   :disabled="disableNewNoteButton"


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4466

Owner cannot edit his/her own private note if s/he lost the `canAccessPrivateNotes` permission.