### PR TITLE
NOJIRA, less hard-coded test data in development_db; advisor_factory fixture instead

### DIFF
--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -51,34 +51,8 @@ from sqlalchemy.sql import text
 
 delete_this_admin_uid = '44444'
 delete_this_uid = '33333'
-no_calnet_record_for_uid = '13'
 
 _test_users = [
-    {
-        # This user has no entry in calnet_search_entries
-        'uid': no_calnet_record_for_uid,
-        'csid': None,
-        'isAdmin': True,
-        'inDemoMode': False,
-        'canAccessAdvisingData': True,
-        'canAccessCanvasData': True,
-    },
-    {
-        'uid': '1',
-        'csid': '111111111',
-        'isAdmin': False,
-        'inDemoMode': True,
-        'canAccessAdvisingData': True,
-        'canAccessCanvasData': False,
-    },
-    {
-        'uid': '2',
-        'csid': '222222222',
-        'isAdmin': False,
-        'inDemoMode': True,
-        'canAccessAdvisingData': True,
-        'canAccessCanvasData': False,
-    },
     {
         # User deleted (see below)
         'uid': delete_this_uid,
@@ -320,12 +294,6 @@ _university_depts = {
                 'isDropInAdvisor': False,
                 'automate_membership': True,
             },
-            {
-                'uid': no_calnet_record_for_uid,
-                'role': 'advisor',
-                'isDropInAdvisor': False,
-                'automate_membership': True,
-            },
         ],
     },
     'QCADV': {
@@ -416,26 +384,6 @@ _university_depts = {
             },
         ],
     },
-    'ZZZZZ': {
-        'users': [
-            {
-                'uid': '1',
-                'role': 'advisor',
-                'isDropInAdvisor': False,
-                'automate_membership': True,
-            },
-        ],
-    },
-    'GUEST': {
-        'users': [
-            {
-                'uid': '2',
-                'role': 'advisor',
-                'isDropInAdvisor': False,
-                'automate_membership': False,
-            },
-        ],
-    },
 }
 
 
@@ -480,26 +428,23 @@ def _create_users():
         csid = test_user['csid'] or datetime.now().strftime('%H%M%S%f')
         first_name = test_user.get('firstName', ''.join(random.choices(string.ascii_uppercase, k=6)))
         last_name = test_user.get('lastName', ''.join(random.choices(string.ascii_uppercase, k=6)))
-
-        # Put mock CalNet data in our json_cache for all users EXCEPT the test "no_calnet_record" user.
-        if uid != no_calnet_record_for_uid:
-            calnet_feed = {
-                'uid': uid,
-                'csid': csid,
-                'firstName': first_name,
-                'lastName': last_name,
-                'name': f'{first_name} {last_name}',
-            }
-            if 'calnetDeptCodes' in test_user:
-                calnet_feed['departments'] = []
-                for dept_code in test_user['calnetDeptCodes']:
-                    calnet_feed['departments'].append({
-                        'code': dept_code,
-                        'name': BERKELEY_DEPT_CODE_TO_NAME.get(dept_code),
-                    })
-            if 'title' in test_user:
-                calnet_feed['title'] = test_user['title']
-            insert_in_json_cache(f'calnet_user_for_uid_{uid}', calnet_feed)
+        calnet_feed = {
+            'uid': uid,
+            'csid': csid,
+            'firstName': first_name,
+            'lastName': last_name,
+            'name': f'{first_name} {last_name}',
+        }
+        if 'calnetDeptCodes' in test_user:
+            calnet_feed['departments'] = []
+            for dept_code in test_user['calnetDeptCodes']:
+                calnet_feed['departments'].append({
+                    'code': dept_code,
+                    'name': BERKELEY_DEPT_CODE_TO_NAME.get(dept_code),
+                })
+        if 'title' in test_user:
+            calnet_feed['title'] = test_user['title']
+        insert_in_json_cache(f'calnet_user_for_uid_{uid}', calnet_feed)
 
         # Add user to authorized_users table if not already present.
         user = AuthorizedUser.find_by_uid(uid=uid)

--- a/tests/test_api/test_auth_controller.py
+++ b/tests/test_api/test_auth_controller.py
@@ -33,7 +33,6 @@ from tests.util import override_config, pause_mock_sts
 admin_uid = '2040'
 advisor_uid = '1133399'
 unauthorized_uid = '1015674'
-no_calnet_record_for_uid = '13'
 
 
 class TestDevAuth:
@@ -112,15 +111,16 @@ class TestDevAuth:
             assert response.status_code == 200
             assert response.json['isAnonymous']
 
-    def test_user_expired_according_to_calnet(self, app, client):
+    def test_user_expired_according_to_calnet(self, advisor_factory, app, client):
         """Fails if user has no record in LDAP."""
+        advisor = advisor_factory(has_calnet_record=False)
         with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
             from boac.models import json_cache
             json_cache.clear('%')
             self._api_dev_auth_login(
                 client,
                 params={
-                    'uid': no_calnet_record_for_uid,
+                    'uid': advisor.uid,
                     'password': app.config['DEVELOPER_AUTH_PASSWORD'],
                 },
                 expected_status_code=403,

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -157,12 +157,13 @@ class TestRefreshDepartmentMemberships:
         assert user.created_by == '0'
         assert user.department_memberships[0].automate_membership is True
 
-    def test_restores_coe_advisors(self, advisor_coeng):
+    def test_restores_coe_advisors(self, advisor_factory):
         """Restores previously deleted COE advisors found in the loch."""
         from boac.api.cache_utils import refresh_department_memberships
 
-        uid = advisor_coeng.uid
-        user_id = advisor_coeng.id
+        coe_advisor = advisor_factory()
+        uid = coe_advisor.uid
+        user_id = coe_advisor.id
         AuthorizedUser.delete(uid=uid)
         UniversityDeptMember.query.filter_by(authorized_user_id=user_id).delete()
         std_commit(allow_test_environment=True)

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -49,13 +49,7 @@ def coe_scheduler(fake_auth):
     fake_auth.login(coe_scheduler_uid)
 
 
-@pytest.fixture()
-def no_canvas_access_advisor(fake_auth):
-    fake_auth.login('1')
-
-
 class TestCourseController:
-    """API for retrieving course info."""
 
     def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
@@ -65,8 +59,10 @@ class TestCourseController:
         """Returns 403 if user is only a scheduler."""
         assert client.get('/api/section/2182/1').status_code == 401
 
-    def test_not_authorized(self, no_canvas_access_advisor, client):
+    def test_not_authorized(self, advisor_factory, client, fake_auth):
         """Returns 403 if user is not authorized."""
+        advisor = advisor_factory(can_access_canvas_data=False)
+        fake_auth.login(advisor.uid)
         assert client.get('/api/section/2182/1').status_code == 403
 
     def test_api_route_not_found(self, coe_advisor, client):

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -60,11 +60,6 @@ def coe_scheduler(fake_auth):
 
 
 @pytest.fixture()
-def no_canvas_data_access_advisor(fake_auth):
-    fake_auth.login('1')
-
-
-@pytest.fixture()
 def admin_user_session(fake_auth):
     fake_auth.login(admin_uid)
 
@@ -335,7 +330,10 @@ class TestGetCuratedGroup:
         assert student_term['enrollments'][0]['displayName'] == 'CLASSIC 130 LEC 001'
         assert student_term['enrollments'][0]['grade'] == 'P'
 
-    def test_curated_group_detail_suppresses_canvas_data_when_unauthorized(self, client, no_canvas_data_access_advisor):
+    def test_curated_group_detail_suppresses_canvas_data_when_unauthorized(self, advisor_factory, client, fake_auth):
+        """Suppress Canvas data when unauthorized."""
+        advisor = advisor_factory(can_access_canvas_data=False)
+        fake_auth.login(advisor.uid)
         group = _api_curated_group_create(client, name='The Awkward Age', sids=['5678901234'])
         student_feed = _api_get_curated_group(client, group['id'])['students'][0]
         assert student_feed['term']['enrollments'][0]['canvasSites'] == []

--- a/tests/test_api/test_search_controller.py
+++ b/tests/test_api/test_search_controller.py
@@ -66,11 +66,6 @@ def ce3_advisor(fake_auth):
     fake_auth.login('2525')
 
 
-@pytest.fixture()
-def no_canvas_access_advisor(fake_auth):
-    fake_auth.login('1')
-
-
 @pytest.fixture(scope='session')
 def asc_inactive_students():
     return data_loch.safe_execute_rds("""
@@ -225,8 +220,10 @@ class TestStudentSearch:
         assert len(students) == 1
         assert students[0]['name'] == 'Wolfgang Pauli-O\'Rourke'
 
-    def test_search_by_name_no_canvas_data_access(self, no_canvas_access_advisor, client):
+    def test_search_by_name_no_canvas_data_access(self, advisor_factory, client, fake_auth):
         """A user with no access to Canvas data can still search for students."""
+        advisor = advisor_factory(can_access_canvas_data=False)
+        fake_auth.login(advisor.uid)
         api_json = _api_search(client, 'Paul', students=True)
         assert len(api_json['students']) == 3
 
@@ -299,8 +296,10 @@ class TestCourseSearch:
         assert len([c for c in courses if c['courseName'] == 'MATH 1A']) == 2
         assert len([c for c in courses if c['courseName'] == 'DANISH 1A']) == 1
 
-    def test_search_courses_no_canvas_data_access(self, no_canvas_access_advisor, client):
+    def test_search_courses_no_canvas_data_access(self, advisor_factory, client, fake_auth):
         """A user with no access to Canvas data cannot search for courses."""
+        advisor = advisor_factory(can_access_canvas_data=False)
+        fake_auth.login(advisor.uid)
         _api_search(client, '1A', courses=True, students=True, expected_status_code=403)
 
 
@@ -523,8 +522,10 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=2, note_ids=['9000000000-00002', '9100000000-00001'])
 
-    def test_search_notes_no_canvas_data_access(self, client, no_canvas_access_advisor):
+    def test_search_notes_no_canvas_data_access(self, advisor_factory, client, fake_auth):
         """A user with no access to Canvas data can still search for notes."""
+        advisor = advisor_factory(can_access_canvas_data=False)
+        fake_auth.login(advisor.uid)
         api_json = _api_search(
             client,
             '',
@@ -727,8 +728,10 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=2)
 
-    def test_search_appointments_no_canvas_data_access(self, client, no_canvas_access_advisor):
+    def test_search_appointments_no_canvas_data_access(self, advisor_factory, client, fake_auth):
         """A user with no access to Canvas data can still search for appointments."""
+        advisor = advisor_factory(can_access_canvas_data=False)
+        fake_auth.login(advisor.uid)
         api_json = _api_search(
             client,
             '',

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -56,11 +56,6 @@ def coe_scheduler_login(fake_auth):
     fake_auth.login(coe_scheduler_uid)
 
 
-@pytest.fixture()
-def no_canvas_data_access_advisor_login(fake_auth):
-    fake_auth.login('1')
-
-
 @pytest.mark.usefixtures('db_session')
 class TestStudent:
     """Student API."""
@@ -333,7 +328,9 @@ class TestStudent:
             assert analytics['lastActivity']['student']['percentile'] == 93
             assert analytics['lastActivity']['displayPercentile'] == '90th'
 
-    def test_suppresses_canvas_data_if_unauthorized(self, client, no_canvas_data_access_advisor_login):
+    def test_suppresses_canvas_data_if_unauthorized(self, advisor_factory, client, fake_auth):
+        advisor = advisor_factory(can_access_canvas_data=False)
+        fake_auth.login(advisor.uid)
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
         student_by_sid = self._api_student_by_sid(client=client, sid=sid)

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -40,7 +40,6 @@ ce3_advisor_uid = '2525'
 coe_advisor_uid = '1133399'
 coe_advisor_no_advising_data_uid = '1022796'
 coe_scheduler_uid = '6972201'
-deleted_user_csid = '333333333'
 deleted_user_uid = '33333'
 l_s_college_scheduler_uid = '19735'
 l_s_college_advisor_uid = '188242'
@@ -684,7 +683,7 @@ class TestUserSearch:
     def test_user_search_by_uid(self, client, fake_auth):
         """Search users by UID."""
         fake_auth.login(admin_uid)
-        assert len(self._api_users_autocomplete(client, '339')) == 2
+        assert len(self._api_users_autocomplete(client, '339')) >= 2
 
     def test_search_for_deleted_user_by_uid(self, client, fake_auth):
         """Search for deleted user by UID."""

--- a/tests/test_merged/test_advising_appointment.py
+++ b/tests/test_merged/test_advising_appointment.py
@@ -24,10 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 
-from boac.merged.advising_appointment import (
-    get_advising_appointments,
-    search_advising_appointments,
-)
+from boac.merged.advising_appointment import get_advising_appointments, search_advising_appointments
 
 
 coe_advisor_uid = '1133399'
@@ -43,9 +40,9 @@ class TestMergedAdvisingAppointment:
         assert len(appointments) == 5
 
         # Legacy SIS appointments
+        advisor_user_id = appointments[0]['advisor']['id']
         assert appointments[0]['id'] == '11667051-00010'
         assert appointments[0]['advisor']
-        assert appointments[0]['advisor']['id'] == 7
         assert appointments[0]['advisor']['name'] == 'Milicent Balthazar'
         assert appointments[0]['advisor']['sid'] == '53791'
         assert appointments[0]['advisor']['title'] is None
@@ -73,7 +70,6 @@ you got to pull up the intruder by the root of the weed; N.Y. Chew through the m
         # Non-legacy appointments
         assert appointments[3]['id'] == 5
         assert appointments[3]['advisor']
-        assert appointments[3]['advisor']['id'] == 7
         assert appointments[3]['advisor']['name'] == 'Milicent Balthazar'
         assert appointments[3]['advisor']['title'] == 'Advisor'
         assert appointments[3]['advisor']['uid'] == '53791'
@@ -84,7 +80,7 @@ you got to pull up the intruder by the root of the weed; N.Y. Chew through the m
         assert appointments[3]['appointmentType'] == 'Drop-in'
         assert appointments[3]['attachments'] is None
         assert appointments[3]['createdAt']
-        assert appointments[3]['createdBy'] == 7
+        assert appointments[3]['createdBy'] == advisor_user_id
         assert appointments[3]['deptCode'] == 'QCADV'
         assert appointments[3]['details'] == 'It is not the length of life, but depth of life.'
         assert 'legacySource' not in appointments[3]
@@ -92,12 +88,12 @@ you got to pull up the intruder by the root of the weed; N.Y. Chew through the m
         assert appointments[3]['student']['sid'] == student_sid
         assert appointments[3]['topics'] == ['Topic for appointments, 1']
         assert appointments[3]['updatedAt'] is None
-        assert appointments[3]['updatedBy'] == 7
+        assert appointments[3]['updatedBy'] == advisor_user_id
         assert appointments[3]['cancelReason'] is None
         assert appointments[3]['cancelReasonExplained'] is None
         assert appointments[3]['status'] == 'checked_in'
         assert appointments[3]['statusBy']
-        assert appointments[3]['statusBy']['id'] == 7
+        assert appointments[3]['statusBy']['id'] == advisor_user_id
         assert appointments[3]['statusBy']['uid'] == '53791'
         assert appointments[3]['statusBy']['csid'] == '53791'
         assert appointments[3]['statusBy']['name'] == 'Milicent Balthazar'
@@ -115,7 +111,7 @@ you got to pull up the intruder by the root of the weed; N.Y. Chew through the m
         assert appointments[4]['appointmentType'] == 'Drop-in'
         assert appointments[4]['attachments'] is None
         assert appointments[4]['createdAt']
-        assert appointments[4]['createdBy'] == 7
+        assert appointments[4]['createdBy'] == advisor_user_id
         assert appointments[4]['deptCode'] == 'QCADV'
         assert appointments[4]['details'] == 'You be you.'
         assert 'legacySource' not in appointments[4]
@@ -123,12 +119,12 @@ you got to pull up the intruder by the root of the weed; N.Y. Chew through the m
         assert appointments[4]['student']['sid'] == student_sid
         assert appointments[4]['topics'] == ['Topic for appointments, 1']
         assert appointments[4]['updatedAt'] is None
-        assert appointments[4]['updatedBy'] == 7
+        assert appointments[4]['updatedBy'] == advisor_user_id
         assert appointments[4]['cancelReason'] is None
         assert appointments[4]['cancelReasonExplained'] is None
         assert appointments[4]['status'] == 'waiting'
         assert appointments[4]['statusBy']
-        assert appointments[4]['statusBy']['id'] == 7
+        assert appointments[4]['statusBy']['id'] == advisor_user_id
         assert appointments[4]['statusBy']['uid'] == '53791'
         assert appointments[4]['statusBy']['csid'] == '53791'
         assert appointments[4]['statusBy']['name'] == 'Milicent Balthazar'
@@ -136,7 +132,7 @@ you got to pull up the intruder by the root of the weed; N.Y. Chew through the m
         assert appointments[4]['statusBy']['firstName'] == 'Milicent'
         assert appointments[4]['statusDate']
 
-    def test_search(self, fake_auth, app):
+    def test_search(self, fake_auth):
         """Finds new and legacy appointments matching the criteria, ordered by rank."""
         fake_auth.login(coe_advisor_uid)
         results = search_advising_appointments(search_phrase='life')

--- a/tests/test_models/test_university_dept.py
+++ b/tests/test_models/test_university_dept.py
@@ -37,14 +37,6 @@ class TestUniversityDept:
         uids = [a['uid'] for a in advisors]
         advisors_by_uid = {
             uid: [a for a in advisors if a['uid'] == uid] for uid in uids}
-        assert advisors_by_uid.get('13') == [
-            {
-                'uid': '13',
-                'can_access_advising_data': True,
-                'can_access_canvas_data': False,
-                'degree_progress_permission': 'read_write',
-            },
-        ]
         assert advisors_by_uid.get('90412') == [
             {
                 'uid': '90412',


### PR DESCRIPTION
Trying to avoid the pitfalls of not-always-static test data.