### PR TITLE
BOAC-4971: preserves line breaks in imported ASC notes

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -519,7 +519,7 @@ def get_asc_advising_notes(sid):
         SELECT
             id, sid, advisor_uid AS author_uid,
             advisor_first_name || ' ' || advisor_last_name AS author_name,
-            subject, body,
+            subject, '<p>' || replace(body, E'\n', '</p><p>') || '</p>' AS body,
             created_at, updated_at
         FROM {asc_schema()}.advising_notes
         WHERE sid=%(sid)s

--- a/fixtures/loch/loch.sql
+++ b/fixtures/loch/loch.sql
@@ -596,7 +596,7 @@ INSERT INTO boac_advising_asc.advising_notes
 (id, asc_id, sid, student_first_name, student_last_name, meeting_date, advisor_uid, advisor_first_name, advisor_last_name, subject, body, created_at, updated_at)
 VALUES
 ('11667051-139362', '139362', '11667051', 'Deborah', 'Davies', '2014-01-03', '1133399', 'Lemmy', 'Kilmister', NULL, NULL, '2014-01-03 20:30:00+00', '2014-01-03 20:30:00+00'),
-('11667051-139379', '139379', '11667051', 'Deborah', 'Davies', '2014-01-16', '90412', 'Ginger', 'Baker', 'Ginger Baker''s Air Force', 'Bands led by drummers tend to leave a lot of space for drum solos', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00'),
+('11667051-139379', '139379', '11667051', 'Deborah', 'Davies', '2014-01-16', '90412', 'Ginger', 'Baker', 'Ginger Baker''s Air Force', E'Bands led by drummers\ntend to leave a lot of space for drum solos', '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00'),
 ('8901234567-139379', '139379', '8901234567', 'John David', 'Crossman', '2014-01-16', '90412', 'Ginger', 'Baker', NULL, NULL, '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00'),
 ('2345678901-139379', '139379', '2345678901', 'Dave', 'Doolittle', '2014-01-16', '90412', 'Ginger', 'Baker', NULL, NULL, '2014-01-16 16:52:00+00', '2014-01-16 16:52:00+00');
 

--- a/tests/test_externals/test_data_loch.py
+++ b/tests/test_externals/test_data_loch.py
@@ -120,7 +120,7 @@ class TestDataLoch:
         assert notes[0]['updated_at']
         assert notes[1]['author_name'] == 'Ginger Baker'
         assert notes[1]['subject'] == 'Ginger Baker\'s Air Force'
-        assert notes[1]['body'] == 'Bands led by drummers tend to leave a lot of space for drum solos'
+        assert notes[1]['body'] == '<p>Bands led by drummers</p><p>tend to leave a lot of space for drum solos</p>'
 
     def test_get_data_science_advising_notes(self):
         notes = data_loch.get_data_science_advising_notes('11667051')

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -93,7 +93,7 @@ class TestMergedAdvisingNote:
         assert notes[5]['id'] == '11667051-139379'
         assert notes[5]['sid'] == '11667051'
         assert notes[5]['subject'] == 'Ginger Baker\'s Air Force'
-        assert notes[5]['body'] == 'Bands led by drummers tend to leave a lot of space for drum solos'
+        assert notes[5]['body'] == '<p>Bands led by drummers</p><p>tend to leave a lot of space for drum solos</p>'
         assert notes[5]['author']['uid'] == '90412'
         assert notes[5]['author']['name'] == 'Ginger Baker'
         assert notes[5]['topics'] is None


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-4971