### PR TITLE
BOAC-4639, if section has 2+ meetings, include start/end dates in uniqueness key

### DIFF
--- a/boac/merged/sis_sections.py
+++ b/boac/merged/sis_sections.py
@@ -83,6 +83,8 @@ def _get_meetings(section_rows):
                 'W': 'Online',
             }.get(instruction_mode, instruction_mode),
             'location': row['meeting_location'],
+            'endDate': row['meeting_end_date'],
+            'startDate': row['meeting_start_date'],
             'time': times,
         }
         key = str(meeting)

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -47,7 +47,12 @@
                   {{ meeting.instructors.join(', ') }}
                 </div>
                 <div :id="'meetings-' + meetingIndex" class="font-size-16">
-                  <div>{{ meeting.days }}</div>
+                  <div>
+                    {{ meeting.days }}
+                    <span v-if="section.meetings.length > 1">
+                      ({{ meeting.startDate | moment('MMM D') }} to {{ meeting.endDate | moment('MMM D') }})
+                    </span>
+                  </div>
                   <div>{{ meeting.time }}</div>
                   <div>{{ meeting.location }}<span v-if="meeting.instructionModeName"><span v-if="meeting.location"> &mdash; </span>{{ meeting.instructionModeName }}</span></div>
                 </div>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4639

See the Jira for details. Diablo has a similar issue: https://jira-secure.berkeley.edu/browse/DIABLO-717