### PR TITLE
BOAC-5546, /draft_notes: deleted attachments are not attachments

### DIFF
--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -129,7 +129,7 @@ class Note(Base):
         sql = f"""
             SELECT n.*, count(a.note_id) as attachment_count
             FROM notes n
-            LEFT JOIN note_attachments a ON n.id = a.note_id
+            LEFT JOIN note_attachments a ON n.id = a.note_id AND a.deleted_at IS NULL
             WHERE
                 n.is_draft IS TRUE
                 AND n.deleted_at IS NULL


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5546

List view was indicating deleted attachments as available attachments.