### PR TITLE
BOAC-5839 / BOAC-5814, vue-publish-lock problematic in Safari when editing note

### DIFF
--- a/src/components/note/EditBatchNoteModal.vue
+++ b/src/components/note/EditBatchNoteModal.vue
@@ -13,7 +13,7 @@
       width="800"
       max-width="90%"
     >
-      <FocusLock :disabled="noteStore.isFocusLockDisabled">
+      <div>
         <CreateNoteHeader :exit="discardRequested" />
         <v-card-text class="modal-body">
           <Transition
@@ -118,7 +118,7 @@
           :show-alert="showAlert"
           :update-template="updateTemplate"
         />
-      </FocusLock>
+      </div>
     </v-card>
   </v-dialog>
   <AreYouSureModal
@@ -150,7 +150,6 @@ import ContactMethod from '@/components/note/ContactMethod'
 import CreateNoteFooter from '@/components/note/CreateNoteFooter'
 import CreateNoteHeader from '@/components/note/CreateNoteHeader'
 import CreateTemplateModal from '@/components/note/CreateTemplateModal'
-import FocusLock from 'vue-focus-lock'
 import ManuallySetDate from '@/components/note/ManuallySetDate'
 import PrivacyPermissions from '@/components/note/PrivacyPermissions'
 import RichTextEditor from '@/components/util/RichTextEditor'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5839
https://jira-secure.berkeley.edu/browse/BOAC-5814

I'll create a new Jira to deal w/ focus (accessibility) in the edit-note dialog. 