### PR TITLE
BOAC-4529, semicolon separator when 'plans' array is flat (DegreesAwarded)

### DIFF
--- a/src/components/student/DegreesAwarded.vue
+++ b/src/components/student/DegreesAwarded.vue
@@ -27,10 +27,8 @@ export default {
     this.$_.each(this.student.degrees || [], degree => {
       const key = degree.dateAwarded
       if (key) {
-        if (!this.degreesAwarded[key]) {
-          this.degreesAwarded[key] = []
-        }
-        this.degreesAwarded[key].push(this.$_.map(degree.plans, 'plan'))
+        const plans = this.degreesAwarded[key] || []
+        this.degreesAwarded[key] = plans.concat(this.$_.map(degree.plans, 'plan'))
       }
     })
   }


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4529

Very minor tweak; QA PR not necessary. Guarantees flattened array for `join(plans, ';')`.