### PR TITLE
[vue2] BOAC-5143, revert stray h1 style causing 'BOA' shrinkage

### DIFF
--- a/src/assets/styles/boac-global.css
+++ b/src/assets/styles/boac-global.css
@@ -1,8 +1,3 @@
-h1 {
-  font-size: 24px !important;
-  font-weight: 700 !important;
-  margin: 0 0 10px 0 !important;
-}
 select {
   appearance: auto !important;
   border: 1px solid #d1d1d1 !important;


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5143

This change was made in [commit 3c350338](https://github.com/ets-berkeley-edu/boac/commit/3c35033839c88d1724cafa21964d9e40a87dc804), in context of `/cohort` view work. Perhaps @lyttam can verify that this revert is okay.