### PR TITLE
BOAC-5113, ditch vue3-shortkey; my own simple impl of: type '/' to search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "v-calendar": "3.1.2",
         "vue": "3.4.21",
         "vue-router": "4.3.0",
-        "vue3-shortkey": "4.0.0",
         "vue3-smooth-scroll": "0.8.1",
         "vuetify": "3.5.13",
         "webfontloader": "1.6.28"
@@ -1875,11 +1874,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
-    "node_modules/custom-event-polyfill": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
-    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -1966,11 +1960,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/element-matches": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/element-matches/-/element-matches-0.1.2.tgz",
-      "integrity": "sha512-yWh1otcs3OKUWDvu/IxyI36ZI3WNaRZlI0uG/DK6fu0pap0VYZ0J5pEGTk1zakme+hT0OKHwhlHc0N5TJhY6yQ=="
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -3856,15 +3845,6 @@
         "vue": "^3.2.0"
       }
     },
-    "node_modules/vue3-shortkey": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vue3-shortkey/-/vue3-shortkey-4.0.0.tgz",
-      "integrity": "sha512-pXb/K7aw3ViqzWL9jz/IL4wOk7M7FQ87ekYxk5J7uKTNEfOVBYtILGjvCBJD3/zEUipcLQJEg7TjE1xYnVYV/w==",
-      "dependencies": {
-        "custom-event-polyfill": "^1.0.7",
-        "element-matches": "^0.1.2"
-      }
-    },
     "node_modules/vue3-smooth-scroll": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/vue3-smooth-scroll/-/vue3-smooth-scroll-0.8.1.tgz",
@@ -5213,11 +5193,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
-    "custom-event-polyfill": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
-    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -5275,11 +5250,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "element-matches": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/element-matches/-/element-matches-0.1.2.tgz",
-      "integrity": "sha512-yWh1otcs3OKUWDvu/IxyI36ZI3WNaRZlI0uG/DK6fu0pap0VYZ0J5pEGTk1zakme+hT0OKHwhlHc0N5TJhY6yQ=="
     },
     "entities": {
       "version": "4.5.0",
@@ -6562,15 +6532,6 @@
       "resolved": "https://registry.npmjs.org/vue-screen-utils/-/vue-screen-utils-1.0.0-beta.13.tgz",
       "integrity": "sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==",
       "requires": {}
-    },
-    "vue3-shortkey": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vue3-shortkey/-/vue3-shortkey-4.0.0.tgz",
-      "integrity": "sha512-pXb/K7aw3ViqzWL9jz/IL4wOk7M7FQ87ekYxk5J7uKTNEfOVBYtILGjvCBJD3/zEUipcLQJEg7TjE1xYnVYV/w==",
-      "requires": {
-        "custom-event-polyfill": "^1.0.7",
-        "element-matches": "^0.1.2"
-      }
     },
     "vue3-smooth-scroll": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "v-calendar": "3.1.2",
     "vue": "3.4.21",
     "vue-router": "4.3.0",
-    "vue3-shortkey": "4.0.0",
     "vue3-smooth-scroll": "0.8.1",
     "vuetify": "3.5.13",
     "webfontloader": "1.6.28"

--- a/src/components/search/AdvancedSearch.vue
+++ b/src/components/search/AdvancedSearch.vue
@@ -89,15 +89,21 @@ import SearchSession from '@/mixins/SearchSession'
 import {addToSearchHistory, getMySearchHistory} from '@/api/search'
 import {getAllTopics} from '@/api/topics'
 import {useSearchStore} from '@/stores/search'
-import {scrollToTop} from '@/lib/utils'
-import {each, noop, trim} from 'lodash'
+import {putFocusNextTick, scrollToTop} from '@/lib/utils'
+import {each, get, noop, trim} from 'lodash'
 
 export default {
-  name: 'StandardHeaderLayout',
+  name: 'AdvancedSearch',
   mixins: [Context, SearchSession],
   data: () => ({
     showErrorPopover: false
   }),
+  mounted() {
+    document.addEventListener('keyup', this.onKeyUp)
+  },
+  beforeUnmount() {
+    document.removeEventListener('keyup', this.onKeyUp)
+  },
   created() {
     useSearchStore().resetAdvancedSearch(this.$route.query.q)
     getMySearchHistory().then(history => {
@@ -122,6 +128,15 @@ export default {
   methods: {
     hideError() {
       this.showErrorPopover = false
+    },
+    onKeyUp(event) {
+      if (event.keyCode === 191) {
+        const el = get(event, 'currentTarget.activeElement')
+        const ignore = ['textbox'].includes(get(el, 'role')) || ['INPUT'].includes(get(el, 'tagName'))
+        if (!ignore) {
+          putFocusNextTick('search-students-input')
+        }
+      }
     },
     search() {
       const q = trim(this.queryText)
@@ -176,21 +191,4 @@ export default {
   border-color: white;
   color: #3b7ea5;
 }
-/*
-.simple-typeahead {
-  display: inline-block;
-  onClickClearflex-basis: 0%;
-  onClickClearflex-grow: 1;
-  onClickClearflex-shrink: 1;
-  onClickClearfont-feature-settings: normal;
-  onClickClearfont-kerning: auto;
-  onClickClearfont-optical-sizing: auto;
-  onClickClearfont-size: 16px;
-  onClickClearheight: 50px;
-  onClickClearmargin: 0;
-  onClickClearoutline-offset: -2px;
-  onClickClearoverflow-x: visible;
-  onClickClearoverflow-y: visible;
-}
-*/
 </style>

--- a/src/layouts/shared/StandardHeaderLayout.vue
+++ b/src/layouts/shared/StandardHeaderLayout.vue
@@ -1,6 +1,5 @@
 <template>
   <v-container
-    v-shortkey="['ctrl', 'alt', 's']"
     class="my-2 py-0"
     fluid
     @shortkey="() => putFocusNextTick('search-students-input')"

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -2,7 +2,6 @@ import 'v-calendar/style.css'
 import axios from '@/plugins/axios'
 import {Calendar, DatePicker, setupCalendar} from 'v-calendar'
 import CKEditor from '@ckeditor/ckeditor5-vue'
-import defaultExport from 'vue3-shortkey'
 import type {App} from 'vue'
 import vuetify from './vuetify'
 import {createPinia} from 'pinia'
@@ -14,7 +13,6 @@ export function registerPlugins (app: App) {
     .use(createPinia())
     .use(setupCalendar, {})
     .use(vuetify)
-    .use(defaultExport)
     .component('focus-trap', FocusTrap)
     .component('elegant-calendar', Calendar)
     .component('elegant-date-picker', DatePicker)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5113

Such events are ignored per:
```
const ignore = ['textbox'].includes(get(el, 'role')) || ['INPUT'].includes(get(el, 'tagName'))
```
Devs should keep this ignore logic in mind. cc: @mohamalnadi @lyttam 