### PR TITLE
BOAC-5524: keeps date input calendar within its container

### DIFF
--- a/src/components/note/BatchNoteAddStudent.vue
+++ b/src/components/note/BatchNoteAddStudent.vue
@@ -28,7 +28,7 @@
         item-value="sid"
         :items="autoSuggestedStudents"
         :menu-icon="null"
-        :menu-props="{'attach': false}"
+        :menu-props="{'attach': false, 'location': 'bottom'}"
         type="search"
         validate-on="submit"
         variant="outlined"

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -81,6 +81,7 @@
           v-if="noteStore.model.isDraft"
           id="update-draft-note-button"
           :action="() => save(true)"
+          class="ml-2"
           :disabled="isSaving || boaSessionExpired"
           :in-progress="isSavingDraft"
           text="Update Draft"
@@ -88,6 +89,7 @@
         />
         <v-btn
           id="cancel-edit-note-button"
+          class="ml-2"
           color="primary"
           :disabled="isSaving || boaSessionExpired"
           slim

--- a/src/components/note/ManuallySetDate.vue
+++ b/src/components/note/ManuallySetDate.vue
@@ -19,6 +19,7 @@
         :disabled="isSaving || boaSessionExpired"
         hide-actions
         hide-details
+        location="top end"
         :max="new Date()"
         :model-value="model.setDate ? DateTime.fromFormat(model.setDate, 'yyyy-MM-dd').toJSDate() : null"
         placeholder="MM/DD/YYYY"
@@ -49,5 +50,7 @@ const onUpdateModel = d => {
 .date-input-container {
   margin-top: 8px;
   max-width: 160px;
+  position: relative;
+  z-index: 100;
 }
 </style>

--- a/src/components/search/AdvancedSearch.vue
+++ b/src/components/search/AdvancedSearch.vue
@@ -25,7 +25,7 @@
           :items="searchStore.searchHistory"
           :menu="searchStore.isFocusOnSearch"
           :menu-icon="null"
-          :menu-props="{'attach': false}"
+          :menu-props="{'attach': false, 'location': 'bottom'}"
           placeholder="/ to search"
           type="search"
           variant="outlined"

--- a/src/components/search/AdvancedSearchModal.vue
+++ b/src/components/search/AdvancedSearchModal.vue
@@ -49,7 +49,7 @@
               hide-no-data
               :items="searchStore.searchHistory"
               :menu-icon="null"
-              :menu-props="{'attach': false}"
+              :menu-props="{'attach': false, 'location': 'bottom'}"
               placeholder="Search"
               type="search"
               variant="outlined"

--- a/src/components/util/Autocomplete.vue
+++ b/src/components/util/Autocomplete.vue
@@ -20,7 +20,7 @@
       :label="placeholder"
       :maxlength="maxlength"
       :menu-icon="null"
-      :menu-props="{'attach': false}"
+      :menu-props="{'attach': false, 'location': 'bottom'}"
       variant="outlined"
       no-data-text="No Users Found"
       @click:clear="onClear"

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -104,7 +104,8 @@ export default createVuetify({
       style: 'text-transform: none;',
     },
     VMenu: {
-      attach: true
+      attach: true,
+      location: 'top'
     }
   },
   directives: {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5524

I couldn't figure out a way to keep the datepicker menu from being partially hidden when it overlaps the boundary of the modal, so instead I changed its position to prevent that overlap.