### PR TITLE
[QA] BOAC-4527, null-safe check during note attachment download

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -224,7 +224,8 @@ def download_attachment(attachment_id):
         stream_data = get_legacy_attachment_stream(id_)
     else:
         attachment = NoteAttachment.find_by_id(id_)
-        if attachment.note and attachment.note.is_private and not current_user.can_access_private_notes:
+        note = attachment and attachment.note
+        if note and note.is_private and not current_user.can_access_private_notes:
             raise ForbiddenRequestError('Unauthorized')
         stream_data = get_boa_attachment_stream(attachment)
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4527

dev PR is #3361 