### PR TITLE
BOAC-4562, add 'domain' column to curated_groups table (as seen in cohorts table)

### DIFF
--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -39,19 +39,12 @@ from boac.models.alert import Alert
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.base import Base
 from boac.models.cohort_filter_event import CohortFilterEvent
+from boac.models.db_relationships import cohort_domain_type
 from flask import current_app as app
 from flask_login import current_user
 from sqlalchemy import text
-from sqlalchemy.dialects.postgresql import ARRAY, ENUM, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import deferred, undefer
-
-
-cohort_domain_type = ENUM(
-    'default',
-    'admitted_students',
-    name='cohort_domain_types',
-    create_type=False,
-)
 
 
 class CohortFilter(Base):

--- a/boac/models/db_relationships.py
+++ b/boac/models/db_relationships.py
@@ -26,6 +26,15 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from datetime import datetime
 
 from boac import db
+from sqlalchemy.dialects.postgresql import ENUM
+
+
+cohort_domain_type = ENUM(
+    'default',
+    'admitted_students',
+    name='cohort_domain_types',
+    create_type=False,
+)
 
 
 # Alert views are represented as a model class because they contain 'created_at' and 'dismissed_at' metadata in

--- a/scripts/db/migrate/2021/20211206-BOAC-4562/add_domain_column_curated_groups.sql
+++ b/scripts/db/migrate/2021/20211206-BOAC-4562/add_domain_column_curated_groups.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE student_groups ADD COLUMN domain cohort_domain_types;
+
+UPDATE student_groups SET domain='default';
+
+ALTER TABLE student_groups ALTER COLUMN domain SET NOT NULL;
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -797,8 +797,9 @@ ALTER TABLE schedulers
 
 CREATE TABLE student_groups (
   id INTEGER NOT NULL,
-  owner_id INTEGER NOT NULL,
+  domain cohort_domain_types NOT NULL,
   name VARCHAR(255) NOT NULL,
+  owner_id INTEGER NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL
 );


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4562

The db table of curated groups will leverage enum type `cohort_domain_type`. Renaming the enum would be too disruptive.

Release instructions updated.