### PR TITLE
BOAC-5607, a better fix for 'None' landing in service announcement

### DIFF
--- a/boac/api/config_controller.py
+++ b/boac/api/config_controller.py
@@ -103,7 +103,7 @@ def get_service_announcement():
 @admin_required
 def update_service_announcement():
     params = request.get_json()
-    text = process_input_from_rich_text_editor(params.get('text', ''))
+    text = process_input_from_rich_text_editor(params.get('text')) or ''
     if not text and _is_service_announcement_published():
         raise BadRequestError('If the service announcement is published then API requires \'text\'')
     ToolSetting.upsert('SERVICE_ANNOUNCEMENT_TEXT', text)

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -101,7 +101,7 @@ def process_input_from_rich_text_editor(rich_text):
         parsed = linkify(parsed, {'target': '_blank'})
         for placeholder, match in exclude_from_parse.items():
             parsed = parsed.replace(placeholder, match, 1)
-    return parsed or ''
+    return parsed
 
 
 def remove_none_values(_dict):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5607

Logic at controller level.