### PR TITLE
BOAC-4922: restores degreeless student names to notes report

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -381,7 +381,7 @@ def get_student_degrees_report(sids):
           d.plan AS degree_awarded_name,
           d.date_awarded AS degree_awarded_date
         FROM {student_schema()}.student_profile_index p
-        JOIN {student_schema()}.student_degrees d ON d.sid = p.sid
+        LEFT JOIN {student_schema()}.student_degrees d ON d.sid = p.sid
         WHERE p.sid = ANY(%(sids)s)
         ORDER BY p.sid, d.date_awarded, d.plan
         """

--- a/fixtures/loch/loch.sql
+++ b/fixtures/loch/loch.sql
@@ -1039,7 +1039,8 @@ INSERT INTO student.student_degrees
 VALUES
 ('9100000000', 'Electrical Eng & Comp Sci BS', '2021-05-16', '2212'),
 ('2718281828', 'Nuclear Engineering BS', '2020-05-16', '2202'),
-('3141592653', 'Philosophy BA', '2020-05-16', '2202');
+('3141592653', 'Philosophy BA', '2020-05-16', '2202'),
+('11667051', 'Ed Cred Pgm Single Subj Cert', '1996-05-25', '1962');
 
 INSERT INTO student.student_holds
 (sid, feed)

--- a/tests/test_api/test_reports_controller.py
+++ b/tests/test_api/test_reports_controller.py
@@ -206,6 +206,10 @@ class TestBoaNotesMetadataReport:
         assert 'author_name 1' in csv
         assert 'author_name 2' in csv
         assert '11667051' in csv
+        assert 'Radioactive Women and Men' in csv
+        assert 'Four students' in csv
+        assert 'Deborah,Davies' in csv
+        assert 'Ed Cred Pgm Single Subj Cert' in csv
         for topic in topics:
             assert topic.topic in csv
         # Clean up


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4922