### PR TITLE
BOAC-5564: fixes VMenu overlay in Safari

### DIFF
--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -103,10 +103,6 @@ export default createVuetify({
     VBtn: {
       style: 'text-transform: none;',
     },
-    VMenu: {
-      attach: true,
-      location: 'top'
-    },
     VTextField: {
       density: 'compact',
       variant: 'outlined'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5564

We no longer need to set these global VMenu configs because we aren't using VDateInput. 