### PR TITLE
BOAC-3119: trims note template titles before saving

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -226,6 +226,9 @@
 .position-relative {
   position: relative;
 }
+.scrollbar-gutter-stable {
+  scrollbar-gutter: stable !important;
+}
 .section-divider {
   background-color: #4a90e2;
   border: none;

--- a/src/components/note/CreateTemplateModal.vue
+++ b/src/components/note/CreateTemplateModal.vue
@@ -72,6 +72,7 @@ import ModalHeader from '@/components/util/ModalHeader'
 import ProgressButton from '@/components/util/ProgressButton'
 import {putFocusNextTick} from '@/lib/utils'
 import {ref, watch} from 'vue'
+import {trim} from 'lodash'
 import {useNoteStore} from '@/stores/note-edit-session'
 import {validateTemplateTitle} from '@/lib/note'
 
@@ -115,9 +116,10 @@ const reset = () => {
 
 const createTemplate = () => {
   isSaving.value = true
-  error.value = validateTemplateTitle({title: title.value})
+  const templateTitle = trim(title.value)
+  error.value = validateTemplateTitle({title: templateTitle})
   if (!error.value) {
-    props.create(title.value)
+    props.create(templateTitle)
   } else {
     isSaving.value = false
   }

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -42,7 +42,7 @@ export function validateAttachment(attachments: any[], existingAttachments: any[
 }
 
 export function validateTemplateTitle(template: any) {
-  const title = trim(template.title)
+  const title = template.title
   let msg: string | undefined = undefined
   if (isEmpty(title)) {
     msg = 'Required'
@@ -53,7 +53,7 @@ export function validateTemplateTitle(template: any) {
     each(myTemplates, existing => {
       if (
         (!template.id || template.id !== existing.id) &&
-        title.toUpperCase() === existing.title.toUpperCase()
+        title.toUpperCase() === trim(existing.title.toUpperCase())
       ) {
         msg = 'You have an existing template with this name. Please choose a different name.'
         return false


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-3119

Also fixes a couple other issues:
- templates menu scrollbar was disappearing when the Rename modal opened, making the content jump
- The menu was closing when user clicks Delete, and the Delete confirmation modal being nested inside the menu meant the modal didn't appear.