### PR TITLE
BOAC-5902, rm 'is_peer_advisor' from schema.sql and db-migrate script

### DIFF
--- a/boac/merged/user_session.py
+++ b/boac/merged/user_session.py
@@ -114,10 +114,6 @@ class UserSession(UserMixin):
     def is_authenticated(self):
         return self.api_json['isAuthenticated']
 
-    @property
-    def is_peer_advisor(self):
-        return self.api_json['isPeerAdvisor']
-
     @classmethod
     @stow('boa_user_session_{user_id}')
     def load_user(cls, user_id):
@@ -194,8 +190,6 @@ class UserSession(UserMixin):
                 'isAdmin': is_admin,
                 'isAnonymous': not is_active,
                 'isAuthenticated': is_active,
-                # TODO: Is 'is_peer_advisor' necessary? Can we not deduce from 'peer_advising_departments' role_type?
-                'isPeerAdvisor': user.is_peer_advisor if user else False,
                 'uid': user and user.uid,
             },
         }

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -52,7 +52,6 @@ class AuthorizedUser(Base):
     degree_progress_permission = db.Column(generic_permission_type_enum)
     deleted_at = db.Column(db.DateTime, nullable=True)
     in_demo_mode = db.Column(db.Boolean, nullable=False)
-    is_peer_advisor = db.Column(db.Boolean, nullable=False)
     is_admin = db.Column(db.Boolean)
     # When True, is_blocked prevents a deleted user from being revived by the automated refresh.
     is_blocked = db.Column(db.Boolean, nullable=False, default=False)
@@ -82,7 +81,6 @@ class AuthorizedUser(Base):
             is_admin=False,
             is_blocked=False,
             in_demo_mode=False,
-            is_peer_advisor=False,
             can_access_advising_data=True,
             can_access_canvas_data=True,
             degree_progress_permission=None,
@@ -96,7 +94,6 @@ class AuthorizedUser(Base):
         self.in_demo_mode = in_demo_mode
         self.is_admin = is_admin
         self.is_blocked = is_blocked
-        self.is_peer_advisor = is_peer_advisor
         self.search_history = search_history
         self.uid = uid
 
@@ -112,7 +109,6 @@ class AuthorizedUser(Base):
                     in_demo_mode={self.in_demo_mode},
                     is_admin={self.is_admin},
                     is_blocked={self.is_blocked},
-                    is_peer_advisor={self.is_peer_advisor},
                     search_history={self.search_history},
                     updated={self.updated_at}>
                 """

--- a/scripts/db/migrate/2025/20250122-BOAC-5841/pre_deploy_01_peer_advising.sql
+++ b/scripts/db/migrate/2025/20250122-BOAC-5841/pre_deploy_01_peer_advising.sql
@@ -1,8 +1,6 @@
 BEGIN;
 
 -- Add columns to already existing tables
-ALTER TABLE authorized_users ADD COLUMN IF NOT EXISTS is_peer_advisor BOOLEAN DEFAULT FALSE NOT NULL;
-
 ALTER TABLE notes ADD COLUMN IF NOT EXISTS peer_advising_department_id INTEGER;
 
 ALTER TABLE notes ADD COLUMN IF NOT EXISTS note_template_id INTEGER;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -112,7 +112,6 @@ CREATE TABLE authorized_users (
     in_demo_mode boolean DEFAULT false NOT NULL,
     is_admin boolean,
     is_blocked boolean DEFAULT false NOT NULL,
-    is_peer_advisor boolean DEFAULT false NOT NULL,
     search_history CHARACTER VARYING[],
     uid character varying(255) NOT NULL,
     updated_at timestamp with time zone NOT NULL


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5902

Because `boa-dev` is the only environment with this column added, I will be manually dropping it. I will use:
```
ALTER TABLE authorized_users DROP COLUMN is_peer_advisor;
```