### PR TITLE
BOAC-5834, is_peer_advisor for user_session class (incl. initial test data)

### DIFF
--- a/boac/merged/user_session.py
+++ b/boac/merged/user_session.py
@@ -113,6 +113,10 @@ class UserSession(UserMixin):
     def is_authenticated(self):
         return self.api_json['isAuthenticated']
 
+    @property
+    def is_peer_advisor(self):
+        return self.api_json['isPeerAdvisor']
+
     @classmethod
     @stow('boa_user_session_{user_id}')
     def load_user(cls, user_id):
@@ -164,20 +168,21 @@ class UserSession(UserMixin):
             **(calnet_profile or {}),
             **{
                 'id': user and user.id,
-                'automateDegreeProgressPermission': user and user.automate_degree_progress_permission,
+                'automateDegreeProgressPermission': user.automate_degree_progress_permission if user else False,
                 'canAccessAdmittedStudents': can_access_ce3_features,
-                'canAccessAdvisingData': user and user.can_access_advising_data,
-                'canAccessCanvasData': user and user.can_access_canvas_data,
+                'canAccessAdvisingData': user.can_access_advising_data if user else False,
+                'canAccessCanvasData': user.can_access_canvas_data if user else False,
                 'canAccessPrivateNotes': can_access_ce3_features,
                 'canEditDegreeProgress': degree_progress_permission == 'read_write',
                 'canReadDegreeProgress': degree_progress_permission in ['read', 'read_write'],
                 'degreeProgressPermission': degree_progress_permission,
                 'departments': departments,
-                'inDemoMode': user and user.in_demo_mode,
+                'inDemoMode': user.in_demo_mode if user else False,
                 'isActive': is_active,
                 'isAdmin': is_admin,
                 'isAnonymous': not is_active,
                 'isAuthenticated': is_active,
+                'isPeerAdvisor': user.is_peer_advisor if user else False,
                 'uid': user and user.uid,
             },
         }

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -154,6 +154,18 @@ _test_users = [
         'lastName': 'Mitchell',
     },
     {
+        'uid': '1133400',
+        'csid': '800700601',
+        'canAccessAdvisingData': False,
+        'canAccessCanvasData': False,
+        'degreeProgressPermission': None,
+        'isAdmin': False,
+        'isPeerAdvisor': True,
+        'inDemoMode': False,
+        'firstName': 'Peer',
+        'lastName': 'Pressure',
+    },
+    {
         'uid': '211159',
         'csid': '211159',
         'isAdmin': False,
@@ -296,6 +308,17 @@ _test_users = [
     },
 ]
 
+_peer_advising_depts = {
+    'COENG': {
+        'users': [
+            {
+                'uid': '1133400',
+                'role': 'peer_advisor',
+            },
+        ],
+    },
+}
+
 _university_depts = {
     'COENG': {
         'users': [
@@ -435,6 +458,7 @@ def _load_users_and_departments():
         UniversityDept.create(code, name)
     _create_users()
     _create_department_memberships()
+    _create_peer_advising_department_memberships()
 
 
 def _create_users():
@@ -474,6 +498,7 @@ def _create_users():
                 can_access_advising_data=test_user['canAccessAdvisingData'],
                 can_access_canvas_data=test_user['canAccessCanvasData'],
                 degree_progress_permission=test_user.get('degreeProgressPermission'),
+                is_peer_advisor=test_user.get('isPeerAdvisor', False),
                 search_history=test_user.get('searchHistory', []),
             )
             if test_user.get('deleted'):
@@ -498,6 +523,20 @@ def _create_department_memberships():
                 role=user['role'],
                 automate_membership=user['automate_membership'],
             )
+
+
+def _create_peer_advising_department_memberships():
+    pass
+    # TODO: Implement when BOAC-5841 is resolved.
+    # for dept_code, dept_membership in _peer_advising_depts.items():
+    #     peer_advising_dept = PeerAdvisingDept.find_by_dept_code(dept_code)
+    #     db.session.add(peer_advising_dept)
+    #     for user in dept_membership['users']:
+    #         authorized_user = AuthorizedUser.find_by_uid(user['uid'])
+    #         PeerAdvisingDeptMember.create_or_update_membership(
+    #             peer_advising_dept_id=peer_advising_dept.id,
+    #             authorized_user_id=authorized_user.id,
+    #         )
 
 
 def _create_topics():

--- a/tests/test_api/test_auth_controller.py
+++ b/tests/test_api/test_auth_controller.py
@@ -31,6 +31,7 @@ import cas
 from tests.util import override_config, pause_mock_sts
 
 advisor_uid = '1133399'
+peer_advisor_uid = '1133400'
 unauthorized_uid = '1015674'
 
 
@@ -151,6 +152,14 @@ class TestAuthorization:
         api_json = self._api_my_profile(client)
         assert api_json['isActive']
         assert len(api_json['departments']) == 1
+
+    def test_is_peer_advisor(self, client, fake_auth):
+        fake_auth.login(peer_advisor_uid)
+        api_json = self._api_my_profile(client)
+        assert api_json
+        # TODO: Verify 'isActive' after the db table 'peer_advising_department_members' is in place.
+        # assert api_json['isActive']
+        # assert api_json['isPeerAdvisor'] is True
 
 
 class TestCasAuth:

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -57,6 +57,7 @@ class TestUserProfile:
         assert not api_json['uid']
         assert api_json['canEditDegreeProgress'] is False
         assert api_json['canReadDegreeProgress'] is False
+        assert api_json['isPeerAdvisor'] is False
 
     def test_current_user_profile(self, client, fake_auth):
         """Includes user profile info from Canvas."""
@@ -69,6 +70,7 @@ class TestUserProfile:
         assert 'lastName' in api_json
         assert api_json['canEditDegreeProgress'] is True
         assert api_json['canReadDegreeProgress'] is True
+        assert api_json['isPeerAdvisor'] is False
 
     def test_can_edit_degree_progress(self, client, fake_auth):
         """Degree check permissions."""


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5834

Proper user auth can be verified (via pytest) when we have `peer_advising_department_members` wired up.