### PR TITLE
BOAC-4865, python 3.9 is required for Codebuild

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   install:
     runtime-versions:
       nodejs: 16
-      python: 3.8
+      python: 3.9
     commands:
       - npm install
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4865

@pauline2k @lyttam - If you don't mind, please merge immediately.  Travis does not care about `buildspec.yml`.