### PR TITLE
[vue2] BOAC-5135, /student/degree: CreateCourseModal sent category.id instead of sid

### DIFF
--- a/src/components/degree/student/CreateCourseModal.vue
+++ b/src/components/degree/student/CreateCourseModal.vue
@@ -199,7 +199,7 @@ export default {
           this._trim(this.name),
           this._trim(this.note),
           this.parentCategory.id,
-          this.parentCategory.id,
+          this.sid,
           this._map(this.selectedUnitRequirements, 'id'),
           this.units
         ).then(course => {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5135

As they say in France, "Les whoops!"