### PR TITLE
BOAC-5560, minor fixes: alert pill styles; z-index in pax icons

### DIFF
--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -610,7 +610,7 @@ const usersProvider = () => {
   left: 12px;
   font-size: 22px;
   color: red;
-  z-index: 10000;
+  z-index: 100;
 }
 .advising-data {
   position: relative;

--- a/src/components/search/AdvancedSearch.vue
+++ b/src/components/search/AdvancedSearch.vue
@@ -56,7 +56,6 @@
               searchStore.queryText = item.value
               search()
             }"
-            @focusin="() => searchStore.setIsFocusOnSearch(true)"
           >
             {{ item.value }}
           </v-list-item>

--- a/src/components/search/SortableStudents.vue
+++ b/src/components/search/SortableStudents.vue
@@ -120,7 +120,6 @@
       <PillAlert
         :aria-label="`${item.alertCount || 'No'} alerts for ${item.firstName} ${item.lastName}`"
         :color="item.alertCount ? 'warning' : 'grey'"
-        outlined
       >
         {{ item.alertCount || 0 }} <span class="sr-only">alerts</span>
       </PillAlert>

--- a/src/components/util/PillAlert.vue
+++ b/src/components/util/PillAlert.vue
@@ -1,7 +1,7 @@
 <template>
   <v-chip
     :aria-label="ariaLabel"
-    class="pill-alert"
+    class="border-sm pill-alert"
     :class="{'pill-color-override': outlined}"
     :color="color"
     density="comfortable"


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5560
https://jira-secure.berkeley.edu/browse/BOAC-5565

And remove `focusin` action on search-history dropdown cuz Anne fixed the keyboard nav of `v-autocomplete`.