### PR TITLE
[QA] BOAC-5172 Guard Nessie against horrendously long queries on admit names also

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -1485,6 +1485,9 @@ def get_admitted_students_query(
                         AND n{i}.sid = sa.cs_empl_id"""
                 word = ''.join(re.split(r'\W', word))
                 query_bindings.update({f'name_phrase_{i}': f'{word}%'})
+                # Some students in BOA have as many as seven distinct words in their name, but for sanity's sake, stop counting at ten.
+                if i > 9:
+                    break
     return query_tables, query_filter, query_bindings
 
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5172

Follow-up to #4331.