### PR TITLE
BOAC-5101 Remove redundant Apache alias

### DIFF
--- a/.ebextensions/01_create_apache_conf.config
+++ b/.ebextensions/01_create_apache_conf.config
@@ -22,17 +22,6 @@ files:
         SSLCertificateFile "/etc/ssl/certs/boac_openssl_x509.crt"
         SSLCertificateKeyFile "/etc/ssl/certs/boac_openssl_private.key"
 
-        ProxyPass /assets !
-        Alias /assets /var/app/current/dist/static/assets
-        <Directory /var/app/current/dist/static/assets>
-            Require all granted
-        </Directory>
-
-        Alias /static /var/app/current/dist/static
-        <Directory /var/app/current/dist/static>
-          Require all granted
-        </Directory>
-
         # Proxy https requests to application on port 8000.
         <Proxy *>
           Require all granted


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5101

The `aws:elasticbeanstalk:environment:proxy:staticfiles:` settings in `00_ami.config` automatically create equivalent aliases, so we shouldn't need to splice these in manually.