### PR TITLE
BOAC-5647: suppresses null unit indicator, changes icon

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -29,7 +29,7 @@ Font Awesome to [MDI](https://pictogrammers.com/library/mdi/)
 | file-alt                                        | mdiFileOutline                             |
 | graduation-cap                                  | mdiSchool                                  |
 | grip-vertical                                   | mdiDrag                                    |
-| info-circle                                     | mdiInformationOutline                      |
+| info-circle                                     | mdiInformation                      |
 | link                                            | mdiLinkVariant                             |
 | list                                            | mdiFormatListBulleted                      |
 | long-arrow-alt-down                             | mdiArrowDownThin                           |

--- a/src/components/degree/CoursesTable.vue
+++ b/src/components/degree/CoursesTable.vue
@@ -143,7 +143,7 @@
                   :id="`units-were-edited-${bundle.course.id}`"
                   class="changed-units-icon"
                   color="accent-green"
-                  :icon="mdiInformationOutline"
+                  :icon="mdiInformation"
                   size="18"
                   :title="`Updated from ${pluralize('unit', bundle.course.sis.units)}`"
                 />
@@ -368,7 +368,7 @@ import {
   mdiCheckCircleOutline,
   mdiCircle,
   mdiContentCopy,
-  mdiInformationOutline,
+  mdiInformation,
   mdiNoteEditOutline,
   mdiTrashCan
 } from '@mdi/js'

--- a/src/components/degree/student/UnassignedCourses.vue
+++ b/src/components/degree/student/UnassignedCourses.vue
@@ -99,7 +99,7 @@
                   :id="course.manuallyCreatedBy ? `${key}-course-${course.id}-manually-created-units-edited` : `${key}-course-${course.termId}-${course.sectionId}-units-edited`"
                   class="changed-units-icon mb-1"
                   color="accent-green"
-                  :icon="mdiInformationOutline"
+                  :icon="mdiInformation"
                   size="18"
                   :title="`Updated from ${pluralize('unit', course.sis.units)}`"
                 />
@@ -222,7 +222,7 @@ import {
   mdiAlert,
   mdiCheckCircleOutline,
   mdiContentCopy,
-  mdiInformationOutline,
+  mdiInformation,
   mdiNoteEditOutline,
   mdiTrashCan
 } from '@mdi/js'

--- a/src/components/student/IncompleteGradeAlertIcon.vue
+++ b/src/components/student/IncompleteGradeAlertIcon.vue
@@ -3,14 +3,14 @@
     :id="`term-${termId}-course-${index}-has-incomplete-status`"
     :aria-label="ariaLabel"
     color="error"
-    :icon="mdiInformationOutline"
+    :icon="mdiInformation"
     :title="ariaLabel"
   />
 </template>
 
 <script setup>
 import {getIncompleteGradeDescription, getSectionsWithIncompleteStatus} from '@/berkeley'
-import {mdiInformationOutline} from '@mdi/js'
+import {mdiInformation} from '@mdi/js'
 
 const props = defineProps({
   course: {

--- a/src/lib/degree-progress.ts
+++ b/src/lib/degree-progress.ts
@@ -69,7 +69,7 @@ export function isValidUnits(value, maxAllowed): boolean {
 }
 
 export function unitsWereEdited(course: any): boolean {
-  return !get(course, 'manuallyCreatedBy') && !!get(course, 'units') && (course.units !== course.sis.units)
+  return !get(course, 'manuallyCreatedBy') && !isNil(get(course, 'units')) && !isNil(get(course, 'sis.units')) && (course.units !== course.sis.units)
 }
 export function validateUnitRange(unitsLower, unitsUpper, maxAllowed, showUnitsUpperInput?: boolean): any {
   const invalid = message => ({valid: false, message})


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5647

The `information` icon is closer to the original version and looks better, IMO.