### PR TITLE
BOAC-5649, fix cohort/group exports (ie, 'this' is not working)

### DIFF
--- a/src/components/degree/EditCategory.vue
+++ b/src/components/degree/EditCategory.vue
@@ -304,7 +304,11 @@ const onChangeParentCategory = option => {
     })
     putFocusNextTick(`column-${props.position}-create-requirement-btn`)
   } else {
-    each(parentUnitRequirements, unitRequirement => this.removeUnitRequirement(unitRequirement))
+    each(parentUnitRequirements, unitRequirement => {
+      const indexOf = selectedUnitRequirements.value.findIndex(u => u.id === unitRequirement.id)
+      selectedUnitRequirements.value.splice(indexOf, 1)
+      alertScreenReader(`${unitRequirement.name} removed`)
+    })
   }
 }
 

--- a/src/components/util/ExportListModal.vue
+++ b/src/components/util/ExportListModal.vue
@@ -131,8 +131,7 @@ const onChange = (value, isChecked) => {
 
 const onSubmit = () => {
   isExporting.value = true
-  this.export(selected.value).then(() => isExporting.value = false)
-
+  props.export(selected.value).then(() => isExporting.value = false)
 }
 </script>
 

--- a/src/components/util/ProgressButton.vue
+++ b/src/components/util/ProgressButton.vue
@@ -8,7 +8,7 @@
     @click.prevent="action"
   >
     <div class="align-center d-flex text-no-wrap">
-      <div v-if="inProgress" class="mr-2">
+      <div v-if="inProgress" class="ml-1 mr-2">
         <v-progress-circular indeterminate size="16" width="2" />
       </div>
       <div>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5649

There was one other errant use of `this` in `EditCategory.vue`.