### PR TITLE
NO-JIRA, enable/disable focusLock in note edit session

### DIFF
--- a/src/components/note/CreateNoteHeader.vue
+++ b/src/components/note/CreateNoteHeader.vue
@@ -181,9 +181,7 @@ export default {
       this.targetTemplate = null
       this.alertScreenReader('Canceled')
       this.putFocusNextTick('create-note-subject')
-      this.nextTick(() => {
-        this.setFocusLockDisabled(false)
-      })
+      this.enableFocusLock()
     },
     deleteTemplateConfirmed() {
       return deleteNoteTemplate(this.targetTemplate.id).then(() => {
@@ -191,9 +189,7 @@ export default {
         this.targetTemplate = null
         this.alertScreenReader('Template deleted.')
         this.putFocusNextTick('create-note-subject')
-        this.nextTick(() => {
-          this.setFocusLockDisabled(false)
-        })
+        this.enableFocusLock()
       })
     },
     editTemplate(template) {
@@ -216,13 +212,13 @@ export default {
     },
     openDeleteTemplateModal(template) {
       this.targetTemplate = template
-      this.setFocusLockDisabled(true)
+      this.disableFocusLock()
       this.showDeleteTemplateModal = true
       this.alertScreenReader('Delete template modal opened.')
     },
     openRenameTemplateModal(template) {
       this.targetTemplate = template
-      this.setFocusLockDisabled(true)
+      this.disableFocusLock()
       this.showRenameTemplateModal = true
       this.alertScreenReader('Rename template modal opened.')
     },
@@ -231,14 +227,13 @@ export default {
         this.targetTemplate = null
         this.showRenameTemplateModal = false
         this.alertScreenReader(`Template renamed '${title}'.`)
-        this.nextTick(() => {
-          this.setFocusLockDisabled(false)
-        })
+        this.enableFocusLock()
       })
     },
     toggleShowRenameTemplateModal(show) {
       this.showRenameTemplateModal = show
-      this.setFocusLockDisabled(show)
+      const toggle = show ? this.disableFocusLock : this.enableFocusLock
+      toggle()
       this.alertScreenReader(`Dialog ${show ? 'opened' : 'closed'}.`)
     }
   }

--- a/src/components/note/EditBatchNoteModal.vue
+++ b/src/components/note/EditBatchNoteModal.vue
@@ -266,7 +266,7 @@ export default {
           this.discardTemplate()
         } else {
           this.showDiscardTemplateModal = true
-          this.setFocusLockDisabled(true)
+          this.disableFocusLock()
         }
       } else {
         const unsavedChanges = this._trim(this.model.subject)
@@ -276,7 +276,7 @@ export default {
           || this.completeSidSet.length
         if (unsavedChanges) {
           this.showDiscardNoteModal = true
-          this.setFocusLockDisabled(true)
+          this.disableFocusLock()
         } else {
           this.discardNote()
         }
@@ -285,28 +285,24 @@ export default {
     cancelCreateTemplate() {
       this.setIsSaving(false)
       this.showCreateTemplateModal = false
-      this.nextTick(() => {
-        this.setFocusLockDisabled(false)
-      })
+      this.enableFocusLock()
     },
     cancelDiscardNote() {
       this.showDiscardNoteModal = false
-      this.setFocusLockDisabled(false)
+      this.enableFocusLock()
       this.alertScreenReader('Continue editing note.')
       this.putFocusNextTick('create-note-subject')
     },
     cancelDiscardTemplate() {
       this.showDiscardTemplateModal = false
       this.putFocusNextTick('create-note-subject')
-      this.nextTick(() => {
-        this.setFocusLockDisabled(false)
-      })
+      this.enableFocusLock()
     },
     createTemplate(title) {
       this.setIsSaving(true)
       const ifAuthenticated = () => {
         this.showCreateTemplateModal = false
-        this.setFocusLockDisabled(false)
+        this.enableFocusLock()
         // File upload might take time; alert will be overwritten when API call is done.
         this.showAlert('Creating template...', 60)
         // Save draft before creating template.
@@ -327,7 +323,7 @@ export default {
       })
     },
     discardNote() {
-      this.setFocusLockDisabled(false)
+      this.enableFocusLock()
       this.alertScreenReader('Canceled create new note')
       this.exit(true)
     },
@@ -376,7 +372,7 @@ export default {
       this.setIsSaving(true)
       const ifAuthenticated = () => {
         this.showCreateTemplateModal = true
-        this.setFocusLockDisabled(true)
+        this.disableFocusLock()
       }
       this.invokeIfAuthenticated(ifAuthenticated)
     },
@@ -387,7 +383,8 @@ export default {
     },
     toggleShowCreateTemplateModal(show) {
       this.showCreateTemplateModal = show
-      this.setFocusLockDisabled(show)
+      const toggle = show ? this.disableFocusLock : this.enableFocusLock
+      toggle()
     },
     updateNote() {
       this.setIsSaving(true)

--- a/src/components/student/profile/AcademicTimelineTable.vue
+++ b/src/components/student/profile/AcademicTimelineTable.vue
@@ -484,10 +484,11 @@ export default {
         })
         if (obj) {
           this.isShowingAll = true
-          this.nextTick(function() {
+          const onNextTick = () => {
             this.open(obj, true)
             this.scrollToPermalink(messageType, messageId)
-          })
+          }
+          this.nextTick(onNextTick)
         }
       }
     }

--- a/src/mixins/NoteEditSession.vue
+++ b/src/mixins/NoteEditSession.vue
@@ -1,6 +1,15 @@
 <script>
+import store from '@/store'
+import Vue from 'vue'
 import {clearAutoSaveJob, onVisibilityChange, scheduleAutoSaveJob} from '@/store/modules/note-edit-session/utils'
 import {mapGetters, mapMutations} from 'vuex'
+
+const $_disableFocusLock = disable => {
+  const onNextTick = () => {
+    store.commit('note/setFocusLockDisabled', disable)
+  }
+  Vue.nextTick(onNextTick)
+}
 
 export default {
   name: 'NoteEditSession',
@@ -37,7 +46,6 @@ export default {
       'setAttachments',
       'setBody',
       'setContactType',
-      'setFocusLockDisabled',
       'setIsDraft',
       'setIsPrivate',
       'setIsRecalculating',
@@ -47,7 +55,9 @@ export default {
       'setNoteTemplates',
       'setSetDate',
       'setSubject',
-    ])
+    ]),
+    disableFocusLock: () => $_disableFocusLock(true),
+    enableFocusLock: () => $_disableFocusLock(false)
   }
 }
 </script>


### PR DESCRIPTION
Jira is down so no issue reference here.

We must be careful in our use of `Vue.nextTick` because the callback function we pass in does not share context of outer Vue component. To fix one problematic bit of code, I added convenience functions in the mixin.