### PR TITLE
BOAC-5875, Passenger Manifest > continue the Peer Advising integration

### DIFF
--- a/boac/api/reports_controller.py
+++ b/boac/api/reports_controller.py
@@ -141,8 +141,8 @@ def available_dept_codes():
     def _to_json(row):
         dept_code = row.upper()
         return {
-            'code': dept_code,
-            'name': BERKELEY_DEPT_CODE_TO_NAME.get(dept_code),
+            'deptCode': dept_code,
+            'deptName': BERKELEY_DEPT_CODE_TO_NAME.get(dept_code),
         }
     return tolerant_jsonify([_to_json(d) for d in dept_codes])
 

--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -258,7 +258,20 @@ def download_boa_users_csv():
 @advisor_required
 def get_departments():
     exclude_empty = to_bool_or_none(util.get(request.args, 'excludeEmpty')) or False
-    return tolerant_jsonify(UniversityDept.get_all_departments(exclude_empty=exclude_empty))
+    api_json = []
+    for department in UniversityDept.get_all_departments(exclude_empty=exclude_empty):
+        dept_code = department['deptCode']
+        department_json = next((d for d in api_json if d['deptCode'] == dept_code), None)
+        if not department_json:
+            department_json = {
+                'id': department['id'],
+                'deptCode': dept_code,
+                'deptName': department['deptName'],
+                'memberCount': department['memberCount'],
+                'peerAdvisingDepartments': [],
+            }
+            api_json.append(department_json)
+    return tolerant_jsonify(api_json)
 
 
 def _get_boa_users():
@@ -297,7 +310,8 @@ def _update_or_create_authorized_user(memberships, profile, include_deleted=Fals
     can_access_advising_data = to_bool_or_none(profile.get('canAccessAdvisingData'))
     degree_progress_permission = profile.get('degreeProgressPermission')
 
-    if (automate_degree_progress_permission or degree_progress_permission) and 'COENG' not in dept_codes_where_advising({'departments': memberships}):
+    foo = dept_codes_where_advising({'departments': memberships})
+    if (automate_degree_progress_permission or degree_progress_permission) and 'COENG' not in foo:
         raise errors.BadRequestError('Degree Progress feature is only available to the College of Engineering.')
 
     is_admin = to_bool_or_none(profile.get('isAdmin'))
@@ -368,14 +382,14 @@ def _delete_existing_memberships(authorized_user):
     for m in PeerAdvisingDepartmentMember.get_peer_advising_department_memberships(authorized_user_id=authorized_user.id):
         PeerAdvisingDepartmentMember.delete_membership(
             authorized_user_id=authorized_user.id,
-            peer_advising_department_id=m.peer_advising_department_id,
+            peer_advising_department_id=m['peer_advising_department_id'],
         )
 
 
 def _describe_dept_roles(dept):
     s = ''
     if dept.get('role'):
-        s += f"{{ {dept.get('code')}: {dept['role']} (automated={dept.get('automateMembership')}) }}"
+        s += f"{{ {dept.get('deptCode')}: {dept['role']} (automated={dept.get('automateMembership')}) }}"
     return s
 
 

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -254,8 +254,8 @@ def authorized_users_api_feed(users, sort_by=None, sort_descending=False):
         })
         for m in user.department_memberships:
             profile['departments'].append({
-                'code': m.university_dept.dept_code,
-                'name': m.university_dept.dept_name,
+                'deptCode': m.university_dept.dept_code,
+                'deptName': m.university_dept.dept_name,
                 'role': m.role,
                 'automateMembership': m.automate_membership,
             })

--- a/boac/models/university_dept.py
+++ b/boac/models/university_dept.py
@@ -59,12 +59,16 @@ class UniversityDept(Base):
     @classmethod
     def get_all_departments(cls, exclude_empty=False):
         sql = f"""
-            SELECT d.id, d.dept_code, d.dept_name, COUNT(m.authorized_user_id) AS member_count
+            SELECT
+                d.id, d.dept_code, d.dept_name, COUNT(m.authorized_user_id) AS member_count,
+                p.id AS peer_advising_department_id,
+                p.name AS peer_advising_department_name
             FROM university_dept_members m
             JOIN university_depts d ON d.id = m.university_dept_id
             LEFT JOIN authorized_users u ON u.id = m.authorized_user_id
+            LEFT JOIN peer_advising_departments p ON p.university_dept_id = d.id
             WHERE u.deleted_at IS NULL
-            GROUP BY d.id, d.dept_code, d.dept_name
+            GROUP BY d.id, d.dept_code, d.dept_name, p.id, p.name
             {'HAVING COUNT(m.authorized_user_id) > 0' if exclude_empty else ''}
             ORDER BY d.dept_name
         """
@@ -72,8 +76,8 @@ class UniversityDept(Base):
         def _to_json(row):
             return {
                 'id': row['id'],
-                'code': row['dept_code'],
-                'name': row['dept_name'],
+                'deptCode': row['dept_code'],
+                'deptName': row['dept_name'],
                 'memberCount': row['member_count'],
             }
         return [_to_json(result) for result in db.session.execute(text(sql))]

--- a/src/berkeley.ts
+++ b/src/berkeley.ts
@@ -211,7 +211,7 @@ export function isAlertGrade(grade: string) {
 }
 
 export function isCoe(user: CurrentUser) {
-  return !!size(filter(user.departments, d => d.code === 'COENG' && includes(['advisor', 'director'], d.role)))
+  return !!size(filter(user.departments, d => d.deptCode === 'COENG' && includes(['advisor', 'director'], d.role)))
 }
 
 export function isDirector(user: CurrentUser) {

--- a/src/components/admin/EditUserProfileModal.vue
+++ b/src/components/admin/EditUserProfileModal.vue
@@ -117,10 +117,7 @@
                 </div>
               </div>
             </div>
-            <div
-              v-if="isCoe({departments: memberships}) || userProfile.degreeProgressPermission"
-              class="pb-3"
-            >
+            <div v-if="isCoe({departments: memberships}) || userProfile.degreeProgressPermission">
               <label class="font-weight-black" for="degree-progress-permission-select">Degree Progress Permission</label>
               <div class="mt-1">
                 <select
@@ -152,32 +149,32 @@
             <h4 class="sr-only">Departments</h4>
             <v-card
               v-for="dept in memberships"
-              :key="dept.code"
+              :key="dept.deptCode"
+              class="bg-grey-lighten-4 border-md mt-1"
               flat
-              variant="tonal"
             >
               <v-card-title class="align-center d-flex">
-                <h5 class="text-wrap font-size-16">{{ dept.name }} ({{ dept.code }})</h5>
+                <h5 class="text-wrap font-size-16">{{ dept.deptName }} ({{ dept.deptCode }})</h5>
                 <v-btn
-                  :id="`remove-department-${dept.code}`"
-                  :aria-label="`Remove department '${dept.name}'`"
-                  class="align-self-start ml-auto text-error"
+                  :id="`remove-department-${dept.deptCode}`"
+                  :aria-label="`Remove department '${dept.deptName}'`"
+                  class="align-self-start bg-grey-lighten-4 ml-auto text-error"
                   density="comfortable"
                   :icon="mdiCloseCircleOutline"
                   title="Remove"
                   variant="flat"
-                  @click="() => removeDepartment(dept.code)"
+                  @click="() => removeDepartment(dept.deptCode, dept.role)"
                 />
               </v-card-title>
               <v-card-text>
                 <div class="align-center d-flex pl-8">
-                  <label class="font-weight-black mr-2" :for="`select-department-${dept.code}-role`">Role</label>
+                  <label class="font-weight-black mr-2" :for="`select-department-${dept.deptCode}-role`">Role</label>
                   <select
-                    :id="`select-department-${dept.code}-role`"
+                    :id="`select-department-${dept.deptCode}-role`"
                     v-model="dept.role"
                     class="select-menu select-department-role"
-                    :class="{'border border-error border-opacity-100 text-error': includes(map(membershipsMissingRoles, 'code'), dept.code)}"
-                    @change="remove(membershipsMissingRoles, {'code': dept.code})"
+                    :class="{'border border-error border-opacity-100 text-error': includes(map(membershipsMissingRoles, 'deptCode'), dept.deptCode)}"
+                    @change="remove(membershipsMissingRoles, {'deptCode': dept.deptCode})"
                   >
                     <option
                       id="department-role-null"
@@ -189,7 +186,7 @@
                       v-for="option in roles"
                       :id="`department-role-${lowerCase(option.value)}`"
                       :key="option.value"
-                      :disabled="isRoleOptionDisabled(dept.code, option.value)"
+                      :disabled="isRoleOptionDisabled(dept.deptCode, option.value)"
                       :value="option.value"
                     >
                       {{ option.text }}
@@ -199,7 +196,7 @@
                 <v-expand-transition>
                   <div v-show="dept.role !== 'peer_advisor_manager'" class="pl-8 pt-1">
                     <v-checkbox
-                      :id="`is-automate-membership-${dept.code}`"
+                      :id="`is-automate-membership-${dept.deptCode}`"
                       v-model="dept.automateMembership"
                       class="automate-membership-checkbox"
                       color="primary"
@@ -327,10 +324,10 @@ const isExistingUser = computed(() => {
 
 const addDepartment = () => {
   if (deptCode.value) {
-    const dept = find(props.departments, ['code', deptCode.value])
+    const dept = find(props.departments, ['deptCode', deptCode.value])
     memberships.value.push({
-      code: dept.code,
-      name: dept.name,
+      deptCode: dept.deptCode,
+      deptName: dept.deptName,
       role: null,
       automateMembership: true
     })
@@ -359,18 +356,20 @@ const closeModal = () => {
 }
 
 const isDepartmentOptionDisabled = deptCode => {
-  const existing_roles = map(_filter(memberships.value, ['code', deptCode]), 'role')
+  const existing_roles = map(_filter(memberships.value, ['deptCode', deptCode]), 'role')
   return existing_roles.length === 2 && existing_roles.includes('peer_advisor_manager')
 }
 
 const isRoleOptionDisabled = (deptCode, role) => {
-  const existing_depts = _filter(memberships.value, ['code', deptCode])
-  const existing_roles = map(existing_depts, 'role')
   let isDisabled = false
-  if (['advisor', 'director'].includes(role)) {
-    isDisabled = existing_roles.includes('advisor') || existing_roles.includes('director')
-  } else if (role === 'peer_advisor_manager') {
-    isDisabled = existing_roles.includes('peer_advisor_manager')
+  const memberships_per_dept_code = _filter(memberships.value, ['deptCode', deptCode])
+  if (memberships_per_dept_code.length > 1) {
+    const existing_roles = map(memberships_per_dept_code, 'role')
+    if (['advisor', 'director'].includes(role)) {
+      isDisabled = existing_roles.includes('advisor') || existing_roles.includes('director')
+    } else if (role === 'peer_advisor_manager') {
+      isDisabled = existing_roles.includes('peer_advisor_manager')
+    }
   }
   return isDisabled
 }
@@ -394,8 +393,8 @@ const openEditUserModal = () => {
     if (d.role) {
       memberships.value.push({
         automateMembership: d.automateMembership,
-        code: d.code,
-        name: d.name,
+        deptCode: d.deptCode,
+        deptName: d.deptName,
         role: d.role,
       })
     }
@@ -403,25 +402,25 @@ const openEditUserModal = () => {
   each(props.profile.peerAdvisingDepartments, d => {
     memberships.value.push({
       automateMembership: d.automateMembership,
-      code: d.universityDeptCode,
-      name: d.universityDeptName,
+      deptCode: d.universityDeptCode,
+      deptName: d.universityDeptName,
       role: d.roleType,
     })
   })
   departmentOptions.value = []
   each(props.departments, d => {
     departmentOptions.value.push({
-      disabled: isDepartmentOptionDisabled(d.code),
-      text: d.name,
-      value: d.code
+      disabled: isDepartmentOptionDisabled(d.deptCode),
+      text: d.deptName,
+      value: d.deptCode
     })
   })
   showEditUserModal.value = true
   putFocusNextTick(props.profile.uid ? 'is-admin' : 'uid-input')
 }
 
-const removeDepartment = deptCode => {
-  const indexOf = memberships.value.findIndex(d => d.code === deptCode)
+const removeDepartment = (deptCode, role) => {
+  const indexOf = memberships.value.findIndex(d => d.deptCode === deptCode && d.role === role)
   const option = find(departmentOptions.value, ['value', deptCode])
   memberships.value.splice(indexOf, 1)
   option.disabled = false
@@ -434,7 +433,7 @@ const save = () => {
     errors.value.push('UID is required')
     isUidInvalid.value = true
   } if (membershipsMissingRoles.value.length) {
-    const deptNames = map(membershipsMissingRoles.value, 'name')
+    const deptNames = map(membershipsMissingRoles.value, 'deptName')
     errors.value.push(`Please specify role for ${oxfordJoin(deptNames)}`)
   }
   if (!isUidInvalid.value && !membershipsMissingRoles.value.length) {

--- a/src/components/admin/MyProfile.vue
+++ b/src/components/admin/MyProfile.vue
@@ -12,7 +12,7 @@
       <v-col>
         <span v-html="value" />
       </v-col>
-      <v-divider class="border-opacity-100"></v-divider>
+      <v-divider class="border-opacity-100" />
     </v-row>
     <v-row align-v="start" no-gutters>
       <v-col class="font-weight-bold" cols="5">
@@ -22,11 +22,11 @@
         <div v-if="currentUser.isAdmin" class="pv-3">You are a BOA Admin user.</div>
         <div v-if="!currentUser.canAccessCanvasData" class="pv-3">You do not have access to bCourses (LMS) data.</div>
         <div v-if="!currentUser.canAccessAdvisingData" class="pv-3">You do not have access to advising notes or appointments.</div>
-        <div v-for="department in currentUser.departments" :key="department.code">
-          <div id="my-dept-roles">{{ upperFirst(department.role) }} in {{ department.name }}</div>
+        <div v-for="department in currentUser.departments" :key="department.deptCode">
+          <div id="my-dept-roles">{{ upperFirst(department.role) }} in {{ department.deptName }}</div>
         </div>
       </v-col>
-      <v-divider class="border-opacity-100"></v-divider>
+      <v-divider class="border-opacity-100" />
     </v-row>
   </v-container>
 </template>
@@ -37,7 +37,7 @@ import {isCoe} from '@/berkeley'
 import {useContextStore} from '@/stores/context'
 
 const currentUser = useContextStore().currentUser
-const memberships = map(filter(currentUser.departments, 'role'), d => ({code: d.code, role: d.role}))
+const memberships = map(filter(currentUser.departments, 'role'), d => ({deptCode: d.deptCode, role: d.role}))
 const profile = {
   Name: currentUser.name,
   UID: currentUser.uid,

--- a/src/components/admin/Users.vue
+++ b/src/components/admin/Users.vue
@@ -71,12 +71,12 @@
                 @update:model-value="fetchUsers('user-permission-options')"
               >
                 <option
-                  v-for="option in [{id: -1, code: null, name: 'All'}, ...departments]"
-                  :id="`department-option-${option.code}`"
-                  :key="option.code"
-                  :value="option.code"
+                  v-for="option in [{id: -1, deptCode: null, deptName: 'All'}, ...departments]"
+                  :id="`department-option-${option.deptCode}`"
+                  :key="option.deptCode"
+                  :value="option.deptCode"
                 >
-                  {{ option.name }}
+                  {{ option.deptName }}
                 </option>
               </select>
             </div>
@@ -91,7 +91,7 @@
               >
                 <option
                   v-for="option in [
-                    {name: 'All', value: null},
+                    {deptName: 'All', value: null},
                     {name: 'Advisors', value: 'advisor'},
                     {name: 'No Canvas Data', value: 'noCanvasDataAccess'},
                     {name: 'No Notes or Appointments', value: 'noAdvisingDataAccess'},
@@ -329,8 +329,8 @@
 
         <template #item.departments="{ item }">
           <div class="row-padding">
-            <div v-for="(department, index) in item.departments" :key="department.code">
-              <span class="font-weight-bold text-body text-success-darken-1">{{ department.name }} - {{ department.role }}</span>
+            <div v-for="(department, index) in item.departments" :key="department.deptCode">
+              <span class="font-weight-bold text-body text-success-darken-1">{{ department.deptName }} - {{ department.role }}</span>
               <div v-if="index !== item.departments.length - 1"></div>
             </div>
             <div v-if="item.canEditDegreeProgress || item.canReadDegreeProgress" class="text-medium-emphasis">
@@ -514,11 +514,11 @@ const fetchUsers = (returnFocusId=null, srAlert='Loading users.') => {
         sortBy.value,
         sortDesc.value
       ).then(data => {
-        const department = find(props.departments, {'code': filterBy.value.deptCode})
+        const department = find(props.departments, {'deptCode': filterBy.value.deptCode})
         users.value = data.users
         totalUserCount.value = data.totalUserCount
         isFetching.value = false
-        alertScreenReader(`${department.name} users loaded${sortDescription}`)
+        alertScreenReader(`${department.deptName} users loaded${sortDescription}`)
         putFocusNextTick(returnFocusId || 'department-select-list')
       })
       break

--- a/src/components/appointment/AdvisingAppointment.vue
+++ b/src/components/appointment/AdvisingAppointment.vue
@@ -57,8 +57,8 @@
           </span>
         </div>
         <div v-if="size(advisor.departments)" class="mt-2 text-medium-emphasis">
-          <span v-for="(dept, index) in advisor.departments" :key="dept.code">
-            <span :id="`appointment-${appointment.id}-advisor-dept-${index}`">{{ dept.name }}</span>
+          <span v-for="(dept, index) in advisor.departments" :key="dept.deptCode">
+            <span :id="`appointment-${appointment.id}-advisor-dept-${index}`">{{ dept.deptName }}</span>
           </span>
         </div>
         <div v-if="appointment.appointmentType" :id="`appointment-${appointment.id}-type`" class="mt-2">

--- a/src/components/reports/NotesReport.vue
+++ b/src/components/reports/NotesReport.vue
@@ -189,7 +189,7 @@ const isShowingBoaNoteCounts = ref(false)
 const isShowingReport = ref(false)
 
 onMounted(() => {
-  getNotesReport(props.department.code).then(data => {
+  getNotesReport(props.department.deptCode).then(data => {
     report.value = data
     getBoaNoteCountByMonth().then(data => {
       boaNoteCountsByMonth.value = reverse(sortBy(data, 'year'))

--- a/src/components/reports/UserReport.vue
+++ b/src/components/reports/UserReport.vue
@@ -62,9 +62,9 @@
         </div>
       </template>
       <template #item.depts="{item}">
-        <div v-for="dept in item.departments" :key="dept.code" class="pb-1">
-          <span :id="`dept-${dept.code}-${item.uid}`">
-            <span class="dept-name text-success">{{ dept.name }}</span> ({{ oxfordJoin(getBoaUserRoles(dept)) }})
+        <div v-for="dept in item.departments" :key="dept.deptCode" class="pb-1">
+          <span :id="`dept-${dept.deptCode}-${item.uid}`">
+            <span class="dept-name text-success">{{ dept.deptName }}</span> ({{ oxfordJoin(getBoaUserRoles(dept)) }})
           </span>
         </div>
         <div v-if="item.isAdmin" class="dept-name text-success">BOA Admin</div>
@@ -120,7 +120,7 @@ watch(() => props.department, () => {
 
 const refresh = () => {
   totalUserCount.value = undefined
-  getUsersReport(props.department.code).then(data => {
+  getUsersReport(props.department.deptCode).then(data => {
     totalUserCount.value = data.totalUserCount
     users.value = data.users
   })

--- a/src/components/search/AdvancedSearchModal.vue
+++ b/src/components/search/AdvancedSearchModal.vue
@@ -524,7 +524,7 @@ const search = () => {
         query.advisorUid = searchStore.author.uid
       } else if (searchStore.postedBy === 'yourDepartment') {
         if (currentUser.departments && currentUser.departments.length > 0) {
-          query.departmentCodes = currentUser.departments.map((department) => department.code)
+          query.departmentCodes = currentUser.departments.map((department) => department.deptCode)
         }
       }
       if (searchStore.student) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -54,7 +54,8 @@ export type CurrentUser = {
 }
 
 export type Department = {
-  code: string,
+  deptCode: string,
+  deptName: string,
   role?: string
 }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -47,7 +47,7 @@ const $_goToLogin = (to: RouteLocation, next: NavigationGuardNext) => {
   })
 }
 
-const $_isCE3 = user => !!size(filter(user.departments, d => d.code === 'ZCEEE' && includes(['advisor', 'director'], d.role)))
+const $_isCE3 = user => !!size(filter(user.departments, d => d.deptCode === 'ZCEEE' && includes(['advisor', 'director'], d.role)))
 
 const $_requiresDegreeProgress = (to: RouteLocation, from: RouteLocation, next: NavigationGuardNext) => {
   const currentUser: CurrentUser = useContextStore().currentUser

--- a/src/views/AllCohorts.vue
+++ b/src/views/AllCohorts.vue
@@ -49,11 +49,11 @@
           :class="department.isOpen ? 'border-1 pb-6' : 'border-0'"
           hide-actions
           rounded
-          :value="department.code"
+          :value="department.deptCode"
           @group:selected="open => onClickExpansionPanel(department, open)"
         >
           <v-expansion-panel-title
-            :id="`department-${department.code.toLowerCase()}`"
+            :id="`department-${department.deptCode.toLowerCase()}`"
             class="bg-transparent pl-2 py-1 w-100"
             hide-actions
           >
@@ -76,8 +76,8 @@
                     />
                   </div>
                   <h2 class="page-section-header-sub pr-8 text-primary">
-                    <span class="sr-only">{{ `${department.isOpen ? 'Hide' : 'Show'} details for ${department.name} ` }}</span>
-                    {{ department.name }}
+                    <span class="sr-only">{{ `${department.isOpen ? 'Hide' : 'Show'} details for ${department.deptName} ` }}</span>
+                    {{ department.deptName }}
                   </h2>
                 </div>
               </div>
@@ -95,16 +95,16 @@
             <div v-if="!department.isFetching" class="ml-14">
               <div class="font-size-14 font-weight-bold text-medium-emphasis" :class="{'mb-3': department.users.length}">
                 {{ department.users.length || 'Zero' }} out of
-                <span v-if="department.code === 'ZZZZZ'">{{ department.memberCount }}</span>
-                <span v-if="department.code !== 'ZZZZZ'">
-                  <span v-if="department.name.includes('Advisors')">{{ department.memberCount }} {{ department.name }}</span>
-                  <span v-if="!department.name.includes('Advisors')">{{ pluralize(`${department.name} advisor`, department.memberCount) }}</span>
+                <span v-if="department.deptCode === 'ZZZZZ'">{{ department.memberCount }}</span>
+                <span v-if="department.deptCode !== 'ZZZZZ'">
+                  <span v-if="department.deptName.includes('Advisors')">{{ department.memberCount }} {{ department.deptName }}</span>
+                  <span v-if="!department.deptName.includes('Advisors')">{{ pluralize(`${department.deptName} advisor`, department.memberCount) }}</span>
                 </span>
                 {{ department.users.length === 1 ? 'has' : 'have' }} {{ modeLabel.toLowerCase() }}s.
               </div>
               <div
                 v-for="(user, index) in department.users"
-                :id="`users-of-department-${department.code.toLowerCase()}`"
+                :id="`users-of-department-${department.deptCode.toLowerCase()}`"
                 :key="index"
                 :class="{'mt-3': index > 0}"
               >
@@ -176,24 +176,24 @@ const collapseAllDepartments = () => {
 }
 
 const expandAllDepartments = () => {
-  panels.value = map(departments.value, 'code')
+  panels.value = map(departments.value, 'deptCode')
   each(departments.value, department => department.isOpen = true)
 }
 
 const onClickExpansionPanel = (department, isOpen) => {
   department.isOpen = isOpen.value
   if (isOpen) {
-    alertScreenReader(`Showing ${mode.value}s of ${department.name} department`)
+    alertScreenReader(`Showing ${mode.value}s of ${department.deptName} department`)
     if (isNil(department.users)) {
       department.isFetching = true
       const api = mode.value === 'cohort' ? getUsersWithCohortsByDeptCode : getUsersWithCuratedGroupsByDeptCode
-      api(department.code).then(data => {
+      api(department.deptCode).then(data => {
         department.users = data
         department.isFetching = false
       })
     }
   } else {
-    alertScreenReader(`Hiding ${mode.value}s of ${department.name} department`)
+    alertScreenReader(`Hiding ${mode.value}s of ${department.deptName} department`)
   }
 }
 </script>

--- a/src/views/FlightDataRecorder.vue
+++ b/src/views/FlightDataRecorder.vue
@@ -10,7 +10,7 @@
     </div>
     <NotesReport :department="department" />
     <div class="pb-4 pt-4">
-      <h2 class="page-section-header-sub ma-0 pt-0" :class="{'sr-only': availableDepartments.length !== 1}">{{ department.name }}</h2>
+      <h2 class="page-section-header-sub ma-0 pt-0" :class="{'sr-only': availableDepartments.length !== 1}">{{ department.deptName }}</h2>
       <div v-if="availableDepartments.length > 1" class="align-items-center d-flex">
         <label class="sr-only" for="available-department-reports">Departments:</label>
         <div>
@@ -21,11 +21,11 @@
           >
             <option
               v-for="d in availableDepartments"
-              :id="`department-report-${d.code}`"
-              :key="d.code"
-              :value="d.code"
+              :id="`department-report-${d.deptCode}`"
+              :key="d.deptCode"
+              :value="d.deptCode"
             >
-              {{ d.name }}
+              {{ d.deptName }}
             </option>
           </select>
         </div>
@@ -38,12 +38,12 @@
 <script setup>
 import NotesReport from '@/components/reports/NotesReport'
 import UserReport from '@/components/reports/UserReport'
+import {computed, onMounted, ref, watch} from 'vue'
 import {find, trim} from 'lodash'
 import {getAvailableDepartmentReports} from '@/api/reports'
-import {computed, onMounted, ref, watch} from 'vue'
-import {useRoute} from 'vue-router'
-import {useContextStore} from '@/stores/context'
 import {mdiAirplane} from '@mdi/js'
+import {useContextStore} from '@/stores/context'
+import {useRoute} from 'vue-router'
 
 const DEFAULT_DEPT_CODE = 'QCADV'
 
@@ -69,5 +69,5 @@ onMounted(() => {
   })
 })
 
-const getDepartment = deptCode => find(availableDepartments.value, ['code', deptCode])
+const getDepartment = deptCode => find(availableDepartments.value, ['deptCode', deptCode])
 </script>

--- a/src/views/PassengerManifest.vue
+++ b/src/views/PassengerManifest.vue
@@ -42,7 +42,7 @@ const refreshUsers = ref(false)
 contextStore.loadingStart()
 
 onMounted(() => {
-  getDepartments(true).then(data => {
+  getDepartments().then(data => {
     departments.value = data
     contextStore.loadingComplete()
   })

--- a/tests/test_api/test_reports_controller.py
+++ b/tests/test_api/test_reports_controller.py
@@ -238,8 +238,8 @@ class TestAvailableDeptCodesPerUser:
         assert len(departments) == 1
         assert departments == [
             {
-                'code': 'UWASC',
-                'name': 'Athletic Study Center',
+                'deptCode': 'UWASC',
+                'deptName': 'Athletic Study Center',
             },
         ]
 
@@ -250,12 +250,12 @@ class TestAvailableDeptCodesPerUser:
         assert len(departments) == 2
         assert departments == [
             {
-                'code': 'QCADV',
-                'name': 'L&S College Advising',
+                'deptCode': 'QCADV',
+                'deptName': 'L&S College Advising',
             },
             {
-                'code': 'QCADVMAJ',
-                'name': 'L&S Major Advising',
+                'deptCode': 'QCADVMAJ',
+                'deptName': 'L&S Major Advising',
             },
         ]
 

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -400,7 +400,7 @@ class TestGetDepartments:
             assert department['memberCount'] > 0
             if index > 0:
                 previous_department = api_json[index - 1]
-                assert department['name'] > previous_department['name']
+                assert department['deptName'] > previous_department['deptName']
 
 
 class TestGetUsers:
@@ -729,7 +729,7 @@ class TestUserUpdate:
 
         departments = user['departments']
         assert len(departments) == 1
-        assert departments[0]['code'] == 'COENG'
+        assert departments[0]['deptCode'] == 'COENG'
         assert departments[0]['role'] == 'advisor'
         assert departments[0]['automateMembership'] is True
 
@@ -851,7 +851,7 @@ class TestUserUpdate:
         # Verify University Dept membership
         university_depts = user['departments']
         assert len(university_depts) == 1
-        assert university_depts[0]['code'] == dept_code
+        assert university_depts[0]['deptCode'] == dept_code
         # Verify Peer Advising
         peer_advising_departments = user['peerAdvisingDepartments']
         assert len(peer_advising_departments) == 1


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5875

In order to avoid confusion in naming collisions w/ peer-advising-dept, I refactored university-dept related API properties to match its own schema: `code` becomes `deptCode` and `name` becomes `deptName`.