### PR TITLE
BOAC-4520, /api/notes/download_for_sid: sanitize filename for download

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -246,7 +246,8 @@ def download_notes_and_attachments(sid):
         return Response('Notes not available.', mimetype='text/html', status=404)
     r = Response(stream_data['stream'])
     r.headers['Content-Type'] = 'application/zip'
-    r.headers['Content-Disposition'] = f"attachment; filename={stream_data['filename']}"
+    encoding_safe_filename = urllib.parse.quote(stream_data['filename'].encode('utf8'))
+    r.headers['Content-Disposition'] = f'attachment; filename={encoding_safe_filename}'
     return r
 
 

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -911,7 +911,7 @@ class TestStreamNotesZip:
             response = client.get('/api/notes/download_for_sid/9000000000')
             assert response.status_code == 200
             assert response.headers['Content-Type'] == 'application/zip'
-            assert response.headers['Content-Disposition'] == f"attachment; filename=advising_notes_wolfgang_pauli-o'rourke_{today}.zip"
+            assert response.headers['Content-Disposition'] == f"attachment; filename=advising_notes_wolfgang_pauli-o%27rourke_{today}.zip"
             assert response.data
 
     def test_authorizes_director(self, app, client, fake_auth):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4520

We do the same encoding in /api/notes/attachment/<attachment_id>

(Accidentally deleted branch of PR #3369)