### PR TITLE
BOAC-4629, conftest/development_db refactor to support users with 2+ depts

### DIFF
--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -451,7 +451,7 @@ def _create_users():
         if not user:
             user = AuthorizedUser(
                 uid=uid,
-                created_by='2040',
+                created_by='0',
                 is_admin=test_user['isAdmin'],
                 in_demo_mode=test_user['inDemoMode'],
                 can_access_advising_data=test_user['canAccessAdvisingData'],
@@ -657,9 +657,6 @@ def _create_topics():
 
 
 def _create_curated_groups():
-    admin_user = AuthorizedUser.find_by_uid('2040')
-    CuratedGroup.create(admin_user.id, 'My Students')
-
     asc_advisor = AuthorizedUser.find_by_uid('6446')
     CuratedGroup.create(asc_advisor.id, 'My Students')
 
@@ -684,28 +681,6 @@ def _create_curated_groups():
 
 
 def _create_cohorts():
-    # Oliver's cohorts
-    CohortFilter.create(
-        uid='2040',
-        name='All sports',
-        filter_criteria={
-            'groupCodes': ['MFB-DL', 'WFH'],
-        },
-    )
-    CohortFilter.create(
-        uid='2040',
-        name='Football, Defense',
-        filter_criteria={
-            'groupCodes': ['MFB-DB', 'MFB-DL'],
-        },
-    )
-    CohortFilter.create(
-        uid='2040',
-        name='Field Hockey',
-        filter_criteria={
-            'groupCodes': ['WFH'],
-        },
-    )
     # Flint's cohorts
     asc_advisor_uid = '1081940'
     CohortFilter.create(

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -59,9 +59,9 @@ class TestCourseController:
         """Returns 403 if user is only a scheduler."""
         assert client.get('/api/section/2182/1').status_code == 401
 
-    def test_not_authorized(self, advisor_factory, client, fake_auth):
+    def test_not_authorized(self, user_factory, client, fake_auth):
         """Returns 403 if user is not authorized."""
-        advisor = advisor_factory(can_access_canvas_data=False)
+        advisor = user_factory(can_access_canvas_data=False)
         fake_auth.login(advisor.uid)
         assert client.get('/api/section/2182/1').status_code == 403
 

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -31,7 +31,6 @@ import simplejson as json
 from tests.test_api.api_test_utils import api_curated_group_add_students, api_curated_group_remove_student
 from tests.util import override_config
 
-admin_uid = '2040'
 asc_advisor_uid = '6446'
 authorized_advisor_uid = '90412'
 ce3_advisor_uid = '2525'
@@ -60,13 +59,13 @@ def coe_scheduler(fake_auth):
 
 
 @pytest.fixture()
-def admin_user_session(fake_auth):
-    fake_auth.login(admin_uid)
+def admin_user_session(admin_user_uid, fake_auth):
+    fake_auth.login(admin_user_uid)
 
 
 @pytest.fixture()
-def admin_curated_groups():
-    user = AuthorizedUser.find_by_uid(admin_uid)
+def admin_curated_groups(admin_user_uid):
+    user = AuthorizedUser.find_by_uid(admin_user_uid)
     return CuratedGroup.get_curated_groups(user.id)
 
 
@@ -330,9 +329,9 @@ class TestGetCuratedGroup:
         assert student_term['enrollments'][0]['displayName'] == 'CLASSIC 130 LEC 001'
         assert student_term['enrollments'][0]['grade'] == 'P'
 
-    def test_curated_group_detail_suppresses_canvas_data_when_unauthorized(self, advisor_factory, client, fake_auth):
+    def test_curated_group_detail_suppresses_canvas_data_when_unauthorized(self, user_factory, client, fake_auth):
         """Suppress Canvas data when unauthorized."""
-        advisor = advisor_factory(can_access_canvas_data=False)
+        advisor = user_factory(can_access_canvas_data=False)
         fake_auth.login(advisor.uid)
         group = _api_curated_group_create(client, name='The Awkward Age', sids=['5678901234'])
         student_feed = _api_get_curated_group(client, group['id'])['students'][0]

--- a/tests/test_models/test_authorized_user.py
+++ b/tests/test_models/test_authorized_user.py
@@ -41,13 +41,12 @@ class TestAuthorizedUser:
         """Returns None to Flask-Login for unrecognized UID."""
         assert AuthorizedUser.find_by_uid(unknown_uid) is None
 
-    def test_load_admin_user(self):
+    def test_load_admin_user(self, admin_user_uid):
         """Returns authorization record to Flask-Login for recognized UID."""
-        loaded_user = AuthorizedUser.find_by_uid(admin_uid)
-        assert loaded_user.uid == admin_uid
+        loaded_user = AuthorizedUser.find_by_uid(admin_user_uid)
+        assert loaded_user.uid == admin_user_uid
         assert loaded_user.is_admin
         assert len(loaded_user.cohort_filters) > 0
-
         assert loaded_user.cohort_filters[0].owner == loaded_user
 
     def test_create_or_restore_deleted(self):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4629

Test coverage is tricky when all test data is hard-coded in development_db. A bloated BOA needs smart fixtures w.r.t mock users and the associated data_loch rows. This is a first pass at more collision-proof test data.

A follow up PR will have fix to BOAC-4629 and test coverage w/ a multi-dept user.