### PR TITLE
BOAC-5017, no more piped date-parsing filters in template code; drop vue-moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "vuex": "3.6.2",
         "d3": "5.16.0",
         "moment": "2.30.1",
-        "vue-moment": "4.1.0",
         "vue-router": "npm:@neverendingsupport/vue-router@3.6.6",
         "vue-highcharts": "0.2.0",
         "@fortawesome/vue-fontawesome": "2.0.10",
@@ -9470,17 +9469,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/vue-moment": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vue-moment/-/vue-moment-4.1.0.tgz",
-      "integrity": "sha512-Gzisqpg82ItlrUyiD9d0Kfru+JorW2o4mQOH06lEDZNgxci0tv/fua1Hl0bo4DozDV2JK1r52Atn/8QVCu8qQw==",
-      "dependencies": {
-        "moment": "^2.19.2"
-      },
-      "peerDependencies": {
-        "vue": ">=1.x.x"
       }
     },
     "node_modules/es-shim-unscopables": {
@@ -33535,14 +33523,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "vue-moment": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vue-moment/-/vue-moment-4.1.0.tgz",
-      "integrity": "sha512-Gzisqpg82ItlrUyiD9d0Kfru+JorW2o4mQOH06lEDZNgxci0tv/fua1Hl0bo4DozDV2JK1r52Atn/8QVCu8qQw==",
-      "requires": {
-        "moment": "^2.19.2"
       }
     },
     "vue-router": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "vue-focus-lock": "1.4.1",
     "vue-highcharts": "0.2.0",
     "vue-linkify": "1.0.1",
-    "vue-moment": "4.1.0",
     "vue-router": "npm:@neverendingsupport/vue-router@3.6.6",
     "vue-router-back-button": "1.3.2",
     "vue-scrollto": "2.20.0",

--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -247,7 +247,10 @@
         <span :id="`user-status-${row.item.uid}`">{{ oxfordJoin(getUserStatuses(row.item)) }}</span>
       </template>
       <template v-slot:cell(lastLogin)="row">
-        <span v-if="row.item.lastLogin" :id="`user-last-login-${row.item.uid}`">{{ row.item.lastLogin | moment('MMM D, YYYY') }}</span>
+        <span :id="`user-last-login-${row.item.uid}`">
+          <span v-if="row.item.lastLogin">{{ $moment(row.item.lastLogin).format('MMM D, YYYY') }}</span>
+          <span v-if="!row.item.lastLogin">&mdash;</span>
+        </span>
       </template>
       <template v-slot:cell(email)="row">
         <span :id="`user-email-${row.item.uid}`">

--- a/src/components/appointment/AdvisingAppointment.vue
+++ b/src/components/appointment/AdvisingAppointment.vue
@@ -27,7 +27,7 @@
         <span class="text-secondary ml-1">
           Arrived @
           <span :id="`appointment-${appointment.id}-created-at`">
-            {{ datePerTimezone(appointment.createdAt) | moment('h:mma') }}
+            {{ $moment(datePerTimezone(appointment.createdAt)).format('h:mma') }}
           </span>
         </span>
       </div>
@@ -55,7 +55,7 @@
           <span class="text-secondary ml-1">
             Check In
             <span v-if="appointment.statusDate">
-              @ <span :id="`appointment-${appointment.id}-checked-in-at`">{{ datePerTimezone(appointment.statusDate) | moment('h:mma') }}</span>
+              @ <span :id="`appointment-${appointment.id}-checked-in-at`">{{ $moment(datePerTimezone(appointment.statusDate)).format('h:mma') }}</span>
             </span>
           </span>
         </div>

--- a/src/components/appointment/AppointmentCancellationModal.vue
+++ b/src/components/appointment/AppointmentCancellationModal.vue
@@ -22,7 +22,7 @@
               </b-col>
               <b-col>
                 <span id="appointment-created-at-date">
-                  {{ new Date(appointment.createdAt) | moment('ddd, MMMM D') }}
+                  {{ $moment(appointment.createdAt).format('ddd, MMMM D') }}
                 </span>
               </b-col>
             </b-row>
@@ -34,7 +34,7 @@
               </b-col>
               <b-col>
                 <span id="appointment-created-at-time">
-                  {{ new Date(appointment.createdAt) | moment('LT') }}
+                  {{ $moment(appointment.createdAt).format('LT') }}
                 </span>
               </b-col>
             </b-row>

--- a/src/components/appointment/AppointmentDetailsModal.vue
+++ b/src/components/appointment/AppointmentDetailsModal.vue
@@ -20,7 +20,7 @@
               Arrival Time
             </label>
             <div id="appointment-created-at">
-              {{ new Date(appointment.createdAt) | moment('LT') }}
+              {{ $moment(appointment.createdAt).format('LT') }}
             </div>
           </div>
           <div class="mt-2">

--- a/src/components/appointment/CheckInModal.vue
+++ b/src/components/appointment/CheckInModal.vue
@@ -36,7 +36,7 @@
             </div>
             <div>
               <span id="appointment-created-at">
-                {{ new Date(appointment.createdAt) | moment('LT') }}
+                {{ $moment(new Date(appointment.createdAt)).format('LT') }}
               </span>
             </div>
           </div>

--- a/src/components/appointment/DropInWaitlist.vue
+++ b/src/components/appointment/DropInWaitlist.vue
@@ -19,7 +19,7 @@
     <div v-if="isHomepage" class="pb-2">
       <div class="align-items-center d-flex homepage-header-border justify-content-between mb-2">
         <div aria-live="polite" role="alert">
-          <h2 class="page-section-header">Drop-in Waitlist - {{ $moment() | moment('MMM D') }}</h2>
+          <h2 class="page-section-header">Drop-in Waitlist - {{ $moment().format('MMM D') }}</h2>
         </div>
         <div v-if="!$currentUser.isAdmin">
           <b-btn
@@ -104,7 +104,7 @@
           </h1>
         </div>
         <div>
-          <h2 id="waitlist-today-date" class="font-size-18 font-weight-bold text-nowrap">{{ $moment() | moment('ddd, MMM D') }}</h2>
+          <h2 id="waitlist-today-date" class="font-size-18 font-weight-bold text-nowrap">{{ $moment().format('ddd, MMM D') }}</h2>
         </div>
       </div>
     </div>

--- a/src/components/appointment/DropInWaitlistAppointment.vue
+++ b/src/components/appointment/DropInWaitlistAppointment.vue
@@ -5,7 +5,7 @@
     no-gutters
   >
     <b-col sm="2" class="pb-2 text-nowrap">
-      <span class="sr-only">Created at </span><span :id="`appointment-${appointment.id}-created-at`">{{ new Date(appointment.createdAt) | moment('LT') }}</span>
+      <span class="sr-only">Created at </span><span :id="`appointment-${appointment.id}-created-at`">{{ $moment(appointment.createdAt).format('LT') }}</span>
     </b-col>
     <b-col sm="6">
       <div class="d-flex">

--- a/src/components/cohort/CohortHistory.vue
+++ b/src/components/cohort/CohortHistory.vue
@@ -39,7 +39,7 @@
             </div>
           </b-td>
           <b-td class="p-1">
-            <div :id="`event-${index}-date`">{{ event.createdAt | moment('MMM D, YYYY') }}</div>
+            <div :id="`event-${index}-date`">{{ $moment(event.createdAt).format('MMM D, YYYY') }}</div>
           </b-td>
           <b-td class="p-1">
             <router-link

--- a/src/components/degree/student/StudentDegreeCheckHeader.vue
+++ b/src/components/degree/student/StudentDegreeCheckHeader.vue
@@ -132,7 +132,7 @@
                 {{ noteUpdatedBy ? 'edited this note' : 'Last edited' }}
                 <span v-if="isToday(noteUpdatedAt)"> today.</span>
                 <span v-if="!isToday(noteUpdatedAt)">
-                  on <span id="degree-note-updated-at">{{ noteUpdatedAt | moment('MMM D, YYYY') }}.</span>
+                  on <span id="degree-note-updated-at">{{ $moment(noteUpdatedAt).format('MMM D, YYYY') }}.</span>
                 </span>
               </span>
             </div>
@@ -229,8 +229,9 @@
 
 <script>
 import DegreeEditSession from '@/mixins/DegreeEditSession'
-import {getCalnetProfileByUserId} from '@/api/user'
+import moment from 'moment-timezone'
 import Util from '@/mixins/Util'
+import {getCalnetProfileByUserId} from '@/api/user'
 
 export default {
   name: 'StudentDegreeCheckHeader',
@@ -294,6 +295,9 @@ export default {
         this.noteBody = this.$_.get(this.degreeNote, 'body')
       }
       this.isSaving = false
+    },
+    isToday: date => {
+      return moment().diff(date, 'days') === 0
     },
     onToggleNotesWhenPrint(flag) {
       this.setIncludeNotesWhenPrint(flag)

--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -67,7 +67,7 @@
           </div>
           <div>
             <dt>Date Initiated</dt>
-            <dd>{{ note.createdAt | moment('MM/DD/YYYY') }}</dd>
+            <dd>{{ $moment(note.createdAt, 'MM/DD/YYYY') }}</dd>
           </div>
           <div>
             <dt>Form Status </dt>
@@ -75,7 +75,7 @@
           </div>
           <div>
             <dt>Final Date &amp; Time Stamp</dt>
-            <dd>{{ note.updatedAt | moment('MM/DD/YYYY h:mm:ssa') }}</dd>
+            <dd>{{ $moment(note.updatedAt, 'MM/DD/YYYY h:mm:ssa') }}</dd>
           </div>
         </dl>
       </div>

--- a/src/components/reports/NotesReport.vue
+++ b/src/components/reports/NotesReport.vue
@@ -147,7 +147,7 @@
                     :key="row.month"
                     class="d-flex justify-content-between align-items-center"
                   >
-                    {{ new Date(annual.year, row.month - 1, 1) | moment('MMMM') }}
+                    {{ $moment(new Date(annual.year, row.month - 1, 1)).format('MMMM') }}
                     <b-badge class="btn-primary-color-override" variant="primary" pill>{{ row.count }}</b-badge>
                   </b-list-group-item>
                 </b-list-group>

--- a/src/components/reports/UserReport.vue
+++ b/src/components/reports/UserReport.vue
@@ -45,7 +45,7 @@
       </template>
       <template v-slot:cell(lastLogin)="row">
         <div :id="`user-last-login-${row.item.uid}`">
-          <span v-if="row.item.lastLogin">{{ row.item.lastLogin | moment('MMM D, YYYY') }}</span>
+          <span v-if="row.item.lastLogin">{{ $moment(row.item.lastLogin).format('MMM D, YYYY') }}</span>
           <span v-if="!row.item.lastLogin">&#8212;</span>
         </div>
       </template>

--- a/src/components/search/AdvisingNoteSnippet.vue
+++ b/src/components/search/AdvisingNoteSnippet.vue
@@ -32,7 +32,7 @@
       <span v-if="note.advisorName" :id="`advising-note-search-result-advisor-${note.id}`">
         {{ note.advisorName }} -
       </span>
-      <span v-if="lastModified">{{ lastModified | moment('MMM D, YYYY') }}</span>
+      <span v-if="lastModified">{{ $moment(lastModified).format('MMM D, YYYY') }}</span>
     </div>
   </div>
 </template>

--- a/src/components/search/AppointmentSnippet.vue
+++ b/src/components/search/AppointmentSnippet.vue
@@ -40,7 +40,7 @@
       <span v-if="appointment.advisorName" :id="`appointment-search-result-advisor-${appointment.id}`">
         {{ appointment.advisorName }} -
       </span>
-      <span v-if="createdAt">{{ createdAt | moment('MMM D, YYYY') }}</span>
+      <span v-if="createdAt">{{ $moment(createdAt).format('MMM D, YYYY') }}</span>
     </div>
   </div>
 </template>

--- a/src/components/student/DegreesAwarded.vue
+++ b/src/components/student/DegreesAwarded.vue
@@ -5,7 +5,7 @@
       :key="dateAwarded"
       class="student-text"
     >
-      Graduated {{ dateAwarded | moment('MMM DD, YYYY') }} ({{ $_.join(plans, '; ') }})
+      Graduated {{ $moment(dateAwarded).format('MMM DD, YYYY') }} ({{ $_.join(plans, '; ') }})
     </div>
   </div>
 </template>

--- a/src/components/student/StudentRowBioColumn.vue
+++ b/src/components/student/StudentRowBioColumn.vue
@@ -76,7 +76,7 @@
     </div>
     <div v-if="student.withdrawalCancel" :id="`row-${rowIndex}-withdrawal-cancel`">
       <span class="red-flag-small">
-        {{ student.withdrawalCancel.description }} {{ student.withdrawalCancel.date | moment('MMM DD, YYYY') }}
+        {{ student.withdrawalCancel.description }} {{ $moment(student.withdrawalCancel.date).format('MMM DD, YYYY') }}
       </span>
     </div>
     <StudentAcademicStanding v-if="student.academicStanding" :standing="student.academicStanding" :row-index="`row-${rowIndex}`" />

--- a/src/components/student/profile/StudentEnrollmentTerm.vue
+++ b/src/components/student/profile/StudentEnrollmentTerm.vue
@@ -51,7 +51,7 @@
           >
             <div :id="`term-${term.termId}-dropped-course-${droppedIndex}`" role="cell">
               {{ droppedSection.displayName }} - {{ droppedSection.component }} {{ droppedSection.sectionNumber }}
-              (Dropped<span v-if="droppedSection.dropDate"> as of {{ droppedSection.dropDate | moment('MMM D, YYYY') }}</span>)
+              (Dropped<span v-if="droppedSection.dropDate"> as of {{ $moment(droppedSection.dropDate).format('MMM D, YYYY') }}</span>)
             </div>
           </div>
         </div>

--- a/src/components/student/profile/StudentProfileHeaderAcademics.vue
+++ b/src/components/student/profile/StudentProfileHeaderAcademics.vue
@@ -78,7 +78,7 @@
           {{ degree.plans.filter(plan => planTypes.includes(plan.type)).map(degree => degree.plan).join(', ') }}
         </div>
         <div id="student-bio-degree-date">
-          <span class="student-text">Awarded {{ degree.dateAwarded | moment('MMM DD, YYYY') }}</span>
+          <span class="student-text">Awarded {{ $moment(degree.dateAwarded).format('MMM DD, YYYY') }}</span>
         </div>
         <div v-for="owner in degree.planOwners" :key="owner" class="student-text">
           <span class="student-text">{{ owner }}</span>
@@ -91,7 +91,7 @@
               {{ minorPlan + " UG" }}
             </div>
           </div>
-          <span class="student-text">Awarded {{ degree.dateAwarded | moment('MMM DD, YYYY') }}</span>
+          <span class="student-text">Awarded {{ $moment(degree.dateAwarded).format('MMM DD, YYYY') }}</span>
         </div>
       </div>
     </div>

--- a/src/components/student/profile/StudentWithdrawalCancel.vue
+++ b/src/components/student/profile/StudentWithdrawalCancel.vue
@@ -3,7 +3,7 @@
     <span :id="`withdrawal-term-${termId}`" class="red-flag-status">
       {{ withdrawal.description }}
       ({{ withdrawal.reason }})
-      <span class="text-nowrap">{{ withdrawal.date | moment('MMM DD, YYYY') }}</span>
+      <span class="text-nowrap">{{ $moment(withdrawal.date).format('MMM DD, YYYY') }}</span>
     </span>
   </div>
 </template>

--- a/src/components/student/profile/TimelineDate.vue
+++ b/src/components/student/profile/TimelineDate.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="datePerTimezone && dateFormat">
-    <span class="sr-only">{{ srPrefix }} </span>{{ datePerTimezone | moment(dateFormat) }}
+    <span class="sr-only">{{ srPrefix }} </span>{{ $moment(datePerTimezone).format(dateFormat) }}
     <div v-if="includeTimeOfDay">
-      {{ datePerTimezone | moment('h:mma') }}
+      {{ $moment(datePerTimezone).format('h:mma') }}
     </div>
   </div>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import highchartsAccessibility from 'highcharts/modules/accessibility'
 import HighchartsMore from 'highcharts/highcharts-more'
 import linkify from 'vue-linkify'
 import mitt from 'mitt'
-import moment from 'moment-timezone'
+import moment from 'moment'
 import router from './router'
 import store from './store'
 import VCalendar from 'v-calendar'
@@ -16,7 +16,6 @@ import Vue from 'vue'
 import VueAnnouncer from '@vue-a11y/announcer'
 import VueHighcharts from 'vue-highcharts'
 import VueHotkey from 'v-hotkey'
-import VueMoment from 'vue-moment'
 import {routerHistory, writeHistory} from 'vue-router-back-button'
 import {library} from '@fortawesome/fontawesome-svg-core'
 import {far} from '@fortawesome/free-regular-svg-icons'
@@ -43,7 +42,6 @@ Vue.use(CKEditor)
 Vue.use(VCalendar)
 Vue.use(VueAnnouncer)
 Vue.use(VueHotkey)
-Vue.use(VueMoment, {moment})
 
 HighchartsMore(Highcharts)
 Vue.use(VueHighcharts, {Highcharts})
@@ -55,11 +53,10 @@ Vue.directive('accessibleGrade', {
 })
 Vue.directive('linkified', linkify)
 
-// Emit and listen for events
+// Global utilities
 Vue.prototype.$eventHub = mitt()
-
-// Lodash
 Vue.prototype.$_ = _
+Vue.prototype.$moment = moment
 
 Vue.use(routerHistory)
 router.afterEach(writeHistory)

--- a/src/mixins/Util.vue
+++ b/src/mixins/Util.vue
@@ -1,6 +1,5 @@
 <script>
 import _ from 'lodash'
-import moment from 'moment-timezone'
 import numeral from 'numeral'
 import {oxfordJoin} from '@/utils'
 
@@ -29,26 +28,7 @@ export default {
       return format(domain === 'admitted_students' ? 'admissions ' : 'curated ') + format('group')
     },
     escapeForRegExp: s => s && s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
-    formatIsoDate(isoDate) {
-      // YYYY-MM-DD to MM/DD/YYYY.
-      if (!isoDate || !(/^\d{4}-\d{2}-\d{2}$/.test(isoDate))) {
-        return null
-      }
-      const dateComponents = isoDate.split('-')
-      return [dateComponents[1], dateComponents[2], dateComponents[0]].join('/')
-    },
-    formatUsaDate(usaDate) {
-      // MM/DD/YYYY to YYYY-MM-DD.
-      if (!usaDate || !(/^\d{2}\/\d{2}\/\d{4}$/.test(usaDate))) {
-        return null
-      }
-      const dateComponents = usaDate.split('/')
-      return [dateComponents[2], dateComponents[0], dateComponents[1]].join('-')
-    },
     isNilOrBlank: s => _.isNil(s) || _.trim(s) === '',
-    isToday: date => {
-      return moment().diff(date, 'days') === 0
-    },
     lastNameFirst: u => u.lastName && u.firstName ? `${u.lastName}, ${u.firstName}` : (u.lastName || u.firstName),
     numFormat: (num, format=null) => numeral(num).format(format),
     oxfordJoin,

--- a/src/views/Course.vue
+++ b/src/views/Course.vue
@@ -50,7 +50,7 @@
                   <div>
                     {{ meeting.days }}
                     <span v-if="meetings.length > 1">
-                      ({{ meeting.startDate | moment('MMM D') }} to {{ meeting.endDate | moment('MMM D') }})
+                      ({{ $moment(meeting.startDate).format('MMM D') }} to {{ $moment(meeting.endDate).format('MMM D') }})
                     </span>
                   </div>
                   <div>{{ meeting.time }}</div>

--- a/src/views/degree/ManageDegreeChecks.vue
+++ b/src/views/degree/ManageDegreeChecks.vue
@@ -132,7 +132,7 @@
           </template>
           <template #cell(createdAt)="row">
             <div v-if="row.item.id !== $_.get(templateForEdit, 'id')">
-              {{ row.item.createdAt | moment('MMM D, YYYY') }}
+              {{ $moment(row.item.createdAt).format('MMM D, YYYY') }}
             </div>
           </template>
           <template #cell(actions)="row">

--- a/src/views/degree/PrintableDegreeTemplate.vue
+++ b/src/views/degree/PrintableDegreeTemplate.vue
@@ -44,7 +44,7 @@
         <b-col>
           <div class="unofficial-label-pill">
             <div>UNOFFICIAL DEGREE PROGRESS REPORT</div>
-            <div>Printed by {{ $currentUser.name }} on {{ new Date() | moment('MMMM D, YYYY') }}</div>
+            <div>Printed by {{ $currentUser.name }} on {{ $moment().format('MMMM D, YYYY') }}</div>
           </div>
           <h2 class="font-size-14">{{ degreeName }}</h2>
           <div :class="{'unit-requirements-of-template': !student}">

--- a/src/views/degree/StudentDegreeHistory.vue
+++ b/src/views/degree/StudentDegreeHistory.vue
@@ -54,7 +54,7 @@
             <span v-if="row.item.isCurrent" class="ml-2">(current)</span>
           </template>
           <template #cell(updatedAt)="row">
-            {{ row.item.updatedAt | moment('MMM D, YYYY') }}
+            {{ $moment(row.item.updatedAt).format('MMM D, YYYY') }}
           </template>
           <template #cell(updatedBy)="row">
             <div class="align-right w-100">
@@ -68,7 +68,7 @@
               class="boac-exclamation mr-1"
               :title="`Revisions to the original degree template have been made since the creation of this degree check.`"
             />
-            <span v-if="row.item.parentTemplateUpdatedAt" :class="{'boac-exclamation': row.item.showRevisionIndicator}">{{ row.item.parentTemplateUpdatedAt | moment('MMM D, YYYY') }}</span>
+            <span v-if="row.item.parentTemplateUpdatedAt" :class="{'boac-exclamation': row.item.showRevisionIndicator}">{{ $moment(row.item.parentTemplateUpdatedAt).format('MMM D, YYYY') }}</span>
             <span v-if="!row.item.parentTemplateUpdatedAt">&mdash;</span>
             <div class="sr-only">
               Note: Revisions to the original degree template have been made since the creation of this degree check.


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5017

* `vue-moment` is what provided the filtering syntax which is not supported in Vue 3.
* Many modified Vue templates are drop-in appt related and will soon be removed  