### PR TITLE
BOAC-4632, .ebextension config to include boa.log in log-bundle download

### DIFF
--- a/.ebextensions/02_logs.config
+++ b/.ebextensions/02_logs.config
@@ -1,0 +1,7 @@
+files:
+  "/opt/elasticbeanstalk/tasks/bundlelogs.d/boa-logs.conf":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      /var/app/current/boa.log*


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4632

Per AWS docs:
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.logging.html#health-logs-extend