### PR TITLE
BOAC-4639, clear 'sis_section' entries from BOA json_cache

### DIFF
--- a/scripts/db/migrate/2022/20220216-BOAC-4639/clear_course_data_from_json_cache.sql
+++ b/scripts/db/migrate/2022/20220216-BOAC-4639/clear_course_data_from_json_cache.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DELETE FROM json_cache WHERE key LIKE '%-sis_section_%';
+
+COMMIT;


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4639

Remove dead entries from json_cache. `sis_section` data is no longer cached (see #3507)