### PR TITLE
NO-JIRA, git-ignore dot-env file in boac/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 node_modules
 
 # Local configs
+boac/.env
 config/*.json
 config/*-local.py
 config/*-local.conf


### PR DESCRIPTION
This file is used by some to keep AWS environment variables, etc.