### PR TITLE
BOAC-2216: Removes unused student profile elements currentTerm, termGpa, academicStanding

### DIFF
--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -135,8 +135,6 @@ def get_course_student_profiles(term_id, section_id, offset=None, limit=None, fe
     enrollments_for_term = data_loch.get_enrollments_for_term(term_id, sids)
     benchmark('end enrollments query')
     enrollments_by_sid = {row['sid']: json.loads(row['enrollment_term']) for row in enrollments_for_term}
-    academic_standing = get_academic_standing_by_sid(sids, as_dicts=True)
-    term_gpas = get_term_gpas_by_sid(sids, as_dicts=True)
     all_canvas_sites = {}
     benchmark('begin profile transformation')
     for student in students:
@@ -148,7 +146,6 @@ def get_course_student_profiles(term_id, section_id, offset=None, limit=None, fe
             student['cumulativeUnits'] = sis_profile.get('cumulativeUnits')
             student['degrees'] = sis_profile.get('degrees')
             student['level'] = _get_sis_level_description(sis_profile)
-            student['currentTerm'] = sis_profile.get('currentTerm')
             student['majors'] = _get_active_plan_descriptions(sis_profile)
             student['transfer'] = sis_profile.get('transfer')
         term = enrollments_by_sid.get(student['sid'])
@@ -172,8 +169,6 @@ def get_course_student_profiles(term_id, section_id, offset=None, limit=None, fe
                         if site['canvasCourseId'] not in all_canvas_sites:
                             all_canvas_sites[site['canvasCourseId']] = site
                     continue
-        student['academicStanding'] = academic_standing.get(student['sid'])
-        student['termGpa'] = term_gpas.get(student['sid'])
     benchmark('end profile transformation')
     mean_metrics = analytics.mean_metrics_across_sites(all_canvas_sites.values(), 'courseMean')
     mean_metrics['gpa'] = {}

--- a/fixtures/loch/student_profile_11667051.json
+++ b/fixtures/loch/student_profile_11667051.json
@@ -11,10 +11,6 @@
         "calnetAffiliations": ["STUDENT-TYPE-REGISTERED"],
         "cumulativeGPA": 3.7999999999999998,
         "cumulativeUnits": 101.3,
-        "currentTerm": {
-            "unitsMax": 25,
-            "unitsMin": 0
-        },
         "degreeProgress": {
             "reportDate": "2017-03-03",
             "requirements": {

--- a/fixtures/loch/student_profile_summary_11667051.json
+++ b/fixtures/loch/student_profile_summary_11667051.json
@@ -39,10 +39,6 @@
     "canvasUserName": "Oski Bear",
     "cumulativeGPA": 3.7999999999999998,
     "cumulativeUnits": 101.3,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2198",

--- a/fixtures/loch/student_profile_summary_2345678901.json
+++ b/fixtures/loch/student_profile_summary_2345678901.json
@@ -18,10 +18,6 @@
     "canvasUserName": "Dave Doolittle",
     "cumulativeGPA": 3.495,
     "cumulativeUnits": 34,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2198",

--- a/fixtures/loch/student_profile_summary_3456789012.json
+++ b/fixtures/loch/student_profile_summary_3456789012.json
@@ -18,10 +18,6 @@
     "canvasUserName": "Pauline Kerschen",
     "cumulativeGPA": 3.005,
     "cumulativeUnits": 70,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2198",

--- a/fixtures/loch/student_profile_summary_5678901234.json
+++ b/fixtures/loch/student_profile_summary_5678901234.json
@@ -17,10 +17,6 @@
     "canvasUserName": "Sandeep Jayaprakash",
     "cumulativeGPA": 3.501,
     "cumulativeUnits": 102,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2198",

--- a/fixtures/loch/student_profile_summary_7890123456.json
+++ b/fixtures/loch/student_profile_summary_7890123456.json
@@ -28,10 +28,6 @@
     "canvasUserName": "Paul Farestveit",
     "cumulativeGPA": 3.9,
     "cumulativeUnits": 110,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2202",

--- a/fixtures/loch/student_profile_summary_8901234567.json
+++ b/fixtures/loch/student_profile_summary_8901234567.json
@@ -39,10 +39,6 @@
     "canvasUserName": "John David Crossman",
     "cumulativeGPA": 1.85,
     "cumulativeUnits": 12,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "1978",

--- a/fixtures/loch/student_profile_summary_890127492.json
+++ b/fixtures/loch/student_profile_summary_890127492.json
@@ -6,10 +6,6 @@
     "canvasUserName": "Siegfried Schlemiel",
     "cumulativeGPA": 0.4,
     "cumulativeUnits": 8,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2198",

--- a/fixtures/loch/student_profile_summary_9000000000.json
+++ b/fixtures/loch/student_profile_summary_9000000000.json
@@ -39,10 +39,6 @@
     "canvasUserName": "Oski Bear",
     "cumulativeGPA": 2.3,
     "cumulativeUnits": 55,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2202",

--- a/fixtures/loch/student_profile_summary_9100000000.json
+++ b/fixtures/loch/student_profile_summary_9100000000.json
@@ -39,10 +39,6 @@
     "canvasUserName": "Nora Stanton Barney",
     "cumulativeGPA": 3.58,
     "cumulativeUnits": 60,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2198",

--- a/fixtures/loch/student_profile_summary_completed_2718281828.json
+++ b/fixtures/loch/student_profile_summary_completed_2718281828.json
@@ -6,10 +6,6 @@
     "canvasUserName": "Ernest Pontifex",
     "cumulativeGPA": 4,
     "cumulativeUnits": 139,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": [
         {
             "dateAwarded": "2010-05-14",

--- a/fixtures/loch/student_profile_summary_inactive_3141592653.json
+++ b/fixtures/loch/student_profile_summary_inactive_3141592653.json
@@ -39,10 +39,6 @@
     "canvasUserName": "Oski Bear",
     "cumulativeGPA": 2.784,
     "cumulativeUnits": 149.6,
-    "currentTerm": {
-        "unitsMax": 25,
-        "unitsMin": 0
-    },
     "degrees": null,
     "expectedGraduationTerm": {
         "id": "2118",

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -95,18 +95,19 @@ class TestCourseController:
         students = response.json['students']
         assert len(students) == 1
         assert response.json['totalStudentCount'] == 1
-        assert students[0]['uid'] == student_uid
-        assert students[0]['sid'] == student_sid
+        assert students[0]['academicCareerStatus'] == 'Active'
+        assert students[0]['cumulativeUnits'] == 101.3
+        assert students[0]['degrees'] is None
         assert students[0]['firstName'] == 'Deborah'
         assert students[0]['lastName'] == 'Davies'
-        assert students[0]['academicStanding']['2182'] == 'GST'
-        assert students[0]['cumulativeGPA'] == 3.8
-        assert students[0]['cumulativeUnits'] == 101.3
         assert students[0]['level'] == 'Junior'
-        assert len(students[0]['majors']) == 2
+        assert students[0]['majors'] == ['English BA', 'Nuclear Engineering BS']
+        assert students[0]['name'] == 'Deborah Davies'
+        assert students[0]['sid'] == '11667051'
+        assert students[0]['transfer'] is False
+        assert students[0]['uid'] == '61889'
         assert len(students[0]['enrollment']['canvasSites']) == 1
         assert students[0]['enrollment']['midtermGrade'] == 'D+'
-        assert students[0]['termGpa']['2182'] == 2.9
         assert isinstance(students[0].get('alertCount'), int)
 
     def test_section_student_analytics(self, coe_advisor, client):

--- a/tests/test_merged/test_student.py
+++ b/tests/test_merged/test_student.py
@@ -23,7 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from boac.merged import student
+from boac.merged.student import get_course_student_profiles, get_distilled_student_profiles
 
 
 coe_advisor = '1133399'
@@ -32,17 +32,15 @@ coe_advisor = '1133399'
 class TestMergedStudent:
     """Student data, merged."""
 
-    def test_get_course_student_profiles(self, app):
-        profiles = student.get_course_student_profiles('2178', '90100')
+    def test_get_course_student_profiles(self):
+        profiles = get_course_student_profiles('2178', '90100')
 
         assert len(profiles['students']) == 1
-        assert profiles['students'][0]['cumulativeUnits'] == 101.3
-        assert profiles['students'][0]['currentTerm']['unitsMax'] == 25
-        assert profiles['students'][0]['currentTerm']['unitsMin'] == 0
+        assert profiles['students'][0]['sid'] == '11667051'
 
     def test_get_distilled_student_profiles(self):
         """Returns basic profiles of both current and non-current students."""
-        profiles = student.get_distilled_student_profiles(['11667051', '2718281828'])
+        profiles = get_distilled_student_profiles(['11667051', '2718281828'])
         assert len(profiles) == 2
         assert profiles[0]['firstName'] == 'Deborah'
         assert profiles[0]['gender'] == 'Different Identity'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-2216

`termGpa` and `academicStanding` are not used on the course page, and `currentTerm` isn't used on any page.