### PR TITLE
BOAC-4524, ebextension: /etc/awslogs/config/logs.conf per AWS docs

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -41,27 +41,15 @@ option_settings:
     ManagedSecurityGroup: '`{"Fn::GetOptionSetting": {"Namespace": "aws:elasticbeanstalk:application:environment", "OptionName": "LOAD_BALANCER_SG"}}`'
 
 files:
-  /opt/aws/amazon-cloudwatch-agent/etc/boac.json:
-    mode: '000644'
+  "/etc/awslogs/config/logs.conf":
+    mode: "000600"
     owner: root
     group: root
     content: |
-      {
-        "logs": {
-          "logs_collected": {
-            "files": {
-              "collect_list": [
-                {
-                  "file_path": "/var/app/current/boa.log",
-                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/boa.log"]]}`",
-                  "log_stream_name": "{instance_id}"
-                }
-              ]
-            }
-          },
-          "force_flush_interval" : 15
-        }
-      }
+      [/var/app/current/boa.log]
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/boa.log"]]}`
+      log_stream_name = {instance_id}
+      file = /var/app/current/boa.log
 
 Resources:
   sslSecurityGroupIngress:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4524

Following AWS docs: https://aws.plainenglish.io/how-to-setup-aws-elasticbeanstalk-to-stream-your-custom-application-logs-to-cloudwatch-d5c877eaa242

More tweaks might follow.