### PR TITLE
BOAC-3809: fixes acad timeline accessibility bugs, labels student page regions

### DIFF
--- a/src/components/appointment/AdvisingAppointment.vue
+++ b/src/components/appointment/AdvisingAppointment.vue
@@ -11,7 +11,7 @@
   </div>
   <div>
     <div class="advising-appointment-outer pb-1">
-      <div v-if="isOpen" :id="`appointment-${appointment.id}-is-open`">
+      <div v-if="isOpen" :id="`appointment-${appointment.id}-is-open`" class="pb-3">
         <div v-if="appointment.appointmentTitle">
           <span :id="`appointment-${appointment.id}-title`" v-html="appointment.appointmentTitle" />
         </div>
@@ -39,8 +39,10 @@
             :aria-label="`Open UC Berkeley Directory page of ${advisor.name} in a new window`"
             :href="`https://www.berkeley.edu/directory/results?search-term=${advisor.name}`"
             target="_blank"
-          >{{ advisor.name }}</a>
-          <span v-if="!appointment.advisor.uid" :id="`appointment-${appointment.id}-advisor-name`">
+          >
+            {{ advisor.name }}
+          </a>
+          <span v-if="!advisor.uid" :id="`appointment-${appointment.id}-advisor-name`">
             {{ advisor.name }}
           </span>
           <span v-if="advisor.title" :id="`appointment-${appointment.id}-advisor-role`" class="text-dark">

--- a/src/components/note/AdvisingNoteAttachments.vue
+++ b/src/components/note/AdvisingNoteAttachments.vue
@@ -81,7 +81,7 @@
     </v-alert>
     <ul
       :id="`${idPrefix}attachments-list`"
-      aria-label="attachments"
+      :aria-labelledby="ariaLabelledby"
       class="list-no-bullets advising-note-pill-list mt-2"
     >
       <li
@@ -124,6 +124,10 @@ const props = defineProps({
     default: () => {},
     required: false,
     type: Function
+  },
+  ariaLabelledby: {
+    required: true,
+    type: String
   },
   disabled: {
     required: true,

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -45,6 +45,7 @@
     <ManuallySetDate class="mt-3" :disabled="isSaving || boaSessionExpired" />
     <AdvisingNoteAttachments
       v-if="size(noteStore.model.attachments)"
+      aria-labelledby="edit-note-attachments-list-label"
       class="mt-3"
       :disabled="isSaving || boaSessionExpired"
       id-prefix="edit-note-"

--- a/src/components/note/EditBatchNoteModal.vue
+++ b/src/components/note/EditBatchNoteModal.vue
@@ -66,10 +66,19 @@
             </TransitionGroup>
             <AdvisingNoteAttachments
               :add-attachments="addNoteAttachments"
+              aria-labelledby="create-note-attachments-list-label"
               class="pt-5"
               :disabled="!!(noteStore.isSaving || noteStore.boaSessionExpired)"
               :remove-attachment="removeAttachmentByIndex"
-            />
+            >
+              <template #label>
+                <label
+                  id="create-note-attachments-list-label"
+                  class="sr-only"
+                  for="attachments-list"
+                >Attachments</label>
+              </template>
+            </AdvisingNoteAttachments>
           </div>
           <v-alert
             v-if="alert"

--- a/src/components/student/profile/AcademicTimeline.vue
+++ b/src/components/student/profile/AcademicTimeline.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!isTimelineLoading">
+  <div v-if="!isTimelineLoading" aria-labelledby="student-academic-timeline-header" role="region">
     <AcademicTimelineHeader
       :counts-per-type="countsPerType"
       :filter="selectedFilter"

--- a/src/components/student/profile/AcademicTimelineHeader.vue
+++ b/src/components/student/profile/AcademicTimelineHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="align-start d-flex flex-wrap justify-space-between pb-1 w-100">
     <div>
-      <h2 class="font-size-24 font-weight-bold py-0">Academic Timeline</h2>
+      <h2 id="student-academic-timeline-header" class="font-size-24 font-weight-bold py-0">Academic Timeline</h2>
     </div>
     <div v-if="!currentUser.isAdmin && currentUser.canAccessAdvisingData" class="mt-1">
       <v-btn
@@ -24,6 +24,8 @@
   <div class="border-b-sm">
     <v-tabs
       v-model="selectedTab"
+      aria-label="timeline messages tab"
+      :aria-orientation="$vuetify.display.mdAndUp ? 'horizontal' : 'vertical'"
       class="mt-2"
       color="primary"
       density="compact"
@@ -33,6 +35,7 @@
     >
       <v-tab
         id="timeline-tab-all"
+        aria-controls="timeline-messages"
         class="border-s-sm border-t-sm"
         value="all"
         variant="tonal"

--- a/src/components/student/profile/StudentClasses.vue
+++ b/src/components/student/profile/StudentClasses.vue
@@ -1,7 +1,7 @@
 <template>
-  <div id="student-terms-container">
+  <div id="student-terms-container" aria-labelledby="student-classes-header" role="region">
     <div class="align-center d-flex">
-      <h2 class="student-section-header">Classes</h2>
+      <h2 id="student-classes-header" class="student-section-header">Classes</h2>
       <div>
         <v-btn
           v-if="enrollmentTermsByYear.length > 1"

--- a/src/components/student/profile/StudentProfileHeader.vue
+++ b/src/components/student/profile/StudentProfileHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-flex flex-wrap mr-4 pb-2 pt-4">
+  <div aria-labelledby="student-name-header student-name-header-sr" class="d-flex flex-wrap mr-4 pb-2 pt-4" role="region">
     <div class="d-flex ml-3 me-auto">
       <div class="text-center" :class="{'column-with-avatar-compact': compact, 'column-with-avatar': !compact}">
         <StudentAvatar :size="compact ? 'medium' : 'large'" :student="student" />
@@ -43,8 +43,6 @@ import StudentPersonalDetails from '@/components/student/profile/StudentPersonal
 import StudentProfileHeaderAcademics from '@/components/student/profile/StudentProfileHeaderAcademics'
 import StudentProfileHeaderBio from '@/components/student/profile/StudentProfileHeaderBio'
 import {compact as _compact, map, partition} from 'lodash'
-import {onMounted} from 'vue'
-import {decodeStudentUriAnchor, putFocusNextTick} from '@/lib/utils'
 
 const props = defineProps({
   compact: {
@@ -64,13 +62,6 @@ const props = defineProps({
 const plansMinorPartitionedByStatus = partition(props.student.sisProfile.plansMinor, (p) => p.status === 'Active')
 const plansPartitionedByStatus = partition(props.student.sisProfile.plans, (p) => p.status === 'Active')
 const discontinuedSubplans = _compact(map(plansPartitionedByStatus[1], 'subplan'))
-
-onMounted(() => {
-  // If custom scroll-to-note is happening then skip the putFocus below.
-  if (!decodeStudentUriAnchor()) {
-    putFocusNextTick('student-name-header')
-  }
-})
 </script>
 
 <style>

--- a/src/components/student/profile/StudentProfileHeaderBio.vue
+++ b/src/components/student/profile/StudentProfileHeaderBio.vue
@@ -20,7 +20,7 @@
         class="mb-1 student-section-header"
         v-html="student.name"
       />
-      <h2 class="sr-only">Profile</h2>
+      <h2 id="student-name-header-sr" class="sr-only">Profile</h2>
       <div
         v-if="student.sisProfile.preferredName !== student.name"
         id="student-preferred-name"

--- a/src/components/util/PillItem.vue
+++ b/src/components/util/PillItem.vue
@@ -31,6 +31,8 @@
 <script setup>
 import {mdiCloseCircle} from '@mdi/js'
 
+defineEmits(['close-clicked'])
+
 defineProps({
   ariaLabel: {
     default: undefined,

--- a/src/views/Student.vue
+++ b/src/views/Student.vue
@@ -3,8 +3,8 @@
     <div class="bg-sky-blue border-b-sm">
       <StudentProfileHeader :student="student" />
     </div>
-    <h2 class="sr-only">Academic Status</h2>
-    <div class="border-b-sm d-flex flex-wrap w-100 h-100">
+    <h2 id="student-academic-status-header" class="sr-only">Academic Status</h2>
+    <div aria-labelledby="student-academic-status-header" class="border-b-sm d-flex flex-wrap w-100 h-100" role="region">
       <div class="border-e-sm" :class="$vuetify.display.mdAndUp ? 'w-50' : 'w-100'">
         <h3 class="sr-only">Units</h3>
         <StudentProfileUnits :student="student" />
@@ -82,7 +82,7 @@ onMounted(() => {
       }
     })
     const permalink = decodeStudentUriAnchor()
-    const putFocusElementId = permalink ? `permalink-${permalink.messageType}-${permalink.messageId}` : null
+    const putFocusElementId = permalink ? `permalink-${permalink.messageType}-${permalink.messageId}` : 'student-name-header'
     // If custom scroll-to-note is happening then skip the default put-focus-on-h1.
     contextStore.loadingComplete(`${student.value.name} loaded`, putFocusElementId)
   })


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-3809

The extra, sr-only Edit and Delete buttons in timeline notes were confusing to JAWS somehow. It thought every element after those buttons was a delete button (e.g. tabbing to the advisor name link and typing Enter would bring up the delete confirm modal).

I don't think the invisible buttons are necessary anymore. JAWS can find the visible ones just fine.