### PR TITLE
NO-JIRA, local lint-vue (in tox.ini) invokes ./scripts/verify-read-only-src-vue2.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build-vue": "vite build --outDir='dist/static'",
-    "lint-vue": "eslint . --ignore-path .eslint-ignore",
+    "lint-vue": "./scripts/verify-read-only-src-vue2.sh && eslint . --ignore-path .eslint-ignore",
     "lint-vue-fix": "eslint . --fix --ignore-path .eslint-ignore",
     "preview": "vite preview",
     "serve-vue": "vite --host --strictPort"

--- a/scripts/verify-read-only-src-vue2.sh
+++ b/scripts/verify-read-only-src-vue2.sh
@@ -10,5 +10,7 @@ total_line_count=$(find ${PWD}/src-vue2 -name '*.*' | xargs wc -l | grep total)
 if [[ "${total_line_count}" == *"${expected_total_line_count}"* ]]; then
   exit 0
 else
+  echo; echo '[ERROR] Changes have been made in src-vue2 directory. That is a no-no.'
+  echo; echo
   exit 1
 fi


### PR DESCRIPTION
Linter will fail (with proper error message) if you have made changes in the 'dev-vue2' dir.