### PR TITLE
boac-5597 - Expanded BOA note title and body don't wrap when viewed in timeline

### DIFF
--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -1,8 +1,8 @@
 <template>
-  <div :id="`note-${note.id}-outer`" class="advising-note-outer w-100">
+  <div :id="`note-${note.id}-outer`" class="advising-note-outer width-90">
     <div
       :id="`note-${note.id}-is-closed`"
-      class="truncate-with-ellipsis w-100"
+      class="w-100"
       :class="{'note-snippet-when-closed': !isOpen}"
       aria-label="Advising note"
     >
@@ -318,6 +318,9 @@ loadAuthorDetails()
 }
 .open-note-message-container {
   overflow-wrap: break-word;
+}
+.width-90 {
+  width: 90%;
 }
 .note-attachments-container {
   width: 90%;


### PR DESCRIPTION
Jira: https://jira-secure.berkeley.edu/browse/BOAC-5597