### PR TITLE
BOAC-4839 COE cohort filters default to excluding COE inactives

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -1227,10 +1227,17 @@ def get_students_query(     # noqa
         query_filter += f' AND s.probation IS {coe_probation}'
     if coe_underrepresented is not None:
         query_filter += f' AND s.minority IS {coe_underrepresented}'
+
+    # COE criteria in a cohort filter will default to COE-active students only.
+    if is_active_coe is None and (
+        coe_advisor_ldap_uids or coe_ethnicities or coe_genders or coe_prep_statuses or coe_probation or coe_underrepresented
+    ):
+        is_active_coe = True
     if is_active_coe is False:
         query_filter += " AND s.status IN ('D','P','U','W','X','Z')"
     elif is_active_coe is True:
         query_filter += " AND s.status NOT IN ('D','P','U','W','X','Z')"
+
     return query_tables, query_filter, query_bindings
 
 

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -1433,7 +1433,6 @@ class TestDownloadCsvPerFilters:
             'first_name,last_name,sid,email,phone,majors,level_by_units,terms_in_attendance,expected_graduation_term,units_completed,term_gpa_2172,term_gpa_2175,cumulative_gpa,program_status',  # noqa: E501
             'Deborah,Davies,11667051,barnburner@berkeley.edu,415/123-4567,English BA;Nuclear Engineering BS,Junior,,Fall 2019,101.3,2.700,,3.8,Active',  # noqa: E501
             'Paul,Farestveit,7890123456,qadept@berkeley.edu,415/123-4567,Nuclear Engineering BS,Senior,2,Spring 2020,110,,,3.9,Active',
-            'Wolfgang,Pauli-O\'Rourke,9000000000,wpo@berkeley.edu,415/123-4567,Engineering Undeclared UG,Sophomore,2,Spring 2020,55,,,2.3,Active',
         ]:
             assert str(snippet) in csv
 

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -434,7 +434,7 @@ class TestBatchNoteCreation:
         # Cohort
         cohort_ids, sids_in_cohorts = _get_cohorts_ids_and_sids(advisor)
         # We need at least one cohort SID that is NOT in the list o' sids above.
-        expected_sid_in_cohort = '9000000000'
+        expected_sid_in_cohort = '7890123456'
         assert expected_sid_in_cohort not in self.sids
         assert expected_sid_in_cohort in sids_in_cohorts
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4839