### PR TITLE
BOAC-5483: adds FocusLock to modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,8 @@
         "vite": "^5.4.2",
         "vite-plugin-compression": "^0.5.1",
         "vite-plugin-vuetify": "^2.0.4",
-        "vue-eslint-parser": "^9.4.3"
+        "vue-eslint-parser": "^9.4.3",
+        "vue-focus-lock": "^3.0.0"
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -2846,6 +2847,18 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/focus-lock": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
@@ -4074,6 +4087,12 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
     "node_modules/turndown": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
@@ -4508,6 +4527,18 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-focus-lock": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vue-focus-lock/-/vue-focus-lock-3.0.0.tgz",
+      "integrity": "sha512-GmuPb7zDYlF81Nw09zSPwBw3zbyHPNbq46+KEudKnl940kU5TtCz2TMQ42ariz/67Tbl61z9UO8VlGps+IlSlg==",
+      "dev": true,
+      "dependencies": {
+        "focus-lock": "^1.3.1"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-highcharts": {
@@ -6701,6 +6732,15 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "focus-lock": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
@@ -7527,6 +7567,12 @@
       "dev": true,
       "requires": {}
     },
+    "tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
+    },
     "turndown": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
@@ -7767,6 +7813,15 @@
         "esquery": "^1.4.0",
         "lodash": "^4.17.21",
         "semver": "^7.3.6"
+      }
+    },
+    "vue-focus-lock": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vue-focus-lock/-/vue-focus-lock-3.0.0.tgz",
+      "integrity": "sha512-GmuPb7zDYlF81Nw09zSPwBw3zbyHPNbq46+KEudKnl940kU5TtCz2TMQ42ariz/67Tbl61z9UO8VlGps+IlSlg==",
+      "dev": true,
+      "requires": {
+        "focus-lock": "^1.3.1"
       }
     },
     "vue-highcharts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "vite": "^5.4.2",
     "vite-plugin-compression": "^0.5.1",
     "vite-plugin-vuetify": "^2.0.4",
-    "vue-eslint-parser": "^9.4.3"
+    "vue-eslint-parser": "^9.4.3",
+    "vue-focus-lock": "^3.0.0"
   },
   "type": "module"
 }

--- a/src/README.md
+++ b/src/README.md
@@ -118,6 +118,7 @@ See https://vuetifyjs.com/en/api/v-data-table/#links
 - Add `<v-card class="modal-content">` as a child of `<v-dialog>` and wrapping its contents.
 - If specifying `width`, `max-width`, or `min-width`, put these properties on the `<v-card>` and not on `<v-dialog`>.
 - Remove these properties: `body-class`, `hide-footer`, and `hide-header`.
+- Add `<FocusLock>` as a child of `<v-card>` to prevent focus from leaving the modal. The Vuetify property `retain-focus` doesn't seem to do what it says, so we need to use https://github.com/theKashey/vue-focus-lock
 - Use `<v-card-title>`, `<v-card-text class="modal-body">`, and `<v-card-actions class="modal-footer">` so that every dialog has consistent padding.
 - Add `aria-labelledby=<id of header>` and optionally `aria-describedby=<id of content explaining the purpose of the dialog>`.
 - When the dialog opens, focus should land on the first interactive element if one exists, or the button to close the dialog.

--- a/src/README.md
+++ b/src/README.md
@@ -118,7 +118,7 @@ See https://vuetifyjs.com/en/api/v-data-table/#links
 - Add `<v-card class="modal-content">` as a child of `<v-dialog>` and wrapping its contents.
 - If specifying `width`, `max-width`, or `min-width`, put these properties on the `<v-card>` and not on `<v-dialog`>.
 - Remove these properties: `body-class`, `hide-footer`, and `hide-header`.
-- Add `<FocusLock>` as a child of `<v-card>` to prevent focus from leaving the modal. The Vuetify property `retain-focus` doesn't seem to do what it says, so we need to use https://github.com/theKashey/vue-focus-lock
+- Add `<FocusLock>` as a child of `<v-card>` to prevent focus from leaving the modal (components need to be ordered this way or it will break scrolling in the modal). The Vuetify property `retain-focus` doesn't seem to do what it says, so we need to use https://github.com/theKashey/vue-focus-lock
 - Use `<v-card-title>`, `<v-card-text class="modal-body">`, and `<v-card-actions class="modal-footer">` so that every dialog has consistent padding.
 - Add `aria-labelledby=<id of header>` and optionally `aria-describedby=<id of content explaining the purpose of the dialog>`.
 - When the dialog opens, focus should land on the first interactive element if one exists, or the button to close the dialog.

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -99,6 +99,9 @@
   color: #333;
   background-color: #eee;
 }
+.date-input-opacity-override .v-field__input {
+  opacity: 1 !important;
+}
 .default-margins {
   margin: 16px 16px 16px 22px;
 }

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -167,18 +167,24 @@
 .min-height-unset {
   min-height: unset !important;
 }
+.min-width-unset {
+  min-width: unset !important;
+}
 .modal-body {
   padding: 16px 24px 0 !important;
 }
 .modal-content {
   background-color: #fff !important;
-  margin: auto !important;
+  margin: auto auto 24px auto !important;
   padding: 16px 0 20px !important;
   width: 60% !important;
 }
 .modal-footer {
   justify-content: flex-end !important;
   padding: 0 20px !important;
+}
+.modal-fullscreen {
+  width: 100% !important;
 }
 .modal-open {
   overflow: hidden;

--- a/src/components/admin/EditUserProfileModal.vue
+++ b/src/components/admin/EditUserProfileModal.vue
@@ -25,152 +25,100 @@
       aria-labelledby="modal-header"
       persistent
     >
-      <v-card
-        class="modal-content"
-        max-width="600"
-        min-width="600"
-      >
-        <v-card-title>
-          <ModalHeader :text="isExistingUser ? profile.name : 'Create User'" />
-        </v-card-title>
-        <v-card-text class="modal-body">
-          <div
-            v-if="error"
-            class="mb-2 mt-1 text-error"
-            aria-live="polite"
-            role="alert"
-          >
-            <span class="font-weight-bolder text-error">Error: {{ error }}</span>
-          </div>
-          <div v-if="!isExistingUser" class="align-items-center pb-3">
-            <label for="uid-input" class="sr-only">U I D </label>
-            <v-text-field
-              id="uid-input"
-              v-model="userProfile.uid"
-              density="compact"
-              hide-details
-              label="UID"
-              variant="outlined"
-              width="50%"
-            />
-          </div>
-          <div class="pb-3">
-            <div class="d-flex">
-              <div class="w-50">
-                <v-checkbox
-                  id="is-admin"
-                  v-model="userProfile.isAdmin"
-                  density="compact"
-                  label="Admin"
-                  color="primary"
-                  hide-details="true"
-                />
-                <v-checkbox
-                  id="is-blocked"
-                  v-model="userProfile.isBlocked"
-                  density="compact"
-                  color="primary"
-                  label="Blocked"
-                  hide-details="true"
-                />
-                <v-checkbox
-                  v-if="profile.id"
-                  id="is-deleted"
-                  v-model="isDeleted"
-                  density="compact"
-                  color="primary"
-                  label="Deleted"
-                  hide-details="true"
-                />
-              </div>
-              <div>
-                <v-checkbox
-                  id="can-access-canvas-data"
-                  v-model="userProfile.canAccessCanvasData"
-                  density="compact"
-                  color="primary"
-                  label="Canvas Data"
-                  hide-details="true"
-                />
-                <v-checkbox
-                  id="can-access-advising-data"
-                  v-model="userProfile.canAccessAdvisingData"
-                  density="compact"
-                  color="primary"
-                  label="Notes and Appointments"
-                  hide-details="true"
-                />
-              </div>
+      <FocusLock>
+        <v-card
+          class="modal-content"
+          max-width="600"
+          min-width="600"
+        >
+          <v-card-title>
+            <ModalHeader :text="isExistingUser ? profile.name : 'Create User'" />
+          </v-card-title>
+          <v-card-text class="modal-body">
+            <div
+              v-if="error"
+              class="mb-2 mt-1 text-error"
+              aria-live="polite"
+              role="alert"
+            >
+              <span class="font-weight-bolder text-error">Error: {{ error }}</span>
             </div>
-          </div>
-          <div
-            v-if="isCoe({departments: memberships}) || userProfile.degreeProgressPermission"
-            class="pb-3"
-          >
-            <hr class="mb-3" />
-            <label class="font-weight-black" for="degree-progress-permission-select">Degree Progress Permission</label>
-            <div class="mt-1">
-              <select
-                id="degree-progress-permission-select"
-                v-model="userProfile.degreeProgressPermission"
-                class="select-menu w-50"
-              >
-                <option id="department-null" :value="null">Select...</option>
-                <option
-                  v-for="option in degreeProgressPermissionItems"
-                  :key="option.value"
-                  :value="option.value"
-                >
-                  {{ option.text }}
-                </option>
-              </select>
-            </div>
-            <div class="mt-1">
-              <v-checkbox
-                id="automate-degree-progress-permission"
-                v-model="userProfile.automateDegreeProgressPermission"
+            <div v-if="!isExistingUser" class="align-items-center pb-3">
+              <label for="uid-input" class="sr-only">U I D </label>
+              <v-text-field
+                id="uid-input"
+                v-model="userProfile.uid"
                 density="compact"
-                color="primary"
-                label="Automate Degree Progress permissions"
-                hide-details="true"
+                hide-details
+                label="UID"
+                variant="outlined"
+                width="50%"
               />
             </div>
-          </div>
-          <h4 class="font-size-18">Departments</h4>
-          <div
-            v-for="dept in memberships"
-            :key="dept.code"
-            class="pt-2"
-          >
-            <div class="align-center d-flex">
-              <h5 class="font-size-16">{{ dept.name }} ({{ dept.code }})</h5>
-              <v-btn
-                :id="`remove-department-${dept.code}`"
-                :aria-label="`Remove department '${dept.name}'`"
-                class="px-0 text-error"
-                :icon="mdiCloseCircleOutline"
-                variant="flat"
-                @click="() => removeDepartment(dept.code)"
-              >
-              </v-btn>
+            <div class="pb-3">
+              <div class="d-flex">
+                <div class="w-50">
+                  <v-checkbox
+                    id="is-admin"
+                    v-model="userProfile.isAdmin"
+                    density="compact"
+                    label="Admin"
+                    color="primary"
+                    hide-details="true"
+                  />
+                  <v-checkbox
+                    id="is-blocked"
+                    v-model="userProfile.isBlocked"
+                    density="compact"
+                    color="primary"
+                    label="Blocked"
+                    hide-details="true"
+                  />
+                  <v-checkbox
+                    v-if="profile.id"
+                    id="is-deleted"
+                    v-model="isDeleted"
+                    density="compact"
+                    color="primary"
+                    label="Deleted"
+                    hide-details="true"
+                  />
+                </div>
+                <div>
+                  <v-checkbox
+                    id="can-access-canvas-data"
+                    v-model="userProfile.canAccessCanvasData"
+                    density="compact"
+                    color="primary"
+                    label="Canvas Data"
+                    hide-details="true"
+                  />
+                  <v-checkbox
+                    id="can-access-advising-data"
+                    v-model="userProfile.canAccessAdvisingData"
+                    density="compact"
+                    color="primary"
+                    label="Notes and Appointments"
+                    hide-details="true"
+                  />
+                </div>
+              </div>
             </div>
-            <div class="w-100">
-              <div class="align-center d-flex pl-8">
-                <label class="font-weight-black mr-2" :for="`select-department-${dept.code}-role`">Role:</label>
+            <div
+              v-if="isCoe({departments: memberships}) || userProfile.degreeProgressPermission"
+              class="pb-3"
+            >
+              <hr class="mb-3" />
+              <label class="font-weight-black" for="degree-progress-permission-select">Degree Progress Permission</label>
+              <div class="mt-1">
                 <select
-                  :id="`select-department-${dept.code}-role`"
-                  v-model="dept.role"
-                  class="select-menu w-25"
+                  id="degree-progress-permission-select"
+                  v-model="userProfile.degreeProgressPermission"
+                  class="select-menu w-50"
                 >
+                  <option id="department-null" :value="null">Select...</option>
                   <option
-                    id="department-role-null"
-                    :value="null"
-                  >
-                    Select...
-                  </option>
-                  <option
-                    v-for="option in roles"
-                    :id="`department-role-${lowerCase(option.value)}`"
+                    v-for="option in degreeProgressPermissionItems"
                     :key="option.value"
                     :value="option.value"
                   >
@@ -178,69 +126,123 @@
                   </option>
                 </select>
               </div>
-              <div class="pl-7">
+              <div class="mt-1">
                 <v-checkbox
-                  :id="`is-automate-membership-${dept.code}`"
-                  v-model="dept.automateMembership"
+                  id="automate-degree-progress-permission"
+                  v-model="userProfile.automateDegreeProgressPermission"
                   density="compact"
                   color="primary"
-                  label="Automated"
-                  hide-details
+                  label="Automate Degree Progress permissions"
+                  hide-details="true"
                 />
               </div>
             </div>
-          </div>
-          <div v-if="memberships.length >= 3">
-            <span class="text-info"><v-icon class="mb-1" :icon="mdiCheckBold" /> Three departments is enough!</span>
-          </div>
-          <div v-if="memberships.length < 3" class="mt-2 w-100">
-            <select
-              id="department-select-list"
-              v-model="deptCode"
-              class="select-menu w-100"
-              @change="addDepartment"
+            <h4 class="font-size-18">Departments</h4>
+            <div
+              v-for="dept in memberships"
+              :key="dept.code"
+              class="pt-2"
             >
-              <option id="department-null" :value="undefined">
-                Select...
-              </option>
-              <option
-                v-for="option in departmentOptions"
-                :id="`department-option-${lowerCase(option.value)}`"
-                :key="option.value"
-                :disabled="memberships.findIndex(d => d.code === option.value) >= 0"
-                :value="option.value"
+              <div class="align-center d-flex">
+                <h5 class="font-size-16">{{ dept.name }} ({{ dept.code }})</h5>
+                <v-btn
+                  :id="`remove-department-${dept.code}`"
+                  :aria-label="`Remove department '${dept.name}'`"
+                  class="px-0 text-error"
+                  :icon="mdiCloseCircleOutline"
+                  variant="flat"
+                  @click="() => removeDepartment(dept.code)"
+                >
+                </v-btn>
+              </div>
+              <div class="w-100">
+                <div class="align-center d-flex pl-8">
+                  <label class="font-weight-black mr-2" :for="`select-department-${dept.code}-role`">Role:</label>
+                  <select
+                    :id="`select-department-${dept.code}-role`"
+                    v-model="dept.role"
+                    class="select-menu w-25"
+                  >
+                    <option
+                      id="department-role-null"
+                      :value="null"
+                    >
+                      Select...
+                    </option>
+                    <option
+                      v-for="option in roles"
+                      :id="`department-role-${lowerCase(option.value)}`"
+                      :key="option.value"
+                      :value="option.value"
+                    >
+                      {{ option.text }}
+                    </option>
+                  </select>
+                </div>
+                <div class="pl-7">
+                  <v-checkbox
+                    :id="`is-automate-membership-${dept.code}`"
+                    v-model="dept.automateMembership"
+                    density="compact"
+                    color="primary"
+                    label="Automated"
+                    hide-details
+                  />
+                </div>
+              </div>
+            </div>
+            <div v-if="memberships.length >= 3">
+              <span class="text-info"><v-icon class="mb-1" :icon="mdiCheckBold" /> Three departments is enough!</span>
+            </div>
+            <div v-if="memberships.length < 3" class="mt-2 w-100">
+              <select
+                id="department-select-list"
+                v-model="deptCode"
+                class="select-menu w-100"
+                @change="addDepartment"
               >
-                {{ option.text }}
-              </option>
-            </select>
-          </div>
-        </v-card-text>
-        <hr />
-        <v-card-actions class="modal-footer">
-          <v-btn
-            id="save-changes-to-user-profile"
-            color="primary"
-            :disabled="isSaving || !userProfile.uid || memberships.findIndex(d => !d.role) >= 0"
-            variant="flat"
-            @click="save"
-          >
-            <span v-if="!isSaving">Save</span>
-            <v-progress-circular
-              v-if="isSaving"
-              indeterminate
-              :size="18"
-              :width="4"
+                <option id="department-null" :value="undefined">
+                  Select...
+                </option>
+                <option
+                  v-for="option in departmentOptions"
+                  :id="`department-option-${lowerCase(option.value)}`"
+                  :key="option.value"
+                  :disabled="memberships.findIndex(d => d.code === option.value) >= 0"
+                  :value="option.value"
+                >
+                  {{ option.text }}
+                </option>
+              </select>
+            </div>
+          </v-card-text>
+          <hr />
+          <v-card-actions class="modal-footer">
+            <v-btn
+              id="save-changes-to-user-profile"
+              color="primary"
+              :disabled="isSaving || !userProfile.uid || memberships.findIndex(d => !d.role) >= 0"
+              variant="flat"
+              @click="save"
+            >
+              <span v-if="!isSaving">Save</span>
+              <v-progress-circular
+                v-if="isSaving"
+                indeterminate
+                :size="18"
+                :width="4"
+              />
+            </v-btn>
+            <v-btn
+              id="cancel-changes-to-user-profile"
+              class="ml-2"
+              text="Cancel"
+              variant="text"
+              @click="cancel"
             />
-          </v-btn>
-          <v-btn
-            id="cancel-changes-to-user-profile"
-            class="ml-2"
-            text="Cancel"
-            variant="text"
-            @click="cancel"
-          />
-        </v-card-actions>
-      </v-card>
+          </v-card-actions>
+        </v-card>
+      </FocusLock>
     </v-dialog>
   </div>
 </template>
@@ -295,9 +297,9 @@ export default {
     error: undefined,
     isDeleted: undefined,
     isSaving: false,
-    memberships: undefined,
+    memberships: [],
     showEditUserModal: false,
-    userProfile: undefined,
+    userProfile: {},
     degreeProgressPermissionItems: [
       {value: 'read', text: 'Read-only'},
       {value: 'read_write', text: 'Read and write'}
@@ -334,8 +336,8 @@ export default {
     closeModal() {
       this.showEditUserModal = false
       this.error = undefined
-      this.userProfile = undefined
-      this.memberships = undefined
+      this.userProfile = {}
+      this.memberships = []
     },
     openEditUserModal() {
       this.userProfile = {

--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -299,6 +299,7 @@
 </template>
 
 <script setup>
+import {get} from 'lodash'
 import {mdiEmail} from '@mdi/js'
 import {mdiLoginVariant} from '@mdi/js'
 import {normalizeId} from '@/lib/utils'
@@ -520,7 +521,7 @@ export default {
     },
     afterCancelUpdateUser(profile) {
       alertScreenReader('Canceled')
-      putFocusNextTick(`edit-${profile.uid}`)
+      putFocusNextTick(get(profile, 'uid') ? `edit-${profile.uid}` : 'add-new-user-btn')
     },
     afterUpdateUser(profile) {
       alertScreenReader(`${profile.name} profile updated.`)
@@ -528,6 +529,7 @@ export default {
         this.userSelection = profile.uid
       }
       this.refreshUsers()
+      putFocusNextTick(get(profile, 'uid') ? `edit-${profile.uid}` : 'add-new-user-btn')
     },
     autocompleteUsers(q) {
       return userAutocomplete(q).then(results => this._orderBy(results, 'label'))

--- a/src/components/cohort/CreateCohortModal.vue
+++ b/src/components/cohort/CreateCohortModal.vue
@@ -4,62 +4,64 @@
     aria-labelledby="modal-header"
     persistent
   >
-    <v-card
-      class="modal-content"
-      min-width="400"
-      max-width="600"
-    >
-      <v-card-title>
-        <ModalHeader text="Name Your Cohort" />
-      </v-card-title>
-      <form @submit.prevent="createCohort" @keydown.esc="cancelModal">
-        <v-card-text class="modal-body">
-          <v-text-field
-            id="create-cohort-input"
-            v-model="name"
-            aria-label="Cohort name, 255 characters or fewer"
-            aria-required="true"
-            class="v-input-details-override"
-            counter="255"
-            density="compact"
-            :disabled="isSaving"
-            maxlength="255"
-            required
-            type="text"
-            persistent-counter
-            :rules="[validationRules.valid]"
-            validate-on="lazy input"
-            variant="outlined"
-            @keyup.esc="cancelModal"
-          >
-            <template #counter="{max, value}">
-              <div id="name-create-cohort-counter" aria-live="polite" class="font-size-13 text-no-wrap ml-2 mt-1">
-                <span class="sr-only">Cohort name has a </span>{{ max }} character limit <span v-if="value">({{ max - value }} left)</span>
-              </div>
-            </template>
-          </v-text-field>
-        </v-card-text>
-        <hr />
-        <v-card-actions class="modal-footer">
-          <ProgressButton
-            id="create-cohort-confirm-btn"
-            :action="createCohort"
-            :disabled="!name.length"
-            :in-progress="isSaving"
-            text="Save"
-          />
-          <v-btn
-            id="create-cohort-cancel-btn"
-            class="ml-2"
-            :disabled="isSaving"
-            variant="text"
-            @click="cancelModal"
-          >
-            Cancel
-          </v-btn>
-        </v-card-actions>
-      </form>
-    </v-card>
+    <FocusLock>
+      <v-card
+        class="modal-content"
+        min-width="400"
+        max-width="600"
+      >
+        <v-card-title>
+          <ModalHeader text="Name Your Cohort" />
+        </v-card-title>
+        <form @submit.prevent="createCohort" @keydown.esc="cancelModal">
+          <v-card-text class="modal-body">
+            <v-text-field
+              id="create-cohort-input"
+              v-model="name"
+              aria-label="Cohort name, 255 characters or fewer"
+              aria-required="true"
+              class="v-input-details-override"
+              counter="255"
+              density="compact"
+              :disabled="isSaving"
+              maxlength="255"
+              required
+              type="text"
+              persistent-counter
+              :rules="[validationRules.valid]"
+              validate-on="lazy input"
+              variant="outlined"
+              @keyup.esc="cancelModal"
+            >
+              <template #counter="{max, value}">
+                <div id="name-create-cohort-counter" aria-live="polite" class="font-size-13 text-no-wrap ml-2 mt-1">
+                  <span class="sr-only">Cohort name has a </span>{{ max }} character limit <span v-if="value">({{ max - value }} left)</span>
+                </div>
+              </template>
+            </v-text-field>
+          </v-card-text>
+          <hr />
+          <v-card-actions class="modal-footer">
+            <ProgressButton
+              id="create-cohort-confirm-btn"
+              :action="createCohort"
+              :disabled="!name.length || isInvalid"
+              :in-progress="isSaving"
+              text="Save"
+            />
+            <v-btn
+              id="create-cohort-cancel-btn"
+              class="ml-2"
+              :disabled="isSaving"
+              variant="text"
+              @click="cancelModal"
+            >
+              Cancel
+            </v-btn>
+          </v-card-actions>
+        </form>
+      </v-card>
+    </FocusLock>
   </v-dialog>
 </template>
 

--- a/src/components/curated/CreateCuratedGroupModal.vue
+++ b/src/components/curated/CreateCuratedGroupModal.vue
@@ -4,62 +4,64 @@
     aria-labelledby="modal-header"
     persistent
   >
-    <v-card
-      class="modal-content"
-      min-width="400"
-      max-width="600"
-    >
-      <v-card-title>
-        <ModalHeader :text="`Name Your ${domainLabel(true)}`" />
-      </v-card-title>
-      <form @submit.prevent="createCuratedGroup" @keydown.esc="cancelModal">
-        <v-card-text class="modal-body">
-          <v-text-field
-            id="create-curated-group-input"
-            v-model="name"
-            :aria-label="`${domainLabel(true)} name, 255 characters or fewer`"
-            aria-required="true"
-            class="v-input-details-override"
-            counter="255"
-            density="compact"
-            :disabled="isSaving"
-            label="Name"
-            maxlength="255"
-            required
-            type="text"
-            persistent-counter
-            :rules="[validationRules.valid]"
-            validate-on="lazy input"
-            variant="outlined"
-            @keyup.esc="cancel"
-          >
-            <template #counter="{max, value}">
-              <div id="name-create-cohort-counter" aria-live="polite" class="font-size-13 text-no-wrap ml-2 mt-1">
-                <span class="sr-only">{{ domainLabel(true) }} name has a </span>{{ max }} character limit <span v-if="value">({{ max - value }} left)</span>
-              </div>
-            </template>
-          </v-text-field>
-        </v-card-text>
-        <hr />
-        <v-card-actions class="modal-footer">
-          <ProgressButton
-            id="create-curated-group-confirm"
-            :action="createCuratedGroup"
-            :disabled="isSaving || !name.length"
-            :in-progress="isSaving"
-            text="Save"
-          />
-          <v-btn
-            id="create-curated-group-cancel"
-            class="ml-2"
-            :disabled="isSaving"
-            text="Cancel"
-            variant="text"
-            @click="cancelModal"
-          />
-        </v-card-actions>
-      </form>
-    </v-card>
+    <FocusLock>
+      <v-card
+        class="modal-content"
+        min-width="400"
+        max-width="600"
+      >
+        <v-card-title>
+          <ModalHeader :text="`Name Your ${domainLabel(true)}`" />
+        </v-card-title>
+        <form @submit.prevent="createCuratedGroup" @keydown.esc="cancelModal">
+          <v-card-text class="modal-body">
+            <v-text-field
+              id="create-curated-group-input"
+              v-model="name"
+              :aria-label="`${domainLabel(true)} name, 255 characters or fewer`"
+              aria-required="true"
+              class="v-input-details-override"
+              counter="255"
+              density="compact"
+              :disabled="isSaving"
+              label="Name"
+              maxlength="255"
+              required
+              type="text"
+              persistent-counter
+              :rules="[validationRules.valid]"
+              validate-on="lazy input"
+              variant="outlined"
+              @keyup.esc="cancel"
+            >
+              <template #counter="{max, value}">
+                <div id="name-create-cohort-counter" aria-live="polite" class="font-size-13 text-no-wrap ml-2 mt-1">
+                  <span class="sr-only">{{ domainLabel(true) }} name has a </span>{{ max }} character limit <span v-if="value">({{ max - value }} left)</span>
+                </div>
+              </template>
+            </v-text-field>
+          </v-card-text>
+          <hr />
+          <v-card-actions class="modal-footer">
+            <ProgressButton
+              id="create-curated-group-confirm"
+              :action="createCuratedGroup"
+              :disabled="isSaving || !name.length || isInvalid"
+              :in-progress="isSaving"
+              text="Save"
+            />
+            <v-btn
+              id="create-curated-group-cancel"
+              class="ml-2"
+              :disabled="isSaving"
+              text="Cancel"
+              variant="text"
+              @click="cancelModal"
+            />
+          </v-card-actions>
+        </form>
+      </v-card>
+    </FocusLock>
   </v-dialog>
 </template>
 
@@ -93,6 +95,7 @@ export default {
   },
   data: () => ({
     name: '',
+    isInvalid: false,
     isSaving: false,
     validationRules: {}
   }),

--- a/src/components/degree/CloneTemplateModal.vue
+++ b/src/components/degree/CloneTemplateModal.vue
@@ -4,63 +4,65 @@
     aria-labelledby="modal-header"
     persistent
   >
-    <v-card class="modal-content" min-width="600">
-      <v-card-title>
-        <ModalHeader text="Name Your Degree Copy" />
-      </v-card-title>
-      <form @submit.prevent="createClone" @keydown.esc="cancel">
-        <v-card-text class="modal-body">
-          <label
-            id="degree-name-input-label"
-            for="degree-name-input"
-          >
-            Degree Name:
-          </label>
-          <v-text-field
-            id="degree-name-input"
-            v-model="name"
-            aria-labelledby="degree-name-input-label"
-            class="mt-2 name-input"
-            :disabled="isSaving"
-            hide-details
-            maxlength="255"
-            variant="outlined"
-            @keydoown.enter="() => name.length && createClone()"
-            @keyup.esc="cancel"
-          />
-          <div class="ml-2">
-            <span class="text-grey font-size-12"><span class="sr-only">Degree name has a </span>255 character limit <span v-if="name.length">({{ 255 - name.length }} left)</span></span>
-            <span
-              v-if="name.length === 255"
-              aria-live="polite"
-              class="sr-only"
-              role="alert"
+    <FocusLock>
+      <v-card class="modal-content" min-width="600">
+        <v-card-title>
+          <ModalHeader text="Name Your Degree Copy" />
+        </v-card-title>
+        <form @submit.prevent="createClone" @keydown.esc="cancel">
+          <v-card-text class="modal-body">
+            <label
+              id="degree-name-input-label"
+              for="degree-name-input"
             >
-              Degree name cannot exceed 255 characters.
-            </span>
-          </div>
-          <div v-if="error" class="mt-2 text-error" v-html="error" />
-        </v-card-text>
-        <v-card-actions class="modal-footer">
-          <ProgressButton
-            id="clone-confirm"
-            :action="createClone"
-            color="primary"
-            :disabled="!name.trim().length || isSaving || !!error || (templateToClone.name === name)"
-            :in-progress="isSaving"
-            :text="isSaving ? 'Saving' : 'Save Copy'"
-          />
-          <v-btn
-            id="clone-cancel"
-            class="ml-2"
-            :disabled="isSaving"
-            text="Cancel"
-            variant="text"
-            @click="cancel"
-          />
-        </v-card-actions>
-      </form>
-    </v-card>
+              Degree Name:
+            </label>
+            <v-text-field
+              id="degree-name-input"
+              v-model="name"
+              aria-labelledby="degree-name-input-label"
+              class="mt-2 name-input"
+              :disabled="isSaving"
+              hide-details
+              maxlength="255"
+              variant="outlined"
+              @keydoown.enter="() => name.length && createClone()"
+              @keyup.esc="cancel"
+            />
+            <div class="ml-2">
+              <span class="text-grey font-size-12"><span class="sr-only">Degree name has a </span>255 character limit <span v-if="name.length">({{ 255 - name.length }} left)</span></span>
+              <span
+                v-if="name.length === 255"
+                aria-live="polite"
+                class="sr-only"
+                role="alert"
+              >
+                Degree name cannot exceed 255 characters.
+              </span>
+            </div>
+            <div v-if="error" class="mt-2 text-error" v-html="error" />
+          </v-card-text>
+          <v-card-actions class="modal-footer">
+            <ProgressButton
+              id="clone-confirm"
+              :action="createClone"
+              color="primary"
+              :disabled="!name.trim().length || isSaving || !!error || (templateToClone.name === name)"
+              :in-progress="isSaving"
+              :text="isSaving ? 'Saving' : 'Save Copy'"
+            />
+            <v-btn
+              id="clone-cancel"
+              class="ml-2"
+              :disabled="isSaving"
+              text="Cancel"
+              variant="text"
+              @click="cancel"
+            />
+          </v-card-actions>
+        </form>
+      </v-card>
+    </FocusLock>
   </v-dialog>
 </template>
 

--- a/src/components/degree/student/CreateCourseModal.vue
+++ b/src/components/degree/student/CreateCourseModal.vue
@@ -25,112 +25,114 @@
     persistent
     @update:model-value="onToggle"
   >
-    <v-card class="modal-content" min-width="600">
-      <v-card-title>
-        <ModalHeader text="Create Course" />
-      </v-card-title>
-      <v-card-text class="modal-body">
-        <div>
-          <label
-            for="course-name-input"
-            class="font-weight-700 mb-1"
-          >
-            <span class="sr-only">Course </span>Name
-          </label>
-          <v-text-field
-            id="course-name-input"
-            v-model="name"
-            class="cohort-create-input-name"
-            density="comfortable"
-            hide-details
-            maxlength="255"
-            variant="outlined"
-          />
-          <div class="text-grey mb-3"><span class="sr-only">Course name has a </span>255 character limit <span v-if="name.length">({{ 255 - name.length }} left)</span></div>
-          <div
-            v-if="error"
-            id="create-error"
-            class="text-error"
-            aria-live="polite"
-            role="alert"
-          >
-            {{ error }}
+    <FocusLock>
+      <v-card class="modal-content" min-width="600">
+        <v-card-title>
+          <ModalHeader text="Create Course" />
+        </v-card-title>
+        <v-card-text class="modal-body">
+          <div>
+            <label
+              for="course-name-input"
+              class="font-weight-700 mb-1"
+            >
+              <span class="sr-only">Course </span>Name
+            </label>
+            <v-text-field
+              id="course-name-input"
+              v-model="name"
+              class="cohort-create-input-name"
+              density="comfortable"
+              hide-details
+              maxlength="255"
+              variant="outlined"
+            />
+            <div class="text-grey mb-3"><span class="sr-only">Course name has a </span>255 character limit <span v-if="name.length">({{ 255 - name.length }} left)</span></div>
+            <div
+              v-if="error"
+              id="create-error"
+              class="text-error"
+              aria-live="polite"
+              role="alert"
+            >
+              {{ error }}
+            </div>
+            <div
+              v-if="name.length === 255"
+              class="sr-only"
+              aria-live="polite"
+            >
+              Course name cannot exceed 255 characters.
+            </div>
           </div>
-          <div
-            v-if="name.length === 255"
-            class="sr-only"
-            aria-live="polite"
-          >
-            Course name cannot exceed 255 characters.
+          <div class="pb-2">
+            <UnitsInput
+              :disable="isSaving"
+              :error-message="unitsErrorMessage"
+              input-id="course-units-input"
+              label-class="font-weight-700 mb-1 pr-2"
+              :on-submit="save"
+              :set-units-lower="setUnits"
+              :units-lower="units"
+            />
           </div>
-        </div>
-        <div class="pb-2">
-          <UnitsInput
-            :disable="isSaving"
-            :error-message="unitsErrorMessage"
-            input-id="course-units-input"
-            label-class="font-weight-700 mb-1 pr-2"
-            :on-submit="save"
-            :set-units-lower="setUnits"
-            :units-lower="units"
-          />
-        </div>
-        <div class="pb-3">
-          <label id="units-grade-label" for="course-grade-input" class="font-weight-700 mb-1 pr-2">
-            Grade
+          <div class="pb-3">
+            <label id="units-grade-label" for="course-grade-input" class="font-weight-700 mb-1 pr-2">
+              Grade
+            </label>
+            <v-text-field
+              id="course-grade-input"
+              v-model="grade"
+              :aria-autocomplete="false"
+              aria-labelledby="units-grade-label"
+              class="grade-input"
+              density="compact"
+              hide-details
+              maxlength="3"
+              variant="outlined"
+              @keydown.enter="save"
+            />
+          </div>
+          <div class="pb-3">
+            <AccentColorSelect
+              :accent-color="accentColor"
+              :on-change="value => accentColor = value"
+            />
+          </div>
+          <label for="course-note-textarea" class="font-weight-700">
+            Note
           </label>
-          <v-text-field
-            id="course-grade-input"
-            v-model="grade"
-            :aria-autocomplete="false"
-            aria-labelledby="units-grade-label"
-            class="grade-input"
-            density="compact"
-            hide-details
-            maxlength="3"
-            variant="outlined"
-            @keydown.enter="save"
+          <div class="pb-2">
+            <v-textarea
+              id="course-note-textarea"
+              v-model="note"
+              :disabled="isSaving"
+              hide-details
+              rows="4"
+              variant="outlined"
+            />
+          </div>
+        </v-card-text>
+        <v-card-actions class="modal-footer">
+          <ProgressButton
+            id="create-course-save-btn"
+            :action="save"
+            color="primary"
+            :disabled="disableSaveButton"
+            :in-progress="isSaving"
+            :text="isSaving ? 'Saving' : 'Save'"
           />
-        </div>
-        <div class="pb-3">
-          <AccentColorSelect
-            :accent-color="accentColor"
-            :on-change="value => accentColor = value"
-          />
-        </div>
-        <label for="course-note-textarea" class="font-weight-700">
-          Note
-        </label>
-        <div class="pb-2">
-          <v-textarea
-            id="course-note-textarea"
-            v-model="note"
+          <v-btn
+            id="create-course-cancel-btn"
+            class="ml-2"
             :disabled="isSaving"
-            hide-details
-            rows="4"
-            variant="outlined"
+            text="Cancel"
+            variant="text"
+            @click="cancel"
           />
-        </div>
-      </v-card-text>
-      <v-card-actions class="modal-footer">
-        <ProgressButton
-          id="create-course-save-btn"
-          :action="save"
-          color="primary"
-          :disabled="disableSaveButton"
-          :in-progress="isSaving"
-          :text="isSaving ? 'Saving' : 'Save'"
-        />
-        <v-btn
-          id="create-course-cancel-btn"
-          class="ml-2"
-          :disabled="isSaving"
-          text="Cancel"
-          variant="text"
-          @click="cancel"
-        />
-      </v-card-actions>
-    </v-card>
+        </v-card-actions>
+      </v-card>
+    </FocusLock>
   </v-dialog>
 </template>
 

--- a/src/components/note/CreateTemplateModal.vue
+++ b/src/components/note/CreateTemplateModal.vue
@@ -9,61 +9,63 @@
       min-width="400"
       max-width="600"
     >
-      <v-card-title>
-        <ModalHeader text="Name Your Template" />
-      </v-card-title>
-      <hr />
-      <form @submit.prevent="createTemplate">
-        <v-card-text class="modal-body">
-          <v-text-field
-            id="template-title-input"
-            v-model="title"
-            class="v-input-details-override"
-            counter="255"
-            density="compact"
-            :disabled="isSaving"
-            :error="!!error"
-            label="Template name"
-            maxlength="255"
-            persistent-counter
-            :rules="[validationRules.required, validationRules.maxLength]"
-            validate-on="blur lazy"
-            variant="outlined"
-          >
-            <template #counter="{max, value}">
-              <div id="name-template-counter" aria-live="polite" class="font-size-13 text-no-wrap my-1">
-                <span class="sr-only">Template name has a </span>{{ max }} character limit <span v-if="value">({{ max - value }} left)</span>
-              </div>
-            </template>
-          </v-text-field>
-          <div
-            v-if="error"
-            id="create-template-error"
-            aria-live="polite"
-            class="text-error font-size-13 font-weight-regular"
-            role="alert"
-          >
-            {{ error }}
-          </div>
-        </v-card-text>
-        <v-card-actions class="modal-footer">
-          <ProgressButton
-            id="create-template-confirm"
-            :action="createTemplate"
-            :disabled="isSaving || !title.length || title.length > 255 || useNoteStore().boaSessionExpired"
-            :in-progress="isSaving"
-            :text="isSaving ? 'Saving' : 'Save'"
-          />
-          <v-btn
-            id="cancel-template-create"
-            class="ml-2"
-            :disabled="isSaving"
-            text="Cancel"
-            variant="text"
-            @click="cancel"
-          />
-        </v-card-actions>
-      </form>
+      <FocusLock>
+        <v-card-title>
+          <ModalHeader text="Name Your Template" />
+        </v-card-title>
+        <hr />
+        <form @submit.prevent="createTemplate">
+          <v-card-text class="modal-body">
+            <v-text-field
+              id="template-title-input"
+              v-model="title"
+              class="v-input-details-override"
+              counter="255"
+              density="compact"
+              :disabled="isSaving"
+              :error="!!error"
+              label="Template name"
+              maxlength="255"
+              persistent-counter
+              :rules="[validationRules.required, validationRules.maxLength]"
+              validate-on="blur lazy"
+              variant="outlined"
+            >
+              <template #counter="{max, value}">
+                <div id="name-template-counter" aria-live="polite" class="font-size-13 text-no-wrap my-1">
+                  <span class="sr-only">Template name has a </span>{{ max }} character limit <span v-if="value">({{ max - value }} left)</span>
+                </div>
+              </template>
+            </v-text-field>
+            <div
+              v-if="error"
+              id="create-template-error"
+              aria-live="polite"
+              class="text-error font-size-13 font-weight-regular"
+              role="alert"
+            >
+              {{ error }}
+            </div>
+          </v-card-text>
+          <v-card-actions class="modal-footer">
+            <ProgressButton
+              id="create-template-confirm"
+              :action="createTemplate"
+              :disabled="isSaving || !title.length || title.length > 255 || useNoteStore().boaSessionExpired"
+              :in-progress="isSaving"
+              :text="isSaving ? 'Saving' : 'Save'"
+            />
+            <v-btn
+              id="cancel-template-create"
+              class="ml-2"
+              :disabled="isSaving"
+              text="Cancel"
+              variant="text"
+              @click="cancel"
+            />
+          </v-card-actions>
+        </form>
+      </FocusLock>
     </v-card>
   </v-dialog>
 </template>

--- a/src/components/note/EditBatchNoteModal.vue
+++ b/src/components/note/EditBatchNoteModal.vue
@@ -4,99 +4,103 @@
     v-model="dialogModel"
     aria-labelledby="dialog-header-note"
     persistent
+    scrollable
   >
     <v-card
       id="new-note-modal-container"
       class="modal-content"
+      :class="{'modal-fullscreen': $vuetify.display.mdAndDown}"
       min-width="500"
     >
-      <CreateNoteHeader />
-      <v-card-text class="modal-body">
-        <Transition
-          v-if="['createBatch', 'editDraft'].includes(mode)"
-          class="mb-3"
-          name="batch-transition"
-        >
-          <div v-show="mode !== 'editTemplate'">
-            <BatchNoteFeatures :discard="discardRequested" />
-          </div>
-        </Transition>
-        <div>
-          <label
-            id="create-note-subject-label"
-            for="create-note-subject"
-            class="font-size-16 font-weight-700"
+      <FocusLock :disabled="noteStore.isFocusLockDisabled">
+        <CreateNoteHeader />
+        <v-card-text class="modal-body">
+          <Transition
+            v-if="['createBatch', 'editDraft'].includes(mode)"
+            class="mb-3"
+            name="batch-transition"
           >
-            <span class="sr-only">Note </span>Subject
-          </label>
-          <v-text-field
-            id="create-note-subject"
-            :model-value="model.subject"
-            aria-labelledby="create-note-subject-label"
-            class="mt-1"
-            :class="{'bg-light': isSaving}"
-            color="primary"
-            density="compact"
-            :disabled="isSaving || boaSessionExpired"
-            maxlength="255"
-            type="text"
-            variant="outlined"
-            @input="setSubjectPerEvent"
-          />
-          <RichTextEditor
-            id="note-details"
-            :disabled="isSaving || boaSessionExpired"
-            :initial-value="model.body || ''"
-            :is-in-modal="true"
-            label="Note Details"
-            :on-value-update="noteStore.setBody"
-            :show-advising-note-best-practices="true"
-          />
-        </div>
-        <div class="py-3">
-          <AdvisingNoteTopics />
-          <PrivacyPermissions v-if="contextStore.currentUser.canAccessPrivateNotes" />
-          <TransitionGroup v-if="mode !== 'editTemplate'" name="batch-transition">
-            <div key="0" class="pt-4">
-              <ContactMethod />
+            <div v-show="mode !== 'editTemplate'">
+              <BatchNoteFeatures :discard="discardRequested" />
             </div>
-            <div key="1" class="pt-4">
-              <ManuallySetDate />
-            </div>
-          </TransitionGroup>
-          <AdvisingNoteAttachments
-            :add-attachments="addNoteAttachments"
-            class="pt-5"
-            :disabled="!!(noteStore.isSaving || noteStore.boaSessionExpired)"
-            :remove-attachment="removeAttachmentByIndex"
-          />
-        </div>
-        <v-alert
-          v-if="alert"
-          id="alert-in-note-modal"
-          :model-value="alert && !!dismissAlertSeconds"
-          class="font-weight-bold w-100 mb-2"
-          closable
-          color="info"
-          density="comfortable"
-          variant="tonal"
-          @click:close="dismissAlert"
-        >
-          <div class="d-flex">
-            <div v-if="isSaving" class="mr-2">
-              <v-icon :icon="mdiSync" spin />
-            </div>
-            <div>{{ alert }}</div>
+          </Transition>
+          <div>
+            <label
+              id="create-note-subject-label"
+              for="create-note-subject"
+              class="font-size-16 font-weight-700"
+            >
+              <span class="sr-only">Note </span>Subject
+            </label>
+            <v-text-field
+              id="create-note-subject"
+              :model-value="model.subject"
+              aria-labelledby="create-note-subject-label"
+              class="mt-1"
+              :class="{'bg-light': isSaving}"
+              color="primary"
+              density="compact"
+              :disabled="isSaving || boaSessionExpired"
+              maxlength="255"
+              type="text"
+              variant="outlined"
+              @input="setSubjectPerEvent"
+            />
+            <RichTextEditor
+              id="note-details"
+              :disabled="isSaving || boaSessionExpired"
+              :initial-value="model.body || ''"
+              :is-in-modal="true"
+              label="Note Details"
+              :on-value-update="noteStore.setBody"
+              :show-advising-note-best-practices="true"
+            />
           </div>
-        </v-alert>
-      </v-card-text>
-      <CreateNoteFooter
-        :discard="discardRequested"
-        :exit="exit"
-        :save-as-template="saveAsTemplate"
-        :show-alert="showAlert"
-        :update-template="updateTemplate"
-      />
+          <div class="py-3">
+            <AdvisingNoteTopics />
+            <PrivacyPermissions v-if="contextStore.currentUser.canAccessPrivateNotes" />
+            <TransitionGroup v-if="mode !== 'editTemplate'" name="batch-transition">
+              <div key="0" class="pt-4">
+                <ContactMethod />
+              </div>
+              <div key="1" class="pt-4">
+                <ManuallySetDate />
+              </div>
+            </TransitionGroup>
+            <AdvisingNoteAttachments
+              :add-attachments="addNoteAttachments"
+              class="pt-5"
+              :disabled="!!(noteStore.isSaving || noteStore.boaSessionExpired)"
+              :remove-attachment="removeAttachmentByIndex"
+            />
+          </div>
+          <v-alert
+            v-if="alert"
+            id="alert-in-note-modal"
+            :model-value="alert && !!dismissAlertSeconds"
+            class="font-weight-bold w-100 mb-2"
+            closable
+            color="info"
+            density="comfortable"
+            variant="tonal"
+            @click:close="dismissAlert"
+          >
+            <div class="d-flex">
+              <div v-if="isSaving" class="mr-2">
+                <v-icon :icon="mdiSync" spin />
+              </div>
+              <div>{{ alert }}</div>
+            </div>
+          </v-alert>
+        </v-card-text>
+        <CreateNoteFooter
+          :discard="discardRequested"
+          :exit="exit"
+          :save-as-template="saveAsTemplate"
+          :show-alert="showAlert"
+          :update-template="updateTemplate"
+        />
+      </FocusLock>
     </v-card>
   </v-dialog>
   <AreYouSureModal
@@ -201,6 +205,7 @@ watch(dialogModel, () => {
     document.documentElement.classList.add('modal-open')
     document.removeEventListener('keyup', selectEscape)
     document.addEventListener('keyup', selectEscape)
+    enableFocusLock()
     getMyNoteTemplates().then(noteStore.setNoteTemplates)
     noteStore.resetModel()
     init().then(note => {
@@ -218,11 +223,16 @@ watch(dialogModel, () => {
     })
   } else {
     noteStore.setMode(null)
+    disableFocusLock()
     document.documentElement.classList.remove('modal-open')
     document.removeEventListener('keyup', selectEscape)
     contextStore.removeEventHandler('user-session-expired', noteStore.onBoaSessionExpires)
   }
 })
+
+watch(showCreateTemplateModal, isOpen => isOpen ? disableFocusLock() : enableFocusLock())
+watch(showDiscardNoteModal, isOpen => isOpen ? disableFocusLock() : enableFocusLock())
+watch(showDiscardTemplateModal, isOpen => isOpen ? disableFocusLock() : enableFocusLock())
 
 const addNoteAttachments = attachments => {
   return new Promise(resolve => {
@@ -245,14 +255,12 @@ const addNoteAttachments = attachments => {
 const cancelCreateTemplate = () => {
   noteStore.setIsSaving(false)
   showCreateTemplateModal.value = false
-  enableFocusLock()
   alertScreenReader('Canceled save note as template.')
   putFocusNextTick('btn-save-as-template')
 }
 
 const cancelDiscardNote = () => {
   showDiscardNoteModal.value = false
-  enableFocusLock()
   alertScreenReader('Continue editing note.')
   putFocusNextTick('create-note-cancel')
 }
@@ -260,14 +268,12 @@ const cancelDiscardNote = () => {
 const cancelDiscardTemplate = () => {
   showDiscardTemplateModal.value = false
   putFocusNextTick('create-note-subject')
-  enableFocusLock()
 }
 
 const createTemplate = title => {
   noteStore.setIsSaving(true)
   alertScreenReader('Creating template')
   const ifAuthenticated = () => {
-    enableFocusLock()
     // File upload might take time; alert will be overwritten when API call is done.
     showAlert('Creating template...', 60)
     // Save draft before creating template.
@@ -293,7 +299,6 @@ const createTemplate = title => {
 }
 
 const discardNote = () => {
-  enableFocusLock()
   exit(true).then(() => alertScreenReader('Canceled create new note'))
 }
 
@@ -309,7 +314,6 @@ const discardRequested = () => {
       discardTemplate()
     } else {
       showDiscardTemplateModal.value = true
-      disableFocusLock()
     }
   } else {
     const unsavedChanges = !!trim(model.value.subject)
@@ -319,7 +323,6 @@ const discardRequested = () => {
       || completeSidSet.value.size
     if (unsavedChanges) {
       showDiscardNoteModal.value = true
-      disableFocusLock()
     } else {
       discardNote()
     }
@@ -341,7 +344,7 @@ const dismissAlert = seconds => {
 const exit = revert => {
   alert.value = dismissAlertSeconds.value = undefined
   showCreateTemplateModal.value = showDiscardNoteModal.value = showDiscardTemplateModal.value = false
-  dialogModel.value = null
+  dialogModel.value = false
   noteStore.setMode(null)
   return exitSession(revert).then(props.onClose)
 }
@@ -377,7 +380,6 @@ const saveAsTemplate = () => {
     noteStore.setIsSaving(true)
     const ifAuthenticated = () => {
       showCreateTemplateModal.value = true
-      disableFocusLock()
     }
     alertScreenReader('Opening Name Template form')
     invokeIfAuthenticated(ifAuthenticated).finally(resolve)

--- a/src/components/note/ManuallySetDate.vue
+++ b/src/components/note/ManuallySetDate.vue
@@ -7,7 +7,7 @@
     >
       Manually Set Date
     </label>
-    <div class="date-input-container">
+    <div class="date-input-container date-input-opacity-override">
       <v-date-input
         id="manually-set-date-input"
         aria-labelledby="manually-set-date-label"

--- a/src/components/note/PrivacyPermissions.vue
+++ b/src/components/note/PrivacyPermissions.vue
@@ -45,7 +45,7 @@ export default {
   computed: {
     isPrivate: {
       get() {
-        return this.model.isPrivate
+        return useNoteStore().model.isPrivate
       },
       set(value) {
         useNoteStore().setIsPrivate(value)

--- a/src/components/topics/EditTopicModal.vue
+++ b/src/components/topics/EditTopicModal.vue
@@ -8,53 +8,55 @@
       class="modal-content"
       min-width="400"
     >
-      <v-card-title>
-        <ModalHeader text="Create Topic" />
-      </v-card-title>
-      <form @submit.prevent="save">
-        <v-card-text class="modal-body">
-          <div class="text-field-width d-block">
-            <v-text-field
-              id="create-topic-input"
-              v-model="topic"
-              aria-describedby="input-live-help topic-label-error"
-              hide-details
-              required
-              :maxlength="50"
-              variant="outlined"
+      <FocusLock>
+        <v-card-title>
+          <ModalHeader text="Create Topic" />
+        </v-card-title>
+        <form @submit.prevent="save">
+          <v-card-text class="modal-body">
+            <div class="text-field-width d-block">
+              <v-text-field
+                id="create-topic-input"
+                v-model="topic"
+                aria-describedby="input-live-help topic-label-error"
+                hide-details
+                required
+                :maxlength="50"
+                variant="outlined"
+              >
+              </v-text-field>
+            </div>
+            <div id="topic-label-error" class="font-size-14 mt-0 pl-2 pt-2">
+              <span v-if="!isValidLabel">Label must be {{ minLabelLength }} or more characters.</span>
+              <span v-if="isLabelReserved">Sorry, the label '{{ trim(topic) }}' is assigned to an existing topic.</span>
+            </div>
+            <div class="text-grey font-size-14 pl-2 pt-2">
+              <span v-if="!isLabelReserved && isValidLabel" id="input-live-help">
+                {{ maxLabelLength }} character limit <span v-if="topic.length">({{ maxLabelLength - topic.length }} left)</span>
+              </span>
+            </div>
+          </v-card-text>
+          <hr />
+          <v-card-actions class="modal-footer">
+            <ProgressButton
+              id="topic-save"
+              :action="save"
+              :disabled="disableSaveButton"
+              :in-progress="isSaving"
+              :text="isSaving ? 'Saving' : 'Save'"
+            />
+            <v-btn
+              id="cancel"
+              class="ml-2"
+              :disabled="isSaving"
+              variant="text"
+              @click.stop="cancel"
             >
-            </v-text-field>
-          </div>
-          <div id="topic-label-error" class="font-size-14 mt-0 pl-2 pt-2">
-            <span v-if="!isValidLabel">Label must be {{ minLabelLength }} or more characters.</span>
-            <span v-if="isLabelReserved">Sorry, the label '{{ trim(topic) }}' is assigned to an existing topic.</span>
-          </div>
-          <div class="text-grey font-size-14 pl-2 pt-2">
-            <span v-if="!isLabelReserved && isValidLabel" id="input-live-help">
-              {{ maxLabelLength }} character limit <span v-if="topic.length">({{ maxLabelLength - topic.length }} left)</span>
-            </span>
-          </div>
-        </v-card-text>
-        <hr />
-        <v-card-actions class="modal-footer">
-          <ProgressButton
-            id="topic-save"
-            :action="save"
-            :disabled="disableSaveButton"
-            :in-progress="isSaving"
-            :text="isSaving ? 'Saving' : 'Save'"
-          />
-          <v-btn
-            id="cancel"
-            class="ml-2"
-            :disabled="isSaving"
-            variant="text"
-            @click.stop="cancel"
-          >
-            Cancel
-          </v-btn>
-        </v-card-actions>
-      </form>
+              Cancel
+            </v-btn>
+          </v-card-actions>
+        </form>
+      </FocusLock>
     </v-card>
   </v-dialog>
 </template>

--- a/src/components/topics/ManageTopics.vue
+++ b/src/components/topics/ManageTopics.vue
@@ -22,7 +22,7 @@
         Clear
       </v-btn>
       <v-btn
-        id="new-note-button"
+        id="create-topic-button"
         class="mr-3"
         color="primary"
         :disabled="isEditTopicModalOpen"
@@ -229,6 +229,7 @@ export default {
       } else {
         this.refresh(focusTarget)
         alertScreenReader(`Topic '${topic.topic}' created.`)
+        putFocusNextTick('create-topic-button')
       }
       this.topicEdit = null
       this.isEditTopicModalOpen = false
@@ -334,10 +335,3 @@ export default {
   }
 }
 </script>
-
-
-<style scoped>
-#new-note-button {
-  margin-left: auto;
-}
-</style>

--- a/src/components/util/AreYouSureModal.vue
+++ b/src/components/util/AreYouSureModal.vue
@@ -6,30 +6,33 @@
     persistent
   >
     <v-card class="modal-content" min-width="600">
-      <v-card-title>
-        <ModalHeader header-id="are-you-sure-header" :text="modalHeader" />
-      </v-card-title>
-      <v-card-text id="are-you-sure-text" class="modal-body">
-        <span v-html="text" />
-        <slot />
-      </v-card-text>
-      <v-card-actions class="modal-footer">
-        <ProgressButton
-          id="are-you-sure-confirm"
-          :action="confirm"
-          :disabled="isProcessing"
-          :in-progress="isProcessing"
-          :text="buttonLabelConfirm"
-        />
-        <v-btn
-          v-if="functionCancel"
-          id="are-you-sure-cancel"
-          :disabled="isProcessing"
-          :text="buttonLabelCancel"
-          variant="text"
-          @click="functionCancel"
-        />
-      </v-card-actions>
+      <FocusLock :disabled="!focusLocked">
+        <v-card-title>
+          <ModalHeader header-id="are-you-sure-header" :text="modalHeader" />
+        </v-card-title>
+        <v-card-text id="are-you-sure-text" class="modal-body">
+          <span v-html="text" />
+          <slot />
+        </v-card-text>
+        <v-card-actions class="modal-footer">
+          <ProgressButton
+            id="are-you-sure-confirm"
+            :action="confirm"
+            :disabled="isProcessing"
+            :in-progress="isProcessing"
+            :text="buttonLabelConfirm"
+          />
+          <v-btn
+            v-if="functionCancel"
+            id="are-you-sure-cancel"
+            class="ml-2"
+            :disabled="isProcessing"
+            :text="buttonLabelCancel"
+            variant="text"
+            @click="functionCancel"
+          />
+        </v-card-actions>
+      </FocusLock>
     </v-card>
   </v-dialog>
 </template>
@@ -73,11 +76,13 @@ const props = defineProps({
 })
 let isProcessing = ref(false)
 
+const focusLocked = ref(false)
 // eslint-disable-next-line vue/require-prop-types
 const model = defineModel()
 
 watch(model, isOpen => {
   if (isOpen) {
+    setTimeout(() => focusLocked.value = isOpen, 500)
     putFocusNextTick('are-you-sure-confirm')
   }
 })

--- a/src/components/util/ExportListModal.vue
+++ b/src/components/util/ExportListModal.vue
@@ -12,67 +12,69 @@
       min-width="500"
       max-width="800"
     >
-      <v-card-title>
-        <ModalHeader text="Export List" />
-      </v-card-title>
-      <v-card-text id="export-list-body" class="modal-body">
-        <div
-          id="csv-column-options"
-          aria-label="Select columns to export"
-          class="d-flex flex-column flex-wrap csv-column-options pb-5 px-1"
-          name="csv-column-options"
-          role="group"
-        >
-          <template v-for="(option, index) in csvColumns" :key="index">
-            <v-checkbox
-              :id="`csv-column-options-${index}`"
-              :model-value="includes(selected, option.value)"
-              :aria-label="`${option.text} column included in export`"
-              class="csv-column-option"
-              color="primary"
-              density="compact"
-              :disabled="isExporting"
-              hide-details
-              :label="option.text"
-              @update:model-value="isChecked => onChange(option.value, isChecked)"
+      <FocusLock>
+        <v-card-title>
+          <ModalHeader text="Export List" />
+        </v-card-title>
+        <v-card-text id="export-list-body" class="modal-body">
+          <div
+            id="csv-column-options"
+            aria-label="Select columns to export"
+            class="d-flex flex-column flex-wrap csv-column-options pb-5 px-1"
+            name="csv-column-options"
+            role="group"
+          >
+            <template v-for="(option, index) in csvColumns" :key="index">
+              <v-checkbox
+                :id="`csv-column-options-${index}`"
+                :model-value="includes(selected, option.value)"
+                :aria-label="`${option.text} column included in export`"
+                class="csv-column-option"
+                color="primary"
+                density="compact"
+                :disabled="isExporting"
+                hide-details
+                :label="option.text"
+                @update:model-value="isChecked => onChange(option.value, isChecked)"
+              />
+            </template>
+          </div>
+          <div>
+            <span class="font-weight-bold">Reminder:</span> <FerpaReminder />
+          </div>
+        </v-card-text>
+        <hr />
+        <v-card-actions class="modal-footer flex-column">
+          <v-alert
+            v-if="error && !isExporting"
+            aria-live="polite"
+            class="font-size-15 w-100 mb-3"
+            color="error"
+            density="compact"
+            :icon="mdiAlert"
+            :text="error"
+            title="Error"
+            variant="tonal"
+          />
+          <div class="d-flex justify-end w-100">
+            <ProgressButton
+              id="export-list-confirm"
+              :action="onSubmit"
+              :disabled="!selected.length || error || isExporting"
+              :in-progress="isExporting"
+              :text="isExporting ? 'Exporting' : 'Export'"
             />
-          </template>
-        </div>
-        <div>
-          <span class="font-weight-bold">Reminder:</span> <FerpaReminder />
-        </div>
-      </v-card-text>
-      <hr />
-      <v-card-actions class="modal-footer flex-column">
-        <v-alert
-          v-if="error && !isExporting"
-          aria-live="polite"
-          class="font-size-15 w-100 mb-3"
-          color="error"
-          density="compact"
-          :icon="mdiAlert"
-          :text="error"
-          title="Error"
-          variant="tonal"
-        />
-        <div class="d-flex justify-end w-100">
-          <ProgressButton
-            id="export-list-confirm"
-            :action="onSubmit"
-            :disabled="!selected.length || error || isExporting"
-            :in-progress="isExporting"
-            :text="isExporting ? 'Exporting' : 'Export'"
-          />
-          <v-btn
-            id="export-list-cancel"
-            class="ml-2"
-            :disabled="isExporting"
-            text="Close"
-            variant="text"
-            @click="cancel"
-          />
-        </div>
-      </v-card-actions>
+            <v-btn
+              id="export-list-cancel"
+              class="ml-2"
+              :disabled="isExporting"
+              text="Close"
+              variant="text"
+              @click="cancel"
+            />
+          </div>
+        </v-card-actions>
+      </FocusLock>
     </v-card>
   </v-dialog>
 </template>

--- a/src/components/util/FerpaReminderModal.vue
+++ b/src/components/util/FerpaReminderModal.vue
@@ -10,30 +10,32 @@
       min-width="400"
       max-width="600"
     >
-      <v-card-title>
-        <ModalHeader text="FERPA Reminder" />
-      </v-card-title>
-      <v-card-text id="ferpa-reminder-text" class="modal-body">
-        <FerpaReminder />
-      </v-card-text>
-      <v-card-actions class="modal-footer">
-        <ProgressButton
-          id="are-you-sure-confirm"
-          :action="confirm"
-          :disabled="isDownloading"
-          :in-progress="isDownloading"
-          text="I understand"
-        />
-        <v-btn
-          id="ferpa-reminder-cancel"
-          class="ml-2"
-          :disabled="isDownloading"
-          variant="text"
-          @click="cancel"
-        >
-          Cancel
-        </v-btn>
-      </v-card-actions>
+      <FocusLock>
+        <v-card-title>
+          <ModalHeader text="FERPA Reminder" />
+        </v-card-title>
+        <v-card-text id="ferpa-reminder-text" class="modal-body">
+          <FerpaReminder />
+        </v-card-text>
+        <v-card-actions class="modal-footer">
+          <ProgressButton
+            id="are-you-sure-confirm"
+            :action="confirm"
+            :disabled="isDownloading"
+            :in-progress="isDownloading"
+            text="I understand"
+          />
+          <v-btn
+            id="ferpa-reminder-cancel"
+            class="ml-2"
+            :disabled="isDownloading"
+            variant="text"
+            @click="cancel"
+          >
+            Cancel
+          </v-btn>
+        </v-card-actions>
+      </FocusLock>
     </v-card>
   </v-dialog>
 </template>

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -102,6 +102,9 @@ export default createVuetify({
   defaults: {
     VBtn: {
       style: 'text-transform: none;',
+    },
+    VMenu: {
+      attach: true
     }
   },
   directives: {

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,6 +1,7 @@
 import './main.scss'
 import {aliases, mdi} from 'vuetify/iconsets/mdi-svg'
 import {createVuetify} from 'vuetify'
+import FocusLock from 'vue-focus-lock'
 import {Intersect, Resize} from 'vuetify/directives'
 import {VAlert} from 'vuetify/components/VAlert'
 import {VAppBar, VAppBarNavIcon, VAppBarTitle} from 'vuetify/components/VAppBar'
@@ -43,6 +44,7 @@ import colors from 'vuetify/lib/util/colors'
 
 export default createVuetify({
   components: {
+    FocusLock,
     VApp,
     VAppBar,
     VAppBarNavIcon,

--- a/src/stores/note-edit-session/utils.ts
+++ b/src/stores/note-edit-session/utils.ts
@@ -2,17 +2,16 @@ import {alertScreenReader} from '@/lib/utils'
 import {get, isString, map, trim} from 'lodash'
 import {deleteNote, removeAttachment, updateNote} from '@/api/notes'
 import {getDistinctSids} from '@/api/student'
-import {nextTick} from 'vue'
 import {NoteEditSessionModel, NoteRecipients} from '@/stores/note-edit-session/index'
 import {useContextStore} from '@/stores/context'
 import {useNoteStore} from '@/stores/note-edit-session'
 
 export function disableFocusLock(): void {
-  nextTick(() => useNoteStore().setFocusLockDisabled(true))
+  useNoteStore().setFocusLockDisabled(true)
 }
 
 export function enableFocusLock(): void {
-  nextTick(() => useNoteStore().setFocusLockDisabled(true))
+  setTimeout(() => useNoteStore().setFocusLockDisabled(false), 500)
 }
 
 export function exitSession(revert: boolean): Promise<NoteEditSessionModel | undefined> {

--- a/src/views/degree/ManageDegreeChecks.vue
+++ b/src/views/degree/ManageDegreeChecks.vue
@@ -194,7 +194,7 @@
                   variant="text"
                   width="70"
                   @click="showDeleteModal(item)"
-                  @keydown.enter="showDeleteModal(item)"
+                  @keydown.enter.prevent="showDeleteModal(item)"
                 >
                   Delete<span class="sr-only"> {{ item.name }}</span>
                 </v-btn>
@@ -210,7 +210,6 @@
       :function-cancel="deleteCanceled"
       :function-confirm="deleteConfirmed"
       modal-header="Delete Degree"
-      :show-modal="!!templateForDelete"
       :text="deleteModalBody"
     />
     <CloneTemplateModal


### PR DESCRIPTION
Wraps the content of each modal with `<FocusLock>` (review with &w=1 for best results).

I skipped adding this to AdvancedSearchModal for now because it breaks the `<v-date-input>` datepicker. Vuetify's datepicker opens an overlay outside of the `<FocusLock>` and doesn't provide programmatic access to it. Still looking for a workaround. 