### PR TITLE
BOAC-4524, Revert old-school YAML for cloudwatch config

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -46,10 +46,22 @@ files:
     owner: root
     group: root
     content: |
-      [/var/app/current/boa.log]
-      log_group_name=`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/boa.log"]]}`
-      log_stream_name={instance_id}
-      file=/var/app/current/boa.log*
+      {
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/app/current/boa.log",
+                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/boa.log"]]}`",
+                  "log_stream_name": "{instance_id}"
+                }
+              ]
+            }
+          },
+          "force_flush_interval" : 15
+        }
+      }
 
 Resources:
   sslSecurityGroupIngress:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4524

Old-school YAML did not fix the problem.

This reverts commit d27ad397bf78259fc25bc8f65ea4a585a1662e2e.