### PR TITLE
boac-5899 - access control decorators for note templates + some UI work for note templates

### DIFF
--- a/boac/api/note_templates_controller.py
+++ b/boac/api/note_templates_controller.py
@@ -24,14 +24,16 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import advising_data_access_required, get_note_attachments_from_http_post, get_note_topics_from_http_post
+from boac.api.util import (advising_data_access_required, get_note_attachments_from_http_post,
+                           get_note_topics_from_http_post, peer_advisor_or_peer_advisor_manager_in_department)
 from boac.lib.berkeley import dept_codes_where_advising
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import process_input_from_rich_text_editor, to_bool_or_none
 from boac.models.note import Note
 from boac.models.note_template import NoteTemplate
+from boac.models.peer_advising_department import PeerAdvisingDepartment
 from flask import current_app as app, request
-from flask_login import current_user
+from flask_login import current_user, login_required
 
 
 @app.route('/api/note_template/create', methods=['POST'])
@@ -62,12 +64,17 @@ def create_note_template():
 
 
 @app.route('/api/note_template/<note_template_id>')
-@advising_data_access_required
+@login_required
 def get_note_template(note_template_id):
     note_template = NoteTemplate.find_by_id(note_template_id=note_template_id)
     if not note_template:
         raise ResourceNotFoundError('Template not found')
-    if note_template.creator_id != current_user.get_id():
+    if not note_template.peer_advising_department_id and note_template.creator_id != current_user.get_id():
+        raise ForbiddenRequestError('Template not available')
+    if (note_template.peer_advising_department_id
+            and not PeerAdvisingDepartment.user_in_peer_advising_department(
+                user=current_user,
+                peer_advising_department_id=note_template.peer_advising_department_id)):
         raise ForbiddenRequestError('Template not available')
     return tolerant_jsonify(note_template.to_api_json())
 
@@ -80,9 +87,9 @@ def get_my_note_templates():
 
 
 @app.route('/api/note_templates/peer_advising_department_id/<peer_advising_department_id>')
-@advising_data_access_required
+@peer_advisor_or_peer_advisor_manager_in_department
 def get_note_templates_for_peer_advising_department(peer_advising_department_id):
-    note_templates = NoteTemplate.get_templates_created_by(peer_advising_department_id=peer_advising_department_id)
+    note_templates = NoteTemplate.get_templates_created_by_peer_advising_department(peer_advising_department_id=peer_advising_department_id)
     return tolerant_jsonify([t.to_api_json() for t in note_templates])
 
 
@@ -97,8 +104,13 @@ def rename_note_template():
     note_template = NoteTemplate.find_by_id(note_template_id=note_template_id)
     if not note_template:
         raise ResourceNotFoundError('Template not found')
-    if note_template.creator_id != current_user.get_id():
-        raise ForbiddenRequestError('Template not available.')
+    if not note_template.peer_advising_department_id and note_template.creator_id != current_user.get_id():
+        raise ForbiddenRequestError('Template not available')
+    if (note_template.peer_advising_department_id
+            and not PeerAdvisingDepartment.user_in_peer_advising_department(
+                user=current_user,
+                peer_advising_department_id=note_template.peer_advising_department_id)):
+        raise ForbiddenRequestError('Template not available')
     note_template = NoteTemplate.rename(note_template_id=note_template_id, title=title)
     return tolerant_jsonify(note_template.to_api_json())
 
@@ -119,8 +131,13 @@ def update_note_template():
     note_template = NoteTemplate.find_by_id(note_template_id=note_template_id)
     if not note_template:
         raise ResourceNotFoundError('Template not found')
-    if note_template.creator_id != current_user.get_id():
-        raise ForbiddenRequestError('Template not available.')
+    if not note_template.peer_advising_department_id and note_template.creator_id != current_user.get_id():
+        raise ForbiddenRequestError('Template not available')
+    if (note_template.peer_advising_department_id
+            and not PeerAdvisingDepartment.user_in_peer_advising_department(
+                user=current_user,
+                peer_advising_department_id=note_template.peer_advising_department_id)):
+        raise ForbiddenRequestError('Template not available')
     note_template = NoteTemplate.update(
         attachments=get_note_attachments_from_http_post(tolerate_none=True),
         body=process_input_from_rich_text_editor(body),
@@ -139,7 +156,12 @@ def delete_note_template(note_template_id):
     note_template = NoteTemplate.find_by_id(note_template_id=note_template_id)
     if not note_template:
         raise ResourceNotFoundError('Template not found')
-    if note_template.creator_id != current_user.get_id():
+    if not note_template.peer_advising_department_id and note_template.creator_id != current_user.get_id():
+        raise ForbiddenRequestError('Template not available')
+    if (note_template.peer_advising_department_id
+            and not PeerAdvisingDepartment.user_in_peer_advising_department(
+                user=current_user,
+                peer_advising_department_id=note_template.peer_advising_department_id)):
         raise ForbiddenRequestError('Template not available')
     NoteTemplate.delete(note_template_id=note_template_id)
     return tolerant_jsonify({'message': f'Note template {note_template_id} deleted'}), 200

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -43,6 +43,7 @@ from boac.models.cohort_filter import CohortFilter
 from boac.models.curated_group import CuratedGroup
 from boac.models.degree_progress_course import ACCENT_COLOR_CODES
 from boac.models.note import Note
+from boac.models.peer_advising_department import PeerAdvisingDepartment
 from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
 from boac.models.university_dept import UniversityDept
 from boac.models.user_login import UserLogin
@@ -103,6 +104,34 @@ def advisor_or_peer_advisor_required(func):
             app.logger.warning(f'Unauthorized request to {request.path}')
             return app.login_manager.unauthorized()
     return _advisor_required
+
+
+# Checks if the peer_advisor or peer_advisor_manager is in the peer_advising_department in the URL parameter
+def peer_advisor_or_peer_advisor_manager_in_department(func):
+    @wraps(func)
+    def _peer_advisor_or_manager_in_department(*args, **kw):
+        # Extract the peer_advising_department_id from the URL params
+        peer_advising_department_id = kw.get('peer_advising_department_id') or request.view_args.get(
+            'peer_advising_department_id')
+        if peer_advising_department_id is None:
+            app.logger.error('Department ID missing in URL.')
+            return app.login_manager.unauthorized()
+        if (
+                (current_user.is_admin
+                    or is_authorized_peer_advisor_manager(current_user)
+                    or is_authorized_peer_advisor(current_user)
+                    or _api_key_ok())
+                and (
+                    PeerAdvisingDepartment.user_in_peer_advising_department(
+                        user=current_user,
+                        peer_advising_department_id=peer_advising_department_id)
+                )
+        ):
+            return func(*args, **kw)
+        else:
+            app.logger.warning(f'Unauthorized request to {request.path}')
+            return app.login_manager.unauthorized()
+    return _peer_advisor_or_manager_in_department
 
 
 def peer_advisor_manager_required(func):

--- a/boac/models/peer_advising_department.py
+++ b/boac/models/peer_advising_department.py
@@ -49,3 +49,12 @@ class PeerAdvisingDepartment(Base):
     @classmethod
     def find_by_university_dept_id(cls, university_dept_id):
         return cls.query.filter_by(university_dept_id=university_dept_id).all()
+
+    @classmethod
+    def user_in_peer_advising_department(cls, user, peer_advising_department_id):
+        membership = cls.query.filter_by(
+            authorized_user_id=user.id,
+            peer_advising_department_id=peer_advising_department_id,
+            deleted_at=None,
+        ).first()
+        return membership is not None

--- a/src/api/note-templates.ts
+++ b/src/api/note-templates.ts
@@ -12,6 +12,12 @@ export function getMyNoteTemplates() {
   return axios.get(`${utils.apiBaseUrl()}/api/note_templates/my`).then(response => response.data)
 }
 
+
+export function getNoteTemplatesForPeerAdvising(peerAdvisingDeptId: number) {
+  const url: string = `${utils.apiBaseUrl()}/api/note_templates/peer_advising_department_id/${peerAdvisingDeptId}`
+  return axios.get(url).then(response => response.data)
+}
+
 export function createNoteTemplate(noteId: number, title: string) {
   const url: string = `${utils.apiBaseUrl()}/api/note_template/create`
   return axios.post(url, {noteId, title}).then(response => {
@@ -58,3 +64,4 @@ export function updateNoteTemplate(
     return data
   })
 }
+

--- a/src/components/peer/PeerAdvisingNoteTemplates.vue
+++ b/src/components/peer/PeerAdvisingNoteTemplates.vue
@@ -10,9 +10,9 @@
           class="float-end"
           color="primary"
           slim
-          text="Add Unit Requirement"
+          text="Create new Note Template"
           variant="text"
-          :append-icon="mdiPlus"
+          :prepend-icon="mdiPlus"
           @click.prevent="onClickAdd"
         />
       </div>
@@ -30,16 +30,12 @@
       mobile-breakpoint="md"
       :row-props="row => ({id: `row-note-template-${row.item.uid}`})"
     >
-      <template #item.createdAt="{item}">
-        <div class="float-right" :class="{'font-weight-medium text-red': item.deletedAt}">
-          {{ item.createdAt }}
-        </div>
-      </template>
-      <template #item.actions="{item}">
-        <v-tooltip text="Delete">
-          <template #activator="{props}">
+      <template #item="{ item, index }">
+        <tr :class="index % 2 === 0 ? 'white-row' : 'grey-row'">
+          <td> {{ item.name }}</td>
+          <td> {{ item.createdAt }} </td>
+          <td>
             <v-btn
-              v-bind="props"
               :id="`edit-note-template-${item.uid}`"
               :aria-label="`Edit ${item.name}`"
               color="primary"
@@ -50,7 +46,6 @@
             />
             |
             <v-btn
-              v-bind="props"
               :id="`copy-note-template-${item.uid}`"
               :aria-label="`Copy ${item.name}`"
               color="primary"
@@ -61,7 +56,6 @@
             />
             |
             <v-btn
-              v-bind="props"
               :id="`delete-note-template-${item.uid}`"
               :aria-label="`Delete ${item.name}`"
               color="primary"
@@ -70,8 +64,8 @@
               variant="text"
               @click="deleteTemplate(item)"
             />
-          </template>
-        </v-tooltip>
+          </td>
+        </tr>
       </template>
     </v-data-table>
   </div>
@@ -81,6 +75,14 @@
 import {onMounted, ref} from 'vue'
 import {mdiPlus} from '@mdi/js'
 import {alertScreenReader} from '@/lib/utils'
+import {getNoteTemplatesForPeerAdvising} from '@/api/note-templates'
+
+const props = defineProps({
+  peerAdvisingDepartment: {
+    required: true,
+    type: Object
+  }
+})
 
 const headers = [
   {align: 'start', key: 'name', title: 'Template Name', width: '60%'},
@@ -108,7 +110,14 @@ onMounted(() => {
       createdAt: 'Mar 3, 2024'
     },
   ]
+  getNoteTemplates()
 })
+
+const getNoteTemplates = () => {
+  getNoteTemplatesForPeerAdvising(props.peerAdvisingDepartment.id).then(response => {
+    noteTemplates.value = response
+  })
+}
 
 const copyTemplate = noteTemplate => {
   alertScreenReader(noteTemplate)
@@ -126,3 +135,16 @@ const onClickAdd = () => {
   alertScreenReader('onClickAdd')
 }
 </script>
+
+<style>
+
+.data-table-header-cell {
+  height: 24px !important;
+}
+.white-row {
+  background-color: white;
+}
+.grey-row {
+  background-color: #f6f6f6;
+}
+</style>

--- a/tests/test_api/test_note_templates_controller.py
+++ b/tests/test_api/test_note_templates_controller.py
@@ -52,7 +52,7 @@ class TestGetNoteTemplate:
     def test_user_without_advising_data_access(self, client, fake_auth, mock_note_template):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_no_advising_data_uid)
-        self._api_note_template(client=client, note_template_id=mock_note_template.id, expected_status_code=401)
+        self._api_note_template(client=client, note_template_id=mock_note_template.id, expected_status_code=403)
 
     def test_unauthorized(self, app, client, fake_auth, mock_note_template):
         """Returns 403 if user did not create the requested note template."""


### PR DESCRIPTION
Jiras:
- https://jira-secure.berkeley.edu/browse/BOAC-5899
- https://jira-secure.berkeley.edu/browse/BOAC-5898

@pauline2k @johncrossman @lyttam - FYI - I was able to limit it to only one new decorator called `peer_advisor_or_peer_advisor_manager_in_department`. Since a **peer_advisor_manager** =  **advisor** and a **peer_advisor_manager** `can_access_advising_data = true`. So I used the original `advising_data_access_required` decorator for the rest of the create/update/delete endpoints. 