### PR TITLE
BOAC-5247, move DismissibleFooterAlert to Vue3

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <router-view />
+  <DismissibleFooterAlert />
 </template>
 
 <style>
@@ -7,3 +8,7 @@
 @import "@/assets/styles/ckeditor-custom.css";
 @import "@/assets/styles/vcalendar-custom.css";
 </style>
+
+<script setup>
+import DismissibleFooterAlert from '@/components/util/DismissibleFooterAlert'
+</script>

--- a/src/components/util/DismissibleFooterAlert.vue
+++ b/src/components/util/DismissibleFooterAlert.vue
@@ -1,0 +1,68 @@
+<template>
+  <transition name="drawer">
+    <div v-if="showAlert" id="fixed_bottom">
+      <div id="fixed-warning-on-all-pages" class="align-center d-flex fixed-bottom fixed-warning">
+        <div class="flex-grow-1">
+          <b>BOA {{ getBoaEnvLabel() }} Environment</b>
+        </div>
+        <div v-if="config.isVueAppDebugMode" class="mr-4">
+          {{ get(contextStore.screenReaderAlert, 'message') }}
+        </div>
+        <div v-if="!config.isVueAppDebugMode" class="mr-4">
+          <span aria-live="polite" role="alert">{{ config.fixedWarningOnAllPages }}</span>
+        </div>
+        <div>
+          <v-btn
+            id="speedbird"
+            aria-label="Dismiss warning about BOA environment type"
+            color="primary"
+            :icon="mdiAirplane"
+            size="sm"
+            @click="dismissTheWarning"
+          />
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import {alertScreenReader} from '@/lib/utils'
+import {computed} from 'vue'
+import {get} from 'lodash'
+import {mdiAirplane} from '@mdi/js'
+import {useContextStore} from '@/stores/context'
+
+const contextStore = useContextStore()
+const config = contextStore.config
+
+const showAlert = computed(() => config.fixedWarningOnAllPages && !contextStore.dismissedFooterAlert)
+
+const dismissTheWarning = () => {
+  contextStore.dismissFooterAlert()
+  alertScreenReader('Warning message dismissed')
+}
+
+const getBoaEnvLabel = () => {
+  return config.ebEnvironment ? config.ebEnvironment.replace('boac-', '').toUpperCase() : 'Test'
+}
+</script>
+
+<style scoped>
+.fixed-bottom {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  z-index: 1000;
+}
+.fixed-warning {
+  background-color: #3b7ea5;
+  border-color: #000;
+  border-style: solid;
+  border-width: 2px 0 0;
+  color: #fff;
+  opacity: 0.9;
+  padding: 15px;
+}
+</style>

--- a/src/stores/context.ts
+++ b/src/stores/context.ts
@@ -2,7 +2,7 @@ import {get, noop, sortBy} from 'lodash'
 import mitt from 'mitt'
 import router from '@/router'
 import {alertScreenReader} from '@/lib/utils'
-import {defineStore, StoreDefinition} from 'pinia'
+import {defineStore} from 'pinia'
 import {nextTick} from 'vue'
 
 const $_getDefaultApplicationState = () => ({
@@ -18,13 +18,14 @@ export type BoaConfig = {
     max: undefined,
     min: undefined
   },
+  fixedWarningOnAllPages: boolean,
   isProduction: boolean,
   isVueAppDebugMode: boolean,
   maxAttachmentsPerNote: number,
   timezone: string
 }
 
-export const useContextStore: StoreDefinition = defineStore('context', {
+export const useContextStore = defineStore('context', {
   state: () => ({
     announcement: undefined,
     applicationState: $_getDefaultApplicationState(),


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5247

This footer (1) warns users "you're in a test env" and (2) shows screen-reader alerts, which is useful.

@lyttam @mohamalnadi - You can disable this alert with `FIXED_WARNING_ON_ALL_PAGES = False` in your `development-local.py` config file. 