### PR TITLE
BOAC-4946, create note-template with note.id, and clone attachment refs

### DIFF
--- a/boac/models/note_template.py
+++ b/boac/models/note_template.py
@@ -79,13 +79,12 @@ class NoteTemplate(Base):
                 note_template.topics.append(
                     NoteTemplateTopic.create(note_template.id, titleize(vacuum_whitespace(topic))),
                 )
-            for byte_stream_bundle in attachments:
+            for attachment in attachments:
                 note_template.attachments.append(
-                    NoteTemplateAttachment.create(
+                    NoteTemplateAttachment(
                         note_template_id=note_template.id,
-                        name=byte_stream_bundle['name'],
-                        byte_stream=byte_stream_bundle['byte_stream'],
-                        uploaded_by=creator.uid,
+                        path_to_attachment=attachment.path_to_attachment,
+                        uploaded_by_uid=creator.uid,
                     ),
                 )
             db.session.add(note_template)

--- a/boac/models/note_template_attachment.py
+++ b/boac/models/note_template_attachment.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from datetime import datetime
 
-from boac import db
+from boac import db, std_commit
 from boac.lib.util import get_attachment_filename, note_attachment_to_api_json, put_attachment_to_s3
 from sqlalchemy import and_
 
@@ -66,11 +66,14 @@ class NoteTemplateAttachment(db.Model):
 
     @classmethod
     def create(cls, note_template_id, name, byte_stream, uploaded_by):
-        return NoteTemplateAttachment(
+        attachment = NoteTemplateAttachment(
             note_template_id=note_template_id,
             path_to_attachment=put_attachment_to_s3(name=name, byte_stream=byte_stream),
             uploaded_by_uid=uploaded_by,
         )
+        db.session.add(attachment)
+        std_commit()
+        return attachment
 
     def to_api_json(self):
         return note_attachment_to_api_json(self)

--- a/src/api/note-templates.ts
+++ b/src/api/note-templates.ts
@@ -12,18 +12,9 @@ export function getMyNoteTemplates() {
     .then(response => response.data, () => null)
 }
 
-export function createNoteTemplate(
-    attachments: any[],
-    body: string,
-    isPrivate: boolean,
-    subject: string,
-    title: string,
-    topics: string[]
-) {
-  const data = {body, isPrivate, subject, title, topics}
-  _.each(attachments || [], (attachment, index) => data[`attachment[${index}]`] = attachment)
-  return utils.postMultipartFormData('/api/note_template/create', data).then(template => {
-    store.dispatch('noteEditSession/onCreateTemplate', template)
+export function createNoteTemplate(noteId: number, title: string) {
+  return axios.post(`${utils.apiBaseUrl()}/api/note_template/create`, {noteId, title}).then(template => {
+    store.dispatch('noteEditSession/loadNoteTemplates')
     $_track('create')
     return template
   })
@@ -32,7 +23,7 @@ export function createNoteTemplate(
 export function deleteNoteTemplate(templateId: number) {
   return axios
     .delete(`${utils.apiBaseUrl()}/api/note_template/delete/${templateId}`)
-    .then(() => store.dispatch('noteEditSession/onDeleteTemplate', templateId))
+    .then(() => store.dispatch('noteEditSession/loadNoteTemplates', templateId))
 }
 
 export function renameNoteTemplate(noteTemplateId: number, title: string) {

--- a/src/components/note/CreateTemplateModal.vue
+++ b/src/components/note/CreateTemplateModal.vue
@@ -40,7 +40,7 @@
             Template name cannot exceed 255 characters.
           </div>
         </div>
-        <div class="modal-footer pl-0 mr-2">
+        <div class="modal-footer pl-0">
           <b-btn
             id="create-template-confirm"
             :disabled="!title.length"

--- a/src/components/note/EditBatchNoteModal.vue
+++ b/src/components/note/EditBatchNoteModal.vue
@@ -91,12 +91,14 @@
               :disabled="isSaving || boaSessionExpired"
             />
           </div>
-          <div class="mt-2 mr-3 mb-3 ml-3">
-            <ContactMethod :disabled="isSaving || boaSessionExpired" />
-          </div>
-          <div class="mt-2 mb-3 ml-3">
-            <ManuallySetDate :disabled="isSaving || boaSessionExpired" />
-          </div>
+          <transition-group v-if="mode !== 'editTemplate'" name="batch-transition">
+            <div key="0" class="mt-2 mr-3 mb-3 ml-3">
+              <ContactMethod :disabled="isSaving || boaSessionExpired" />
+            </div>
+            <div key="1" class="mt-2 mb-3 ml-3">
+              <ManuallySetDate :disabled="isSaving || boaSessionExpired" />
+            </div>
+          </transition-group>
           <div class="mt-2 mr-3 mb-1 ml-3">
             <AdvisingNoteAttachments
               :add-attachment="addAttachment"
@@ -281,14 +283,7 @@ export default {
         this.setFocusLockDisabled(false)
         // File upload might take time; alert will be overwritten when API call is done.
         this.showAlert('Creating template...', 60)
-        createNoteTemplate(
-          this.model.attachments,
-          this.model.body,
-          this.model.isPrivate,
-          this.model.subject,
-          title,
-          this.model.topics,
-        ).then(template => {
+        createNoteTemplate(this.model.id, title).then(template => {
           this.showAlert(`Template '${title}' created.`)
           this.setIsSaving(false)
           this.setModel({

--- a/src/store/modules/note-edit-session.ts
+++ b/src/store/modules/note-edit-session.ts
@@ -151,11 +151,6 @@ const mutations = {
   },
   isAutoSavingDraftNote: (state: any, value: boolean) => state.isAutoSavingDraftNote = value,
   onBoaSessionExpires: (state: any) => state.boaSessionExpired = true,
-  onCreateTemplate: (state: any, template) => state.noteTemplates = _.orderBy(state.noteTemplates.concat([template]), ['title'], ['asc']),
-  onDeleteTemplate: (state: any, templateId: any) => {
-    const indexOf = state.noteTemplates.findIndex(template => template.id === templateId)
-    state.noteTemplates.splice(indexOf, 1)
-  },
   onUpdateTemplate: (state: any, template: any) => {
     const indexOf = state.noteTemplates.findIndex(t => t.id === template.id)
     Object.assign(state.noteTemplates[indexOf], template)
@@ -282,8 +277,6 @@ const actions = {
     }
   },
   onBoaSessionExpires: ({commit}) => commit('onBoaSessionExpires'),
-  onCreateTemplate: ({commit}, template: any) => commit('onCreateTemplate', template),
-  onDeleteTemplate: ({commit}, templateId: number) => commit('onDeleteTemplate', templateId),
   onUpdateTemplate: ({commit}, template: any) => commit('onUpdateTemplate', template),
   removeAllStudents: ({commit}) => commit('removeAllStudents'),
   removeAttachment: ({commit, state}, index: number) => {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ml-3 mt-3">
+  <div class="ml-4 mt-4">
     <h1 class="sr-only">Welcome to BOA</h1>
     <Spinner />
     <div v-if="!loading" class="home-content">
@@ -22,7 +22,7 @@
       </div>
       <div v-if="$_.filter(curatedGroups, ['domain', 'default']).length">
         <div id="curated-groups-header-row">
-          <h2 class="mb-0 page-section-header">Curated Groups</h2>
+          <h2 class="page-section-header">Curated Groups</h2>
         </div>
         <div
           v-for="curatedGroup in $_.filter(curatedGroups, ['domain', 'default'])"

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -1075,49 +1075,6 @@ def _get_student_notifications(client, uid):
     return response.json['notifications']
 
 
-# def _api_note_create(
-#         app,
-#         author_id,
-#         body,
-#         client,
-#         sids,
-#         subject,
-#         attachments=(),
-#         expected_status_code=200,
-#         contact_type=None,
-#         is_draft=False,
-#         is_private=False,
-#         set_date=None,
-#         template_attachment_ids=(),
-#         topics=(),
-# ):
-#     with mock_advising_note_s3_bucket(app):
-#         data = {
-#             'authorId': author_id,
-#             'body': body,
-#             'isDraft': is_draft,
-#             'isPrivate': is_private,
-#             'sids': sids,
-#             'subject': subject,
-#             'templateAttachmentIds': ','.join(str(_id) for _id in template_attachment_ids),
-#             'topics': ','.join(topics),
-#         }
-#         if contact_type:
-#             data['contactType'] = contact_type
-#         if set_date:
-#             data['setDate'] = set_date
-#         for index, path in enumerate(attachments):
-#             data[f'attachment[{index}]'] = open(path, 'rb')
-#         response = client.post(
-#             '/api/notes/create',
-#             buffered=True,
-#             content_type='multipart/form-data',
-#             data=data,
-#         )
-#         assert response.status_code == expected_status_code
-#         return response.json
-
-
 def _api_create_draft_note(client, expected_status_code=200, sid=None):
     response = client.post(
         '/api/note/create_draft',

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -156,7 +156,7 @@ class TestMergedAdvisingNote:
         assert boa_created_note['updatedBy'] is None
         assert boa_created_note['updatedAt'] is None
         assert boa_created_note['read'] is False
-        assert boa_created_note['topics'] == []
+        assert len(boa_created_note['topics']) == 3
         assert len(boa_created_note['attachments']) == 1
         assert 'legacySource' not in boa_created_note
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4946

A draft note is created the moment the modal is open, so if user clicks create-note-template then we pass note.id to the server and clone the note to make the template.