### PR TITLE
BOAC-4599 & BOAC-4595, if cohort/group is CE3 then use 'admit', not 'student'

### DIFF
--- a/src/components/cohort/CohortPageHeader.vue
+++ b/src/components/cohort/CohortPageHeader.vue
@@ -18,7 +18,7 @@
           <span
             v-if="editMode !== 'apply' && totalStudentCount !== undefined"
             class="faint-text"
-          >{{ pluralize('student', totalStudentCount) }}</span>
+          >{{ pluralize(domain === 'admitted_students' ? 'admit' : 'student', totalStudentCount) }}</span>
         </h1>
         <h1 v-if="!cohortName && totalStudentCount !== undefined" id="cohort-results-header">
           {{ pluralize('Result', totalStudentCount) }}
@@ -28,7 +28,7 @@
         <div v-if="cohortId && $_.size(filters)">
           <b-btn
             id="show-hide-details-button"
-            class="no-wrap pr-2 p-0"
+            class="no-wrap pr-1 p-0"
             variant="link"
             @click="toggleShowHideDetails"
           >

--- a/src/components/curated/CuratedGroupHeader.vue
+++ b/src/components/curated/CuratedGroupHeader.vue
@@ -4,7 +4,9 @@
       <div v-if="mode !== 'rename'">
         <h1 id="curated-group-name" class="page-section-header mb-0 mt-0">
           {{ curatedGroupName || domainLabel(true) }}
-          <span v-if="!$_.isNil(totalStudentCount)" class="faint-text"> ({{ pluralize('student', totalStudentCount, {1: '1'}) }})</span>
+          <span v-if="!$_.isNil(totalStudentCount)" class="faint-text">
+            ({{ pluralize(domain === 'admitted_students' ? 'admit' : 'student', totalStudentCount, {1: '1'}) }})
+          </span>
         </h1>
       </div>
       <div v-if="mode === 'rename'" class="w-100 mr-3">

--- a/src/components/sidebar/MyAdmitCohorts.vue
+++ b/src/components/sidebar/MyAdmitCohorts.vue
@@ -31,9 +31,8 @@
       <div class="ml-1 truncate-with-ellipsis">
         <NavLink
           :id="`sidebar-admitted-students-cohort-${cohort.id}`"
-          :aria-label="`Cohort ${cohort.name} has ${cohort.totalStudentCount} admitted students`"
+          :aria-label="`Cohort ${cohort.name} has ${cohort.totalStudentCount} admits`"
           :path="`/cohort/${cohort.id}`"
-          :query-args="{domain: 'admitted_students'}"
         >
           {{ cohort.name }}
         </NavLink>
@@ -42,7 +41,7 @@
         <span
           :id="`sidebar-admitted-students-cohort-${cohort.id}-total-student-count`"
           class="sidebar-pill"
-        >{{ cohort.totalStudentCount }}<span class="sr-only">{{ pluralize('admitted student', cohort.totalStudentCount) }}</span>
+        >{{ cohort.totalStudentCount }}<span class="sr-only">{{ pluralize('admits', cohort.totalStudentCount) }}</span>
         </span>
       </div>
     </div>

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -12,7 +12,7 @@
         <CuratedGroups domain="default" />
         <hr class="ml-2 mr-2 section-divider" />
       </div>
-      <div v-if="myAdmitCohorts || myAdmitCuratedGroups">
+      <div v-if="$currentUser.canAccessAdmittedStudents">
         <div class="ml-2 sidebar-header">
           Admitted Students
         </div>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4595
https://jira-secure.berkeley.edu/browse/BOAC-4599

Plus, sidebar fix per `canAccessAdmittedStudents`.