### PR TITLE
BOAC-5100, CodeBuild 2023-x86_64-standard:5.0 supports node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export BOAC_LOCAL_CONFIGS=/Volumes/XYZ/boac_config
 
 We use [Tox](https://tox.readthedocs.io) for continuous integration. Under the hood, you'll find [PyTest](https://docs.pytest.org), [Flake8](http://flake8.pycqa.org) and [ESLint](https://eslint.org/).
 ```
-# Run all tests and linters with Tox's parallel mode:
+# Run tests and linters with Tox's parallel mode:
 tox -p
 
 # Pytest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   install:
     runtime-versions:
       nodejs: 18
-      python: 3.9
+      python: 3.11
     commands:
       - npm install
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5100

Also, this AWS image does not support Python 3.9 so we're going with 3.11.  This build step does not really do anything python or pip related.