### PR TITLE
[dev-vue2] NO-JIRA, BOA dev-vue2 is now v5.26 (aligned w/ Nessie)

### DIFF
--- a/boac/__init__.py
+++ b/boac/__init__.py
@@ -29,7 +29,7 @@ from flask_caching import Cache
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = '5.24'
+__version__ = '5.26'
 
 db = SQLAlchemy()
 


### PR DESCRIPTION
I'll update Jira accordingly.