### PR TITLE
BOAC-5703: fixes broken service alert ref (and other refs)

### DIFF
--- a/src/components/degree/SelectUnitFulfillment.vue
+++ b/src/components/degree/SelectUnitFulfillment.vue
@@ -19,7 +19,7 @@
         {{ option.name }}
       </option>
     </select>
-    <div v-if="selected.length" class="w-100">
+    <div v-if="size(selected)" class="w-100">
       <label
         :for="`column-${position}-unit-requirement-list`"
         class="sr-only"
@@ -62,7 +62,7 @@
 
 <script setup>
 import {alertScreenReader, putFocusNextTick} from '@/lib/utils'
-import {cloneDeep, includes, map, remove, size} from 'lodash'
+import {includes, map, remove, size} from 'lodash'
 import {mdiCloseCircleOutline} from '@mdi/js'
 import {ref, watch} from 'vue'
 import {useDegreeStore} from '@/stores/degree-edit-session/index'
@@ -79,33 +79,31 @@ const props = defineProps({
     required: false,
     type: Array
   },
-  onUnitRequirementsChange: {
-    required: true,
-    type: Function
-  },
   position: {
     required: true,
     type: Number
   }
 })
 
-const model = ref(null)
-const selected = ref(cloneDeep(props.initialUnitRequirements))
+const model = ref()
+const selected = ref(props.initialUnitRequirements)
 
 watch(model, () => {
   if (model.value) {
-    alertScreenReader(`${model.value.name} selected`)
     selected.value.push(model.value)
-    props.onUnitRequirementsChange(selected.value)
-    model.value = null
+    alertScreenReader(`${model.value.name} selected`)
   }
+})
+
+watch(() => props.initialUnitRequirements, value => {
+  selected.value = value
+  alertScreenReader('Requirement Fulfillments updated.')
 })
 
 const removeUnitRequirement = (item, index) => {
   const lastItemIndex = size(selected.value) - 1
   alertScreenReader(`${item.name} removed`)
   selected.value = remove(selected.value, selected => selected.id !== item.id)
-  props.onUnitRequirementsChange(selected.value)
   if (lastItemIndex > 0) {
     const nextFocusIndex = (index === lastItemIndex ) ? index - 1 : index
     putFocusNextTick(`column-${props.position}-unit-requirement-remove-${nextFocusIndex}`)

--- a/src/components/util/PillItem.vue
+++ b/src/components/util/PillItem.vue
@@ -22,7 +22,7 @@
         :icon="mdiCloseCircle"
         title="Remove"
         variant="text"
-        @click.stop.prevent="$emit('close-clicked')"
+        @click.stop.prevent="emit('closeClicked')"
       />
     </template>
   </v-chip>
@@ -31,7 +31,7 @@
 <script setup>
 import {mdiCloseCircle} from '@mdi/js'
 
-defineEmits('close-clicked')
+const emit = defineEmits(['closeClicked'])
 
 defineProps({
   ariaLabel: {

--- a/src/layouts/StandardLayout.vue
+++ b/src/layouts/StandardLayout.vue
@@ -98,7 +98,7 @@ import SidebarFooter from '@/components/sidebar/SidebarFooter.vue'
 import PlaneGoRound from '@/layouts/shared/PlaneGoRound.vue'
 import ServiceAnnouncement from '@/layouts/shared/ServiceAnnouncement'
 import Sidebar from '@/components/sidebar/Sidebar'
-import {onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {onBeforeUnmount, onMounted, ref, useTemplateRef, watch} from 'vue'
 import {get, split} from 'lodash'
 import {putFocusNextTick, scrollTo} from '@/lib/utils'
 import {storeToRefs} from 'pinia'
@@ -111,7 +111,7 @@ const hideFooter = ref(false)
 const {currentUser, loading} = storeToRefs(contextStore)
 const noteStore = useNoteStore()
 const route = useRoute()
-const serviceAlert = ref(null)
+const serviceAlert = useTemplateRef('serviceAlert')
 const serviceAlertOffset = ref(0)
 const showSidebar = ref(true)
 
@@ -141,7 +141,7 @@ const setHideFooter = value => hideFooter.value = value
 const setServiceAlertOffset = () => {
   let counter = 0
   const setOffset = setInterval(() => {
-    const height = get(serviceAlert.value, '$el.clientHeight')
+    const height = get(serviceAlert.value.ref, 'clientHeight')
     if (height) {
       serviceAlertOffset.value = `${height}px`
     }

--- a/src/layouts/shared/ServiceAnnouncement.vue
+++ b/src/layouts/shared/ServiceAnnouncement.vue
@@ -2,6 +2,7 @@
   <h2 v-if="announcement && announcement.isPublished" id="service-announcement-label" class="sr-only">BOA Service Alert</h2>
   <div
     v-if="announcement && announcement.isPublished"
+    ref="serviceAlert"
     aria-labelledby="service-announcement-label"
   >
     <v-expand-transition>
@@ -39,9 +40,13 @@ import {alertScreenReader, putFocusNextTick} from '@/lib/utils'
 import {mdiClose} from '@mdi/js'
 import {storeToRefs} from 'pinia'
 import {useContextStore} from '@/stores/context'
+import {useTemplateRef} from 'vue'
 
 const contextStore = useContextStore()
 const {announcement, dismissedServiceAnnouncement} = storeToRefs(contextStore)
+const serviceAlertRef = useTemplateRef('serviceAlert')
+
+defineExpose({ref: serviceAlertRef})
 
 const toggle = () => {
   if (dismissedServiceAnnouncement.value) {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5703

We recently upgraded from Vue 3.x to 3.5 and the new version has some different syntax for refs: https://vuejs.org/api/composition-api-helpers.html#usetemplateref