### PR TITLE
BOAC-4888, front-end: refactor edit-note transactions; edit-batch-note-modal for editing drafts

### DIFF
--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -205,7 +205,7 @@ def update_note():
             is_private=is_private,
             note_id=note.id,
             set_date=set_date,
-            sid=sids[0],
+            sid=sids[0] if sids else None,
             subject=subject,
             topics=topics,
         )

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -375,6 +375,7 @@ class Note(Base):
             note.body = body
             note.contact_type = contact_type
             note.is_private = is_private
+            note.sid = sid
             note.set_date = set_date
             note.subject = subject
             cls._update_note_topics(note, topics)

--- a/src/components/note/BatchNoteFeatures.vue
+++ b/src/components/note/BatchNoteFeatures.vue
@@ -1,49 +1,42 @@
 <template>
   <div>
-    <div>
-      <span role="alert">
-        <transition name="drawer">
-          <div
-            v-if="!isRecalculating && completeSidSet.length"
-            id="target-student-count-alert"
-            :class="{'has-error': completeSidSet.length >= 250, 'font-weight-bolder': completeSidSet.length >= 500}"
-            class="font-italic pb-2"
-          >
-            <span v-if="completeSidSet.length < 500">This note will be attached</span>
-            <span v-if="completeSidSet.length >= 500">Are you sure you want to attach this note</span>
-            to {{ pluralize('student record', completeSidSet.length) }}.
-            <div v-if="completeSidSet.length > 1">
-              <span class="font-weight-700 has-error">Important:</span> Saving as a draft will save the content of your
-              note but not the associated students.
-            </div>
-          </div>
-        </transition>
-        <span v-if="!completeSidSet.length && (addedCohorts.length || addedCuratedGroups.length)" class="font-italic">
-          <span
-            v-if="addedCohorts.length && !addedCuratedGroups.length"
-            id="no-students-per-cohorts-alert"
-          >There are no students in the {{ pluralize('cohort', addedCohorts.length, {1: ' '}) }}.</span>
-          <span
-            v-if="addedCuratedGroups.length && !addedCohorts.length"
-            id="no-students-per-curated-groups-alert"
-          >There are no students in the {{ pluralize('group', addedCuratedGroups.length, {1: ' '}) }}.</span>
-          <span
-            v-if="addedCohorts.length && addedCuratedGroups.length"
-            id="no-students-alert"
-          >
-            Neither the {{ pluralize('cohort', addedCohorts.length, {1: ' '}) }} nor the {{ pluralize('group', addedCuratedGroups.length, {1: ' '}) }} have students.
-          </span>
+    <div role="alert">
+      <div
+        v-if="!isRecalculating && completeSidSet.length"
+        id="target-student-count-alert"
+        :class="{'has-error': completeSidSet.length >= 250, 'font-weight-bolder': completeSidSet.length >= 500}"
+        class="font-italic pb-2"
+      >
+        <span v-if="completeSidSet.length < 500">This note will be attached</span>
+        <span v-if="completeSidSet.length >= 500">Are you sure you want to attach this note</span>
+        to {{ pluralize('student record', completeSidSet.length) }}.
+        <div v-if="!['editDraft', 'editTemplate'].includes(mode) && completeSidSet.length > 1">
+          <span class="font-weight-700 has-error">Important:</span> Saving as a draft will save the content of your
+          note but not the associated students.
+        </div>
+      </div>
+      <span v-if="!completeSidSet.length && (addedCohorts.length || addedCuratedGroups.length)" class="font-italic">
+        <span
+          v-if="addedCohorts.length && !addedCuratedGroups.length"
+          id="no-students-per-cohorts-alert"
+        >There are no students in the {{ pluralize('cohort', addedCohorts.length, {1: ' '}) }}.</span>
+        <span
+          v-if="addedCuratedGroups.length && !addedCohorts.length"
+          id="no-students-per-curated-groups-alert"
+        >There are no students in the {{ pluralize('group', addedCuratedGroups.length, {1: ' '}) }}.</span>
+        <span
+          v-if="addedCohorts.length && addedCuratedGroups.length"
+          id="no-students-alert"
+        >
+          Neither the {{ pluralize('cohort', addedCohorts.length, {1: ' '}) }} nor the {{ pluralize('group', addedCuratedGroups.length, {1: ' '}) }} have students.
         </span>
       </span>
     </div>
     <div>
       <BatchNoteAddStudent
-        :add-sid="addStudentBySid"
-        :add-sid-list="addStudentsBySidList"
         :disabled="isSaving || boaSessionExpired"
-        :on-esc-form-input="cancel"
-        :remove-sid="removeSid"
         dropdown-class="position-relative"
+        :on-esc-form-input="cancel"
       />
     </div>
     <div>
@@ -84,7 +77,10 @@ export default {
   },
   mixins: [Context, NoteEditSession, Util],
   props: {
-    cancel: Function
+    cancel: {
+      required: true,
+      type: Function
+    }
   },
   methods: {
     addCohortToBatch(cohort) {
@@ -97,16 +93,6 @@ export default {
       this.addCuratedGroup(curatedGroup)
       this.$announcer.polite(`Added ${this.describeCuratedGroupDomain(curatedGroup.domain)} '${curatedGroup.name}'`)
     },
-    addStudentBySid(sid) {
-      this.setIsRecalculating(true)
-      this.addSid(sid)
-      this.$putFocusNextTick('create-note-add-student-input')
-    },
-    addStudentsBySidList(sidList) {
-      this.setIsRecalculating(true)
-      this.addSidList(sidList)
-      this.$putFocusNextTick('create-note-add-student-input')
-    },
     removeCohortFromBatch(cohort) {
       this.setIsRecalculating(true)
       this.removeCohort(cohort)
@@ -116,13 +102,6 @@ export default {
       this.setIsRecalculating(true)
       this.removeCuratedGroup(curatedGroup)
       this.$announcer.polite(`${this.$_.capitalize(this.describeCuratedGroupDomain(curatedGroup.domain))} '${curatedGroup.name}' removed`)
-    },
-    removeSid(sid) {
-      if (this.$_.includes(this.sids, sid)) {
-        this.setIsRecalculating(true)
-        this.removeStudent(sid)
-        this.$putFocusNextTick('create-note-add-student-input')
-      }
     }
   }
 }

--- a/src/components/note/CreateNoteFooter.vue
+++ b/src/components/note/CreateNoteFooter.vue
@@ -13,7 +13,7 @@
       <div class="d-flex flex-wrap-reverse">
         <div class="flex-grow-1">
           <b-btn
-            v-if="mode !== 'editTemplate'"
+            v-if="!['editTemplate'].includes(mode)"
             id="btn-save-as-template"
             :disabled="isSaving || !$_.trim(model.subject) || !!model.setDate || !!model.contactType"
             variant="link"
@@ -33,26 +33,26 @@
             Update Template
           </b-btn>
         </div>
-        <div v-if="mode !== 'editTemplate'">
+        <div v-if="model.isDraft">
           <b-btn
             id="save-as-draft-button"
             class="mr-2"
             :disabled="isSaving || (!$_.trim(model.subject) && !$_.trim(model.body))"
             variant="link"
-            @click.prevent="createDraft"
+            @click.prevent="updateNote"
           >
-            Save Draft
+            {{ mode === 'editDraft' ? 'Update' : 'Save' }} Draft
           </b-btn>
         </div>
-        <div v-if="mode !== 'editTemplate'">
+        <div v-if="!['editTemplate'].includes(mode)">
           <b-btn
             id="create-note-button"
             :disabled="isSaving || !completeSidSet.length || !$_.trim(model.subject)"
             class="btn-primary-color-override"
             variant="primary"
-            @click.prevent="createNote"
+            @click.prevent="publish"
           >
-            Save
+            {{ mode === 'editDraft' ? 'Publish' : 'Save' }}
           </b-btn>
         </div>
         <div>
@@ -85,21 +85,23 @@ export default {
       required: true,
       type: Function
     },
-    createNote: {
-      required: true,
-      type: Function
-    },
-    createDraft: {
-      required: true,
-      type: Function
-    },
     saveAsTemplate: {
+      required: true,
+      type: Function
+    },
+    updateNote: {
       required: true,
       type: Function
     },
     updateTemplate: {
       required: true,
       type: Function
+    }
+  },
+  methods: {
+    publish() {
+      this.setIsDraft(false)
+      this.updateNote()
     }
   }
 }

--- a/src/components/note/CreateNoteHeader.vue
+++ b/src/components/note/CreateNoteHeader.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="align-items-end d-flex flex-wrap mb-1 mt-2 pt-2">
     <div class="flex-grow-1">
-      <ModalHeader class="border-bottom-0" header-id="modal-header-note" :text="mode === 'editTemplate' ? 'Edit Template' : 'New Note'" />
+      <ModalHeader
+        class="border-bottom-0"
+        header-id="modal-header-note"
+        :text="headerText"
+      />
     </div>
     <div class="mr-4">
       <b-dropdown
@@ -117,10 +121,34 @@ export default {
     }
   },
   data: () => ({
+    modalHeader: undefined,
     showDeleteTemplateModal: false,
     showRenameTemplateModal: false,
     targetTemplate: undefined
   }),
+  computed: {
+    headerText() {
+      let text
+      switch (this.mode) {
+      case 'createBatch':
+        text = 'Create Note(s)'
+        break
+      case 'createNote':
+        text = 'Create Note'
+        break
+      case 'editDraft':
+        text = 'Edit Draft Note'
+        break
+      case 'editNote':
+        text = 'Edit Note'
+        break
+      case 'editTemplate':
+        text = 'Edit Note Template'
+        break
+      }
+      return text
+    }
+  },
   methods: {
     cancel() {
       this.showDeleteTemplateModal = false

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -182,7 +182,7 @@ export default {
       if (note.sid) {
         this.addSid(note.sid)
       }
-      this.setMode('edit')
+      this.setMode('editNote')
       this.$putFocusNextTick('edit-note-subject')
       this.$announcer.polite('Edit note form is open.')
     })
@@ -224,15 +224,18 @@ export default {
     save(isDraft) {
       const ifAuthenticated = () => {
         const trimmedSubject = this.$_.trim(this.model.subject)
-        const dateString = this.model.setDate ? this.$moment(this.model.setDate).format('YYYY-MM-DD') : null
+        const setDate = this.model.setDate ? this.$moment(this.model.setDate).format('YYYY-MM-DD') : null
         if (trimmedSubject) {
           updateNote(
+            this.model.id,
             this.$_.trim(this.model.body),
+            [],
             this.model.contactType,
+            [],
             isDraft,
             this.model.isPrivate,
-            this.model.id,
-            dateString,
+            setDate,
+            this.sids,
             trimmedSubject,
             this.model.topics
           ).then(updatedNote => {

--- a/src/components/note/EditBatchNoteModal.vue
+++ b/src/components/note/EditBatchNoteModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div role="dialog">
+  <div v-if="mode" role="dialog">
     <FocusLock
       :disabled="isFocusLockDisabled"
       class="create-note-container"
@@ -8,109 +8,112 @@
         id="new-note-modal-container"
         :class="{
           'd-none': $_.isNil(mode),
-          'modal-content': $_.includes(['batch', 'create', 'editTemplate'], mode),
-          'mt-4': isBatchFeature
+          'modal-content': ['createBatch', 'createNote', 'editDraft', 'editTemplate'].includes(mode),
+          'mt-4': ['createBatch', 'editDraft'].includes(mode)
         }"
       >
-        <form @submit.prevent="submitForm">
-          <CreateNoteHeader :cancel-primary-modal="cancelRequested" />
-          <hr class="m-0" />
-          <div class="mt-2 mr-3 mb-1 ml-3">
-            <transition v-if="isBatchFeature" name="batch">
-              <div v-show="mode !== 'editTemplate'">
-                <BatchNoteFeatures :cancel="cancelRequested" />
-                <hr />
-              </div>
-            </transition>
-            <div class="ml-2 mr-3 mt-2 pl-2 pr-2">
-              <b-alert
-                id="alert-in-note-modal"
-                :show="dismissAlertSeconds"
-                class="font-weight-bolder w-100"
-                dismissible
-                fade
-                variant="info"
-                aria-live="polite"
-                role="alert"
-                @dismiss-count-down="dismissAlert"
-              >
-                <div class="d-flex">
-                  <div v-if="isSaving" class="mr-2">
-                    <font-awesome icon="sync" spin />
-                  </div>
-                  <div>{{ alert }}</div>
+        <CreateNoteHeader :cancel-primary-modal="cancelRequested" />
+        <hr class="m-0" />
+        <div class="mt-2 mr-3 mb-1 ml-3">
+          <transition v-if="['createBatch', 'editDraft'].includes(mode)" name="batch-transition">
+            <div v-show="mode !== 'editTemplate'">
+              <BatchNoteFeatures :cancel="cancelRequested" />
+              <hr />
+            </div>
+          </transition>
+          <div class="ml-2 mr-3 mt-2 pl-2 pr-2">
+            <b-alert
+              id="alert-in-note-modal"
+              :show="dismissAlertSeconds"
+              class="font-weight-bolder w-100"
+              dismissible
+              fade
+              variant="info"
+              aria-live="polite"
+              role="alert"
+              @dismiss-count-down="dismissAlert"
+            >
+              <div class="d-flex">
+                <div v-if="isSaving" class="mr-2">
+                  <font-awesome icon="sync" spin />
                 </div>
-              </b-alert>
-            </div>
-            <div>
-              <label id="create-note-subject-label" for="create-note-subject" class="font-size-14 font-weight-bolder mb-1"><span class="sr-only">Note </span>Subject</label>
-            </div>
-            <div>
-              <input
-                id="create-note-subject"
-                :value="model.subject"
-                :disabled="isSaving || boaSessionExpired"
-                :class="{'bg-light': isSaving}"
-                aria-labelledby="create-note-subject-label"
-                class="cohort-create-input-name"
-                maxlength="255"
-                type="text"
-                @input="setSubjectPerEvent"
-                @keydown.esc="cancelRequested"
-              >
-            </div>
-            <div id="note-details">
-              <RichTextEditor
-                :initial-value="model.body || ''"
-                :disabled="isSaving || boaSessionExpired"
-                :is-in-modal="true"
-                label="Note Details"
-                :on-value-update="setBody"
-              />
-            </div>
+                <div>{{ alert }}</div>
+              </div>
+            </b-alert>
           </div>
           <div>
-            <div class="mt-2 mr-3 mb-1 ml-3">
-              <AdvisingNoteTopics
-                :key="mode"
-                :disabled="isSaving || boaSessionExpired"
-                :function-add="addTopic"
-                :function-remove="removeTopic"
-                :topics="model.topics"
-              />
-            </div>
-            <div class="mt-2 mr-3 mb-3 ml-3">
-              <PrivacyPermissions
-                v-if="$currentUser.canAccessPrivateNotes"
-                :disabled="isSaving || boaSessionExpired"
-              />
-            </div>
-            <div class="mt-2 mr-3 mb-3 ml-3">
-              <ContactMethod :disabled="isSaving || boaSessionExpired" />
-            </div>
-            <div class="mt-2 mb-3 ml-3">
-              <ManuallySetDate :disabled="isSaving || boaSessionExpired" />
-            </div>
-            <div class="mt-2 mr-3 mb-1 ml-3">
-              <AdvisingNoteAttachments
-                :add-attachment="addAttachment"
-                :disabled="isSaving || boaSessionExpired"
-                :existing-attachments="model.attachments"
-                :remove-attachment="removeAttachment"
-              />
-            </div>
+            <label
+              id="create-note-subject-label"
+              for="create-note-subject"
+              class="font-size-14 font-weight-bolder mb-1"
+            >
+              <span class="sr-only">Note </span>Subject
+            </label>
           </div>
-          <hr />
           <div>
-            <CreateNoteFooter
-              :cancel="cancelRequested"
-              :create-note="createNote"
-              :create-draft="createDraft"
-              :save-as-template="saveAsTemplate"
-              :update-template="updateTemplate"
+            <input
+              id="create-note-subject"
+              :value="model.subject"
+              :disabled="isSaving || boaSessionExpired"
+              :class="{'bg-light': isSaving}"
+              aria-labelledby="create-note-subject-label"
+              class="cohort-create-input-name"
+              maxlength="255"
+              type="text"
+              @input="setSubjectPerEvent"
+              @keydown.esc="cancelRequested"
+            >
+          </div>
+          <div id="note-details">
+            <RichTextEditor
+              :initial-value="model.body || ''"
+              :disabled="isSaving || boaSessionExpired"
+              :is-in-modal="true"
+              label="Note Details"
+              :on-value-update="setBody"
             />
           </div>
-        </form>
+        </div>
+        <div>
+          <div class="mt-2 mr-3 mb-1 ml-3">
+            <AdvisingNoteTopics
+              :key="mode"
+              :disabled="isSaving || boaSessionExpired"
+              :function-add="addTopic"
+              :function-remove="removeTopic"
+              :topics="model.topics"
+            />
+          </div>
+          <div class="mt-2 mr-3 mb-3 ml-3">
+            <PrivacyPermissions
+              v-if="$currentUser.canAccessPrivateNotes"
+              :disabled="isSaving || boaSessionExpired"
+            />
+          </div>
+          <div class="mt-2 mr-3 mb-3 ml-3">
+            <ContactMethod :disabled="isSaving || boaSessionExpired" />
+          </div>
+          <div class="mt-2 mb-3 ml-3">
+            <ManuallySetDate :disabled="isSaving || boaSessionExpired" />
+          </div>
+          <div class="mt-2 mr-3 mb-1 ml-3">
+            <AdvisingNoteAttachments
+              :add-attachment="addAttachment"
+              :disabled="isSaving || boaSessionExpired"
+              :existing-attachments="model.attachments"
+              :remove-attachment="removeAttachment"
+            />
+          </div>
+        </div>
+        <hr />
+        <div>
+          <CreateNoteFooter
+            :cancel="cancelRequested"
+            :save-as-template="saveAsTemplate"
+            :update-note="updateNote"
+            :update-template="updateTemplate"
+          />
+        </div>
       </div>
     </FocusLock>
     <AreYouSureModal
@@ -153,6 +156,7 @@ import PrivacyPermissions from '@/components/note/PrivacyPermissions'
 import RichTextEditor from '@/components/util/RichTextEditor'
 import store from '@/store'
 import Util from '@/mixins/Util'
+import {createNotes, deleteNote, getNote} from '@/api/notes'
 import {createNoteTemplate, updateNoteTemplate} from '@/api/note-templates'
 import {getUserProfile} from '@/api/user'
 
@@ -174,18 +178,24 @@ export default {
   },
   mixins: [Context, NoteEditSession, Util],
   props: {
-    isBatchFeature: {
+    initialMode: {
       required: true,
-      type: Boolean
+      type: String
     },
-    note: {
-      required: true,
-      type: Object
+    noteId: {
+      default: undefined,
+      required: false,
+      type: Number
     },
     onClose: {
       default: () => {},
       required: false,
       type: Function
+    },
+    sid: {
+      default: undefined,
+      required: false,
+      type: String
     }
   },
   data: () => ({
@@ -196,15 +206,17 @@ export default {
     showDiscardTemplateModal: false,
     showErrorPopover: false
   }),
-  mounted() {
+  created() {
     store.dispatch('noteEditSession/loadNoteTemplates')
     this.resetModel()
-    this.setModel(this.$_.cloneDeep(this.note))
-    this.setMode(this.isBatchFeature ? 'batch' : 'create')
-    this.$announcer.polite(this.isBatchFeature ? 'Create batch note form is open.' : 'Create note form is open')
-    this.$putFocusNextTick('modal-header-note')
-    this.$eventHub.on('user-session-expired', () => {
-      this.onBoaSessionExpires()
+    this.init().then(note => {
+      this.setModel(this.$_.cloneDeep(note))
+      this.setMode(this.initialMode)
+      this.$announcer.polite(this.mode === 'createNote' ? 'Create note form is open.' : 'Create batch note form is open.')
+      this.$putFocusNextTick('modal-header-note')
+      this.$eventHub.on('user-session-expired', () => {
+        this.onBoaSessionExpires()
+      })
     })
   },
   methods: {
@@ -257,43 +269,6 @@ export default {
         this.setFocusLockDisabled(false)
       })
     },
-    createDraft() {
-      this.setIsSaving(true)
-      const ifAuthenticated = () => {
-        // File upload might take time; alert will be overwritten when API call is done.
-        this.showAlert('Creating draft note...', 60)
-        if (this.sids.length > 1) {
-          this.removeAllStudents()
-        }
-        this.setIsDraft(true)
-        this.setSubject(this.model.subject || '[DRAFT NOTE]')
-        this.createAdvisingNotes().then(note => {
-          this.setIsSaving(false)
-          this.$announcer.polite(this.isBatchFeature ? `Note created for ${this.completeSidSet.length} students.` : 'New note saved.')
-          this.exit(note)
-        })
-      }
-      this.invokeIfAuthenticated(ifAuthenticated, () => {
-        this.setIsSaving(false)
-      })
-    },
-    createNote() {
-      this.setIsSaving(true)
-      const ifAuthenticated = () => {
-        if (this.model.subject && this.completeSidSet.length) {
-          // File upload might take time; alert will be overwritten when API call is done.
-          this.showAlert('Creating note...', 60)
-          this.createAdvisingNotes().then(note => {
-            this.setIsSaving(false)
-            this.$announcer.polite(this.isBatchFeature ? `Note created for ${this.completeSidSet.length} students.` : 'New note saved.')
-            this.exit(note)
-          })
-        }
-      }
-      this.invokeIfAuthenticated(ifAuthenticated, () => {
-        this.setIsSaving(false)
-      })
-    },
     createTemplate(title) {
       this.setIsSaving(true)
       const ifAuthenticated = () => {
@@ -320,7 +295,7 @@ export default {
             subject: template.subject,
             topics: template.topics
           })
-          this.setMode(this.isBatchFeature ? 'batch' : 'create')
+          this.setMode(this.initialMode)
           this.$putFocusNextTick('create-note-subject')
         })
       }
@@ -330,16 +305,23 @@ export default {
       })
     },
     discardNote() {
-      this.showDiscardNoteModal = false
-      this.setFocusLockDisabled(false)
-      this.dismissAlertSeconds = 0
-      this.$announcer.polite('Canceled create new note')
-      this.exit()
+      const done = () => {
+        this.showDiscardNoteModal = false
+        this.setFocusLockDisabled(false)
+        this.dismissAlertSeconds = 0
+        this.$announcer.polite('Canceled create new note')
+        this.exit()
+      }
+      if (['createBatch', 'createNote'].includes(this.mode)) {
+        deleteNote(this.model).then(done)
+      } else {
+        done()
+      }
     },
     discardTemplate() {
       this.showDiscardTemplateModal = false
       this.resetModel(false)
-      this.setMode(this.isBatchFeature ? 'batch' : 'create')
+      this.setMode(this.initialMode)
       this.$announcer.polite('Canceled create template.')
       this.$putFocusNextTick('create-note-subject')
       this.$nextTick(() => {
@@ -357,6 +339,31 @@ export default {
       this.showCreateTemplateModal = this.showDiscardNoteModal = this.showDiscardTemplateModal = this.showErrorPopover = false
       this.exitSession()
       this.onClose(note)
+    },
+    init() {
+      return new Promise(resolve => {
+        if (this.noteId) {
+          getNote(this.noteId).then(resolve)
+        } else {
+          // Create a draft note.
+          const isDraft = true
+          const sids = this.sid ? [this.sid] : []
+          createNotes(
+            [],
+            null,
+            [],
+            null,
+            [],
+            isDraft,
+            false,
+            null,
+            sids,
+            '',
+            [],
+            []
+          ).then(resolve)
+        }
+      })
     },
     invokeIfAuthenticated(callback, onReject = () => {}) {
       getUserProfile().then(data => {
@@ -380,16 +387,26 @@ export default {
       this.alert = alert
       this.dismissAlertSeconds = seconds
     },
-    submitForm() {
-      if (this.mode === 'editTemplate') {
-        this.updateTemplate()
-      } else {
-        this.createNote()
-      }
-    },
     toggleShowCreateTemplateModal(show) {
       this.showCreateTemplateModal = show
       this.setFocusLockDisabled(show)
+    },
+    updateNote() {
+      this.setIsSaving(true)
+      const ifAuthenticated = () => {
+        if (this.model.isDraft || (this.model.subject && this.completeSidSet.length)) {
+          // File upload might take time; alert will be overwritten when API call is done.
+          this.showAlert('Creating note...', 60)
+          this.updateAdvisingNote().then(note => {
+            this.setIsSaving(false)
+            this.$announcer.polite(this.mode.includes('create') ? 'Note created' : 'Note saved')
+            this.exit(note)
+          })
+        }
+      }
+      this.invokeIfAuthenticated(ifAuthenticated, () => {
+        this.setIsSaving(false)
+      })
     },
     updateTemplate() {
       this.setIsSaving(true)
@@ -417,7 +434,7 @@ export default {
           subject: template.subject,
           topics: template.topics
         })
-        this.setMode(this.isBatchFeature ? 'batch' : 'create')
+        this.setMode(this.initialMode)
         this.showAlert(`Template '${template.title}' updated`)
       })
     }
@@ -425,6 +442,7 @@ export default {
 }
 </script>
 
+<!-- The 'batch' classes (below) are used by Vue transition above. -->
 <style scoped>
 .batch-enter-active {
    -webkit-transition-duration: 0.3s;

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -61,7 +61,7 @@
         </b-btn>
         <EditBatchNoteModal
           v-if="isCreateNoteModalOpen"
-          :is-batch-feature="true"
+          initial-mode="createBatch"
           :on-close="onCreateNoteModalClose"
         />
       </div>

--- a/src/components/student/profile/AcademicTimelineHeader.vue
+++ b/src/components/student/profile/AcademicTimelineHeader.vue
@@ -45,7 +45,7 @@
             :disabled="!!mode"
             class="mt-1 mr-2 btn-primary-color-override btn-primary-color-override-opaque"
             variant="primary"
-            @click="editNote"
+            @click="isEditingNote = true"
           >
             <span class="m-1">
               <font-awesome icon="file-alt" />
@@ -54,10 +54,10 @@
           </b-btn>
         </div>
         <EditBatchNoteModal
-          v-if="draftNote && isEditingNote"
-          :is-batch-feature="false"
-          :note="draftNote"
+          v-if="isEditingNote"
+          initial-mode="createNote"
           :on-close="onModalClose"
+          :sid="student.sid"
         />
       </div>
     </div>
@@ -68,7 +68,6 @@
 import Context from '@/mixins/Context'
 import EditBatchNoteModal from '@/components/note/EditBatchNoteModal'
 import Util from '@/mixins/Util'
-import {createNotes} from '@/api/notes'
 
 export default {
   name: 'AcademicTimelineHeader',
@@ -97,33 +96,11 @@ export default {
     }
   },
   data: () => ({
-    draftNote: undefined,
     isEditingNote: false
   }),
   methods: {
-    editNote() {
-      const isDraft = true
-      createNotes(
-        [],
-        null,
-        [],
-        null,
-        [],
-        isDraft,
-        false,
-        null,
-        [this.student.sid],
-        '',
-        [],
-        []
-      ).then(data => {
-        this.draftNote = data
-        this.isEditingNote = true
-      })
-    },
     onModalClose(note) {
       this.isEditingNote = false
-      this.draftNote = null
       this.$putFocusNextTick(note && this.$_.includes(['all', 'note'], this.activeTab) ? `timeline-tab-${this.activeTab}-message-0` : 'new-note-button')
     }
   }

--- a/src/components/student/profile/AcademicTimelineTable.vue
+++ b/src/components/student/profile/AcademicTimelineTable.vue
@@ -451,7 +451,7 @@ export default {
   created() {
     this.refreshSearchIndex()
     if (this.$currentUser.canAccessAdvisingData) {
-      this.$eventHub.on('begin-note-creation', event => {
+      this.$eventHub.on('note-creation-is-starting', event => {
         if (this.$_.includes(event.completeSidSet, this.student.sid)) {
           this.creatingNoteEvent = event
         }
@@ -461,8 +461,8 @@ export default {
         this.onCreateNewNote(note)
         this.refreshSearchIndex()
       }
-      this.$eventHub.on('advising-note-created', afterCreateNote)
-      this.$eventHub.on('batch-of-notes-created', noteIdsBySid => {
+      this.$eventHub.on('note-created', afterCreateNote)
+      this.$eventHub.on('notes-created', noteIdsBySid => {
         const noteId = noteIdsBySid[this.student.sid]
         if (noteId) {
           getNote(noteId).then(afterCreateNote)

--- a/src/components/util/RichTextEditor.vue
+++ b/src/components/util/RichTextEditor.vue
@@ -20,7 +20,7 @@
         :editor="editor"
         :config="editorConfig"
         @input="onUpdate"
-      ></ckeditor>
+      />
     </div>
   </div>
 </template>

--- a/src/mixins/NoteEditSession.vue
+++ b/src/mixins/NoteEditSession.vue
@@ -28,7 +28,6 @@ export default {
       'addSid',
       'addSidList',
       'addTopic',
-      'createAdvisingNotes',
       'exitSession',
       'onBoaSessionExpires',
       'removeAllStudents',
@@ -48,7 +47,8 @@ export default {
       'setMode',
       'setModel',
       'setSetDate',
-      'setSubject'
+      'setSubject',
+      'updateAdvisingNote'
     ]),
     setSubjectPerEvent(event) {
       store.dispatch('noteEditSession/setSubject', _.isString(event) ? event : event.target.value)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4888

A work in progress. When editing a draft note, the user has the option of "publishing" it to one or more students via edit-batch-note modal. *Note:* Our schema limits drafts to zero or one SIDs but using a draft to create 2+ notes allows for unlimited SIDs so the modal must accommodate.