### PR TITLE
[QA] NO-JIRA, BOA qa branch is now v5.32.2

### DIFF
--- a/boac/__init__.py
+++ b/boac/__init__.py
@@ -29,7 +29,7 @@ from flask_caching import Cache
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import SQLAlchemyError
 
-__version__ = '5.23.1'
+__version__ = '5.23.2'
 
 db = SQLAlchemy()
 


### PR DESCRIPTION
We intend to deploy a patch to prod. It'll be a fix for https://jira-secure.berkeley.edu/browse/BOAC-5382 and possible one other issue.