### PR TITLE
BOAC-5613, /student: after note edit, smoothly scroll to expanded note

### DIFF
--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -36,7 +36,7 @@
               hide-details
               :hide-no-data="!!(size(autocompleteInput) < 3 || isFetching || isSuggesting || suggestedUsers.length)"
               :items="suggestedUsers"
-              label="Enter name or SID..."
+              label="Enter name or UID"
               :maxlength="72"
               :menu-icon="null"
               :model-value="userSelection"
@@ -49,9 +49,9 @@
               <template #append-inner>
                 <v-progress-circular
                   v-if="isSuggesting"
-                  color="pale-blue"
+                  color="primary"
                   indeterminate
-                  :size="16"
+                  :size="18"
                   :width="3"
                 />
               </template>

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -23,7 +23,7 @@
 <script setup>
 import AcademicTimelineHeader from '@/components/student/profile/AcademicTimelineHeader'
 import AcademicTimelineTable from '@/components/student/profile/AcademicTimelineTable'
-import {get, each, findIndex, keys, remove, size} from 'lodash'
+import {get, each, findIndex, keys, remove, size, find} from 'lodash'
 import {getNote} from '@/api/notes'
 import {DateTime} from 'luxon'
 import {onUnmounted, reactive, ref} from 'vue'
@@ -79,13 +79,14 @@ const init = () => {
 
 const onCreateNewNote = note => {
   if (note.sid === props.student.sid) {
-    const existingNoteIndex = findIndex(messages.value, {'id': note.id})
-    note.transientId = note.id
-    if (existingNoteIndex < 0) {
+    const message = find(messages.value, ['id', note.id])
+    note.transientId = message ? message.transientId : note.id
+    if (message) {
+      const existingNoteIndex = findIndex(messages.value, {'id': note.id})
+      messages.value.splice(existingNoteIndex, 1, note)
+    } else {
       messages.value.push(note)
       updateCountsPerType('note', countsPerType.value.note + 1)
-    } else {
-      messages.value.splice(existingNoteIndex, 1, note)
     }
     sortMessages()
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -96,7 +96,7 @@ export function putFocusNextTick(id: string, cssSelector?: string) {
     const putFocus = setInterval(() => {
       let el = document.getElementById(id)
       el = el && cssSelector ? el.querySelector(cssSelector) : el
-      el && el.focus()
+      el && el.scrollIntoView({behavior: 'smooth', block: 'center'})
       if (el || ++counter > 5) {
         // Abort after success or three attempts
         clearInterval(putFocus)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5613

* `putFocusNextTick` now uses smooth-scroll
* EditNote component uses `onMounted` instead of inline `init()`
* In `AcademicTimelineTable`, the event-handlers do the job of refreshing timeline after edit or create note. Some of the component callback logic was redundant.