### PR TITLE
BOAC-4503, protect against null event.target.classList

### DIFF
--- a/src/mixins/Attachments.vue
+++ b/src/mixins/Attachments.vue
@@ -5,7 +5,8 @@ export default {
   name: 'Attachments',
   beforeCreate() {
     const preventFileDropOutsideFormControl = e => {
-      if (!e.target.classList.contains('choose-attachment-file-wrapper')) {
+      const classList = _.get(e.target, 'classList', '')
+      if (!classList.contains('choose-attachment-file-wrapper')) {
         e.preventDefault()
         e.dataTransfer.effectAllowed = 'none'
         e.dataTransfer.dropEffect = 'none'

--- a/src/views/degree/StudentDegreeCheck.vue
+++ b/src/views/degree/StudentDegreeCheck.vue
@@ -172,8 +172,7 @@ export default {
     },
     scrollTo(event) {
       // Firefox does not need the intervention below.
-      const isFirefox = navigator.userAgent.indexOf('Firefox') === -1
-      if (this.draggingContext.course && isFirefox) {
+      if (this.draggingContext.course && navigator.userAgent.indexOf('Firefox') === -1) {
         const eventY = event.clientY
         // Distance to bottom of viewport
         const distanceToBottom = window.innerHeight - eventY


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4503

Fixes error I hit when testing drag/drop on Windows + Chrome.