### PR TITLE
BOAC-5902, peer_advisors have no university_dept affiliation

### DIFF
--- a/boac/api/peer_advising_controller.py
+++ b/boac/api/peer_advising_controller.py
@@ -26,14 +26,14 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from datetime import datetime
 from random import randrange
 
-from boac.api.util import peer_advising_manager_required
+from boac.api.util import peer_advisor_manager_required
 from boac.lib.http import tolerant_jsonify
 from dateutil.tz import tzutc
 from flask import current_app as app
 
 
 @app.route('/api/peer/department/<peer_advising_department_id>')
-@peer_advising_manager_required
+@peer_advisor_manager_required
 def get_peer_advising_department(peer_advising_department_id):
     mock_names = [
         'Amelia Cortez',

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -44,6 +44,7 @@ from boac.models.curated_group import CuratedGroup
 from boac.models.degree_progress_course import ACCENT_COLOR_CODES
 from boac.models.note import Note
 from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
+from boac.models.university_dept import UniversityDept
 from boac.models.user_login import UserLogin
 from dateutil.tz import tzutc
 from flask import current_app as app, request
@@ -81,7 +82,7 @@ def admin_or_director_required(func):
 def peer_advisor_required(func):
     @wraps(func)
     def _authorize(*args, **kw):
-        if current_user.is_admin or _is_authorized_peer_advisor(current_user) or _api_key_ok():
+        if current_user.is_admin or is_authorized_peer_advisor(current_user) or _api_key_ok():
             return func(*args, **kw)
         else:
             app.logger.warning(f'Unauthorized request to {request.path}')
@@ -95,7 +96,7 @@ def advisor_or_peer_advisor_required(func):
         if (
             current_user.is_admin
             or _is_authorized_advisor(current_user)
-            or _is_authorized_peer_advisor(current_user)
+            or is_authorized_peer_advisor(current_user)
             or _api_key_ok()
         ):
             return func(*args, **kw)
@@ -105,12 +106,12 @@ def advisor_or_peer_advisor_required(func):
     return _advisor_required
 
 
-def peer_advising_manager_required(func):
+def peer_advisor_manager_required(func):
     @wraps(func)
     def _advisor_required(*args, **kw):
         if (
             current_user.is_admin
-            or _is_authorized_peer_advising_manager(current_user)
+            or is_authorized_peer_advisor_manager(current_user)
             or _api_key_ok()
         ):
             return func(*args, **kw)
@@ -249,28 +250,34 @@ def authorized_users_api_feed(users, sort_by=None, sort_descending=False):
             'departments': [],
             'isAdmin': user.is_admin,
             'isBlocked': user.is_blocked,
-            'isPeerAdvisor': user.is_peer_advisor,
         })
-        peer_advising_dept_memberships = PeerAdvisingDepartmentMember.get_peer_advising_department_memberships(
-            authorized_user_id=user.id,
-        )
         for m in user.department_memberships:
-            department = {
-                'deptCode': m.university_dept.dept_code,
-                'deptName': m.university_dept.dept_name,
-                'memberships': [{
-                    'role': m.role,
-                    'automateMembership': m.automate_membership,
-                }],
+            profile['departments'].append({
+                **m.university_dept.to_api_json(),
+                'memberships': [
+                    {
+                        'automateMembership': m.automate_membership,
+                        'role': m.role,
+                    },
+                ],
+            })
+        for m in PeerAdvisingDepartmentMember.get_peer_advising_department_memberships(authorized_user_id=user.id):
+            peer_advising_dept_membership = {
+                'role': m['role_type'],
+                'peerAdvisingDepartmentId': m['peer_advising_department_id'],
+                'peerAdvisingDepartmentName': m['peer_advising_department_name'],
             }
-            peer_advising_dept_membership = next((p for p in peer_advising_dept_memberships if p['university_dept_id'] == m.university_dept.id), None)
-            if peer_advising_dept_membership:
-                department['memberships'].append({
-                    'role': peer_advising_dept_membership['role_type'],
-                    'peerAdvisingDepartmentId': peer_advising_dept_membership['peer_advising_department_id'],
-                    'peerAdvisingDepartmentName': peer_advising_dept_membership['peer_advising_department_name'],
+            university_dept_id = m['university_dept_id']
+            university_dept_api_json = next((d for d in profile['departments'] if d['id'] == university_dept_id), None)
+            if university_dept_api_json:
+                # If the university_dept was added in the 'for user.department_memberships' loop above
+                # then we append the peer_advising membership to the existing object.
+                university_dept_api_json['memberships'].append(peer_advising_dept_membership)
+            else:
+                profile['departments'].append({
+                    **UniversityDept.find_by_id(university_dept_id).to_api_json(),
+                    'memberships': [peer_advising_dept_membership],
                 })
-            profile['departments'].append(department)
         user_login = UserLogin.last_login(user.uid)
         profile['lastLogin'] = _isoformat(user_login.created_at) if user_login else None
         profiles.append(profile)
@@ -451,6 +458,14 @@ def get_students_csv_header_labels(term_id):
     }
 
 
+def is_authorized_peer_advisor(user):
+    return _has_role_in_any_department(user, 'peer_advisor')
+
+
+def is_authorized_peer_advisor_manager(user):
+    return _has_role_in_any_department(user, 'peer_advisor_manager')
+
+
 def is_unauthorized_domain(domain):
     if domain not in ['default', 'admitted_students']:
         raise BadRequestError(f'Invalid domain: {domain}')
@@ -505,14 +520,6 @@ def validate_advising_note_set_date(params):
 
 def _is_authorized_advisor(user):
     return user.is_authenticated and (_has_role_in_any_department(user, 'advisor') or _has_role_in_any_department(user, 'director'))
-
-
-def _is_authorized_peer_advisor(user):
-    return user.is_authenticated and user.is_peer_advisor
-
-
-def _is_authorized_peer_advising_manager(user):
-    return _has_role_in_any_department(user, 'peer_advisor_manager')
 
 
 def _response_with_students_csv_download(sids, fieldnames, benchmark, term_id):
@@ -681,19 +688,27 @@ def _get_current_user_curated_groups_containing(profile, curated_groups):
 
 def _has_role_in_any_department(user, role):
     has_role = False
-    for department in user.departments:
-        if next((m for m in department['memberships'] if m['role'] == role), False):
-            has_role = True
-            break
+    is_dict = isinstance(user, dict)
+    is_authenticated = user['isAuthenticated'] if is_dict else user.is_authenticated
+    departments = user['departments'] if is_dict else user.departments
+    if is_authenticated:
+        for department in departments:
+            if next((m for m in department['memberships'] if m['role'] == role), False):
+                has_role = True
+                break
     return has_role
 
 
 def _is_advisor_in_department(user, dept_code):
     is_advisor_in_department = False
-    for department in user.departments:
-        if dept_code == department['deptCode'] and next((m for m in department['memberships'] if m['role'] in ('advisor', 'director')), False):
-            is_advisor_in_department = True
-            break
+    is_dict = isinstance(user, dict)
+    is_authenticated = user['isAuthenticated'] if is_dict else user.is_authenticated
+    departments = user['departments'] if is_dict else user.departments
+    if is_authenticated:
+        for department in departments:
+            if dept_code == department['deptCode'] and next((m for m in department['memberships'] if m['role'] in ('advisor', 'director')), False):
+                is_advisor_in_department = True
+                break
     return is_advisor_in_department
 
 

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -172,7 +172,6 @@ _test_users = [
         'canAccessCanvasData': False,
         'degreeProgressPermission': None,
         'isAdmin': False,
-        'isPeerAdvisor': True,
         'inDemoMode': False,
         'firstName': 'Peer',
         'lastName': 'Pressure',
@@ -337,6 +336,13 @@ _peer_advising_departments = [
         'university_dept_code': 'ZCEEE',
         'users': [
             {'uid': '1563405', 'role': 'peer_advisor'},
+        ],
+    },
+    {
+        'peer_advising_department_name': 'NAVCAL',
+        'university_dept_code': 'ZCEEE',
+        'users': [
+            {'uid': '1133400', 'role': 'peer_advisor'},
         ],
     },
     {
@@ -537,7 +543,6 @@ def _create_users():
                 can_access_advising_data=test_user['canAccessAdvisingData'],
                 can_access_canvas_data=test_user['canAccessCanvasData'],
                 degree_progress_permission=test_user.get('degreeProgressPermission'),
-                is_peer_advisor=test_user.get('isPeerAdvisor', False),
                 search_history=test_user.get('searchHistory', []),
             )
             if test_user.get('deleted'):

--- a/boac/models/university_dept.py
+++ b/boac/models/university_dept.py
@@ -52,6 +52,10 @@ class UniversityDept(Base):
         self.dept_name = dept_name
 
     @classmethod
+    def find_by_id(cls, university_dept_id):
+        return cls.query.filter_by(id=university_dept_id).first()
+
+    @classmethod
     def find_by_dept_code(cls, dept_code):
         return cls.query.filter_by(dept_code=dept_code).first()
 
@@ -136,3 +140,11 @@ class UniversityDept(Base):
             }
         advisors.sort(key=itemgetter('uid'))
         return [_resolve(uid, rows) for (uid, rows) in groupby(advisors, itemgetter('uid'))]
+
+    def to_api_json(self):
+        dept_code = self.dept_code
+        return {
+            'id': self.id,
+            'deptCode': dept_code,
+            'deptName': self.dept_name,
+        }

--- a/tests/test_api/test_auth_controller.py
+++ b/tests/test_api/test_auth_controller.py
@@ -26,11 +26,13 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import json
 from unittest import mock
 
+from boac.api.util import is_authorized_peer_advisor, is_authorized_peer_advisor_manager
 from boac.models.user_login import UserLogin
 import cas
 from tests.util import override_config, pause_mock_sts
 
-advisor_uid = '1133399'
+advisor_uid = '211159'
+peer_advisor_manager_uid = '1133399'
 peer_advisor_uid = '1133400'
 unauthorized_uid = '1015674'
 
@@ -152,14 +154,24 @@ class TestAuthorization:
         api_json = self._api_my_profile(client)
         assert api_json['isActive']
         assert len(api_json['departments']) == 1
+        assert is_authorized_peer_advisor(api_json) is False
+        assert is_authorized_peer_advisor_manager(api_json) is False
 
-    def test_is_peer_advisor(self, client, fake_auth):
+    def test_authorized_peer_advisor_manager(self, client, fake_auth):
+        fake_auth.login(peer_advisor_manager_uid)
+        api_json = self._api_my_profile(client)
+        assert api_json
+        assert api_json['isActive']
+        assert is_authorized_peer_advisor(api_json) is False
+        assert is_authorized_peer_advisor_manager(api_json) is True
+
+    def test_authorized_peer_advisor(self, client, fake_auth):
         fake_auth.login(peer_advisor_uid)
         api_json = self._api_my_profile(client)
         assert api_json
-        # TODO: Verify 'isActive' after the db table 'peer_advising_department_members' is in place.
         # assert api_json['isActive']
-        # assert api_json['isPeerAdvisor'] is True
+        # assert is_authorized_peer_advisor(api_json) is True
+        # assert is_authorized_peer_advisor_manager(api_json) is False
 
 
 class TestCasAuth:

--- a/tests/test_api/test_peer_advising_controller.py
+++ b/tests/test_api/test_peer_advising_controller.py
@@ -23,7 +23,7 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-peer_advising_manager_uid = '1133399'
+peer_advisor_manager_uid = '1133399'
 qcadv_advisor_uid = '53791'
 
 
@@ -46,7 +46,7 @@ class TestGetPeerAdvisingDepartment:
 
     def test_authorized(self, client, fake_auth):
         """Delivers peer_advising_department data to authorized user."""
-        user_profile = fake_auth.login(peer_advising_manager_uid)
+        user_profile = fake_auth.login(peer_advisor_manager_uid)
         api_json = self._api_get_peer_advising_department(client=client, peer_advising_department_id=2)
         departments = user_profile['departments']
         assert len(departments) == 1

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -58,7 +58,6 @@ class TestUserProfile:
         assert not api_json['uid']
         assert api_json['canEditDegreeProgress'] is False
         assert api_json['canReadDegreeProgress'] is False
-        assert api_json['isPeerAdvisor'] is False
 
     def test_current_user_profile(self, client, fake_auth):
         """Includes user profile info from Canvas."""
@@ -71,7 +70,6 @@ class TestUserProfile:
         assert 'lastName' in api_json
         assert api_json['canEditDegreeProgress'] is True
         assert api_json['canReadDegreeProgress'] is True
-        assert api_json['isPeerAdvisor'] is False
 
     def test_can_edit_degree_progress(self, client, fake_auth):
         """Degree check permissions."""
@@ -832,7 +830,7 @@ class TestUserUpdate:
         assert user['canAccessCanvasData'] is False
         assert len(user['departments']) == 1
 
-    def test_peer_advising_manager_role(self, client, fake_auth):
+    def test_peer_advisor_manager_role(self, client, fake_auth):
         """Give an advisor the 'Peer Advising Manager' role."""
         fake_auth.login(admin_uid)
         advisor = AuthorizedUser.find_by_uid(coe_advisor_uid)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5902

When building `authorized_user` JSON object, we merge memberships of `university_dept` and `peer_advising_dept` into a single `user.departments` property. And we must keep in mind that a peer-advisor has no `university_dept_memberships`.