### PR TITLE
BOAC-5607, python null should not put 'None' in service announcement text

### DIFF
--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -101,9 +101,7 @@ def process_input_from_rich_text_editor(rich_text):
         parsed = linkify(parsed, {'target': '_blank'})
         for placeholder, match in exclude_from_parse.items():
             parsed = parsed.replace(placeholder, match, 1)
-        return parsed
-    else:
-        return None
+    return parsed or ''
 
 
 def remove_none_values(_dict):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5607
