### PR TITLE
BOAC-5932, roll back ckEditor version bump; v43.3.1 needs no license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "BOA",
       "dependencies": {
-        "@ckeditor/ckeditor5-build-classic": "44.1.0",
+        "@ckeditor/ckeditor5-build-classic": "43.3.1",
         "@ckeditor/ckeditor5-vue": "5.1.0",
         "@mdi/js": "7.4.47",
         "@popperjs/core": "2.11.8",
@@ -129,715 +129,701 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-44.1.0.tgz",
-      "integrity": "sha512-RCamOkjMHlhUg7MhRbP/ZZJ7mq0zk1hj6Hg25efv22WHb2SNnesiwzLtYoyc6ess72/1CYpgZPfamhxsOTXoMA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-43.3.1.tgz",
+      "integrity": "sha512-fOnEq31euR9B/awWZCOc8KfgLwwG4ACtqBhSv7Hu6VOgHa5TKWyWAdhr9ILSiUp7NMfYJoTQStbxcXZIWPqQXQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-44.1.0.tgz",
-      "integrity": "sha512-t+xIuGiG9pvG4lkglSQfXwoZU9zCPUvrBYISI8G0WAJXdWdmyWUN2Vj84CKQQ6LRgnqq/eybSR2O2l02psgtZw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-43.3.1.tgz",
+      "integrity": "sha512-E+04zNdNBFDNgQajrWl8iFQqA1sB29y/XDFFRK+bzhcUaWdMadr88yodjHHdcax8/zI+GzBElCvWGEGchyrL+Q==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-44.1.0.tgz",
-      "integrity": "sha512-JHJh+iD9//sYsVlwdGZTV+ScPMlWjqFuR7xwF2QbU7xYGMqTy4mPnFvkT6fF73e3PZvtAzgENLU45pUAS9oo/A==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-43.3.1.tgz",
+      "integrity": "sha512-hSQxIXIObrMfxijMPmz8odOtz/wD5SwuGZWVoF5km3EtRQxZwAcQr1Vjy+VHHPo6PZ+o3YoLP+IHCaULtNobYg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-44.1.0.tgz",
-      "integrity": "sha512-KlkJcgu5THkfdwzYzVa9zKkADGd8J5VW5kRrRSK4oJYONA5mmiZ9UsIcoIk2QbGnDGnZW1Iih5Pjrvz0HYjIKw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-43.3.1.tgz",
+      "integrity": "sha512-28667m7ea0wBZMb3uIzgipanB4DrDvKn4o+mRUDExlRT8M14vn1u/ILX8ZJy28Rihbg2wPcVh6rP3zoQjcucHw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-44.1.0.tgz",
-      "integrity": "sha512-/pZ0wBdXlv8AX43O/nZ4ENg8Xk/SwZZMAJKKVZa3SwtxNRmeGYTNKIEQEQouWF1PLz3SEZ8L5sS/j9AYX7f5Xw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-43.3.1.tgz",
+      "integrity": "sha512-1RBnPmgsIoxPL7wZhId2KsfPujITbEAfzHhi0c6m4kuWlkmcVXYldWvUvCvAUguAznx4LOxhKlp6RdFSPTFTbg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-44.1.0.tgz",
-      "integrity": "sha512-mApNvTckUbAjeHFaPg7+Je3zTkJDDsM5FWNJJuzaRhl5TBvyW9BM+p7AN8B9cx+pj2Srzlbu+056c0jg4ibCIw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-43.3.1.tgz",
+      "integrity": "sha512-cgY4GKwMlIVLnhszPoc1ortp+T/s3TLowrwRFtWYxTKSsHWBGFlZUL6oMASPunpXvvJqHcgnKlCMxVSh2VMCkQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-bookmark": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-44.1.0.tgz",
-      "integrity": "sha512-gzUOspXUb4sN308JbeVWLGxGdFHeYpobiBn8Zj2/Niw6y+/4ZQfssn7fLhKnoHM12bzoxYYq3DvcMUrs78Ukvg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-build-classic": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-44.1.0.tgz",
-      "integrity": "sha512-/zuF39CLlRz0+15yW2fOeopJ1Dasfb2kOhyNbyLnFhaYPvAGZjqAlepYdRXuQRfjclYURimHlZbvIlzALqG2EA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-43.3.1.tgz",
+      "integrity": "sha512-ilc1YyOyIhknNd1NSAiHmXZewazGuIHYl5rHPeCiBShNGTjnh9DrA5hXSk7JBc1BpAxpxd4ojKR1nJ0dvkaR7g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-autoformat": "44.1.0",
-        "@ckeditor/ckeditor5-basic-styles": "44.1.0",
-        "@ckeditor/ckeditor5-block-quote": "44.1.0",
-        "@ckeditor/ckeditor5-ckbox": "44.1.0",
-        "@ckeditor/ckeditor5-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-cloud-services": "44.1.0",
-        "@ckeditor/ckeditor5-easy-image": "44.1.0",
-        "@ckeditor/ckeditor5-editor-classic": "44.1.0",
-        "@ckeditor/ckeditor5-essentials": "44.1.0",
-        "@ckeditor/ckeditor5-heading": "44.1.0",
-        "@ckeditor/ckeditor5-image": "44.1.0",
-        "@ckeditor/ckeditor5-indent": "44.1.0",
-        "@ckeditor/ckeditor5-link": "44.1.0",
-        "@ckeditor/ckeditor5-list": "44.1.0",
-        "@ckeditor/ckeditor5-media-embed": "44.1.0",
-        "@ckeditor/ckeditor5-paragraph": "44.1.0",
-        "@ckeditor/ckeditor5-paste-from-office": "44.1.0",
-        "@ckeditor/ckeditor5-table": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-autoformat": "43.3.1",
+        "@ckeditor/ckeditor5-basic-styles": "43.3.1",
+        "@ckeditor/ckeditor5-block-quote": "43.3.1",
+        "@ckeditor/ckeditor5-ckbox": "43.3.1",
+        "@ckeditor/ckeditor5-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-cloud-services": "43.3.1",
+        "@ckeditor/ckeditor5-easy-image": "43.3.1",
+        "@ckeditor/ckeditor5-editor-classic": "43.3.1",
+        "@ckeditor/ckeditor5-essentials": "43.3.1",
+        "@ckeditor/ckeditor5-heading": "43.3.1",
+        "@ckeditor/ckeditor5-image": "43.3.1",
+        "@ckeditor/ckeditor5-indent": "43.3.1",
+        "@ckeditor/ckeditor5-link": "43.3.1",
+        "@ckeditor/ckeditor5-list": "43.3.1",
+        "@ckeditor/ckeditor5-media-embed": "43.3.1",
+        "@ckeditor/ckeditor5-paragraph": "43.3.1",
+        "@ckeditor/ckeditor5-paste-from-office": "43.3.1",
+        "@ckeditor/ckeditor5-table": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-44.1.0.tgz",
-      "integrity": "sha512-J+vJckr25Oi3KjJcTYIIUFa2KIXHitknW8iNPegavCV/FFNieTezvvpjJzROlWRiy+U7CRYvgrNbSJXHx5pR6Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-43.3.1.tgz",
+      "integrity": "sha512-KObL9w/QBWJi0lG2zfm+x124Kzd7aVt+UaJHJEwsAPwhZvqM0LCUeR6wwb0oCN6ph5qrCjXoj09z7z8Txk5IwA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "blurhash": "2.0.5",
-        "ckeditor5": "44.1.0",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-44.1.0.tgz",
-      "integrity": "sha512-oRWHiejta6irRuO78KmtQEiYRrzcad+BycTrFsLRCIZp0hzKx5Vp5olAhXodX+d8gZaV8fJJpswdK0LTjrfKNA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-43.3.1.tgz",
+      "integrity": "sha512-Yji6c1/0H5fExDcT+NNyQQePx2cd8Ul1Xuko1UVmsLN2Vhi7VIDJjEkCFndJozd8VQqI62Obe1GTyjmapBV5+A==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-44.1.0.tgz",
-      "integrity": "sha512-Z5P1P6ATLVy/c7AvI3Akt3mEqQfCnhZmz4EdAS7sF34WTayrHQ/TQjdte/0mN+6LXcQV1whhXe1xLM7GVsG+bg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-43.3.1.tgz",
+      "integrity": "sha512-Ke6fVEy1fF3AWHMtKvF1pAoDYBVOG4q+gDHD8+dcV6KPK1uA/CR0mw6TZsslQQquT4jC79y05IWu2bq1Mxv01w==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-44.1.0.tgz",
-      "integrity": "sha512-3Nr8EM6CyRpNkmm+7tbhg/4H16SY5Tqo0TLGHtXdyRxx7y2GLev5OsN01qBhSSGifALTCHyOWymxt5Qo9V5wXg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-43.3.1.tgz",
+      "integrity": "sha512-JppySF+uWedDXPTVZBsTfZCe3qedDAdWSgw0Ww/qi4/sPFcgf/MaQ0LBHbl2Ii7JlJjng82F1F2kv9Ny/Rkauw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-44.1.0.tgz",
-      "integrity": "sha512-2z4ULLehgMjwxvo0a26UkA2p3MdDITGVDpt7FZkO+P9XCim/j5DdXK4/xVNXLbrOifpFq/5kfrAZvjDX0lPMIw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-43.3.1.tgz",
+      "integrity": "sha512-UGhGCPNfFXLua0TmszLSWX6BlkemaPULN1EZ+FBPsUZb757qWWWVWI9GKLmAc4jSPqOv+azU+JAZJzX9bE1oYA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-44.1.0.tgz",
-      "integrity": "sha512-vBxHT/g37uWM5QKj0i7++clGd85htX9rPtlqzjz3I26NJQvcKCmT39Szv3oPFzAJKuUaqKso5iLq+Sw+VtQRBg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-43.3.1.tgz",
+      "integrity": "sha512-6pil2OF4auF3PKrg1Oa86CqC91ZYc+NuHih0ebM0JW/I06d+0smnJg5dw4yN7mKbghbJS8mNrusxA5cf6Hkh6w==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-watchdog": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-watchdog": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-44.1.0.tgz",
-      "integrity": "sha512-hmn9MmVebb/abTBq1ci2fYi7uK93Dt2F3lDYErqsFWCxZ4S2PQW3+qON44E5phE9aDKOLEZ/B61niGrLgcWS5g==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-43.3.1.tgz",
+      "integrity": "sha512-Cd5NojL0Vfa1SQj6uzbP3oSHvQY5ys2hXF/2jNsYKLePTCybSvGkg5REv1JifM6kSNRH1VXdad7a2LkqvXnCnA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-44.1.0.tgz",
-      "integrity": "sha512-BVxO3WECurMZEhxIVb2JMqeMcqaqefvc/YfrWNRriVyK7muW47EH74IIZdCXSm7g5i0npEIk808sKqA0t/xR0g==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-43.3.1.tgz",
+      "integrity": "sha512-klS1FZG29nJE/XbfRXrXtwYU/9uCFdi7xGbYfaJnmyNt54h46aiquKacosbiffA87Tr5sT3Oqm3dBbNlsU158w==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-44.1.0.tgz",
-      "integrity": "sha512-rZtJ1KpJGxW8iWE0wVhp9giiYiu3XypjsmthkK8oeMf4+8wTr3ySncLKKts3/BDiAcFdJnog5lv5LQbrAVqO+Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-43.3.1.tgz",
+      "integrity": "sha512-wjBeXUQBuvz6CmGlb5XncJ9cHE7tozU6eoorycfSTQCzqr5uE57LWTlKclU42w7MgS2ya5V2kLnncr0ZqrZ2Vw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-44.1.0.tgz",
-      "integrity": "sha512-pRnDrPVyIM4uCLCjhgzvRk4v63Cc1u9Nc21yx1igswvxAfhGx2BMO+JiC6+8PAHT/mOSbgFB83N+A823sms3uA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-43.3.1.tgz",
+      "integrity": "sha512-aw2iZ+WCcCu9sUAnsHhsXZWLeVPyiLhZfpZDuEWjPlvsrCfT0RfSuwMcfx7l9PREA09VR8+6MTstm61EG8dmWQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-44.1.0.tgz",
-      "integrity": "sha512-NglsnVkzioMU9XirmjyTM/DKSL/rzkBBwFaZFiTVyGfhuVzTUClPxGtxKOlML2v0Mtqg/OdRUMPMIo+qtjymeQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-43.3.1.tgz",
+      "integrity": "sha512-3iZiWl2aM1bCnS52NeBoAqCVowABhWrBlns27JEGKZ+LNPZroMie7uKuMX3YQGYE2awFnsyP6XofoJtu6CcKCA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-44.1.0.tgz",
-      "integrity": "sha512-NAMBGIDn/xMGHXv2IeLRDa84yW9OwHri9H5NdJJ4F+gFtiQbOhIhTQj4nZ8TuLIaYr2NOUrTpTrkw3frgd0lLg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-43.3.1.tgz",
+      "integrity": "sha512-HDgfTuotrHW91AZ+x+lumwo1tngRRZ87dnHT8kjSRFWAeXPSd2Kw986++Oj9K080+idZaYLF+IutAOqvCT32sw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-44.1.0.tgz",
-      "integrity": "sha512-+149hsqfZX+Q+ho7P64XUrIpkLqX2jGBuEWjC2ZZYujv1ZIOWOMihkpJL8jE6Vcplee6vsTXGSj2sIHNoOp+3g==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-43.3.1.tgz",
+      "integrity": "sha512-Fkv3ibQLDPVHFH0z4/+gA5wrkPVWOen+Cjv/NecNBeAszZUo+F2j9RwvQ1zHwtGb0RWj3+BWOPgo8jhSe7tFgA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-44.1.0.tgz",
-      "integrity": "sha512-NmtqxEov25rYRN8Uq7MRabsqYfvL6ZNj/mvBHqn3PE9aHE+lTwD51D3zgCw1RN2sipXsvedwo3g+NynAtS/HIw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-43.3.1.tgz",
+      "integrity": "sha512-xaHnU2RbfYi8ilfN260pB3YDvJ9lE4SfiFQusyRdWkeBo5gDAGBbQY+qCC/hmxkr/yftNZfK+d7Ow93xXtqEwg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-44.1.0.tgz",
-      "integrity": "sha512-UWSc2lSCqztfy3LLeuHfyKU/oSbFyw/4KEbQso9DsMPQ4vdmX/sW6BoklCYF9mPJrg+zNSseJj9T/M1Q+Z6U0Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-43.3.1.tgz",
+      "integrity": "sha512-bZtzXhmBz8XF9J4eUxOjURmw0HJPKIqo18a6vNxg07W8z3ouHMb9ke//4z4FF9N/1dbtA7a2+jIACO6WvXrX4A==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-select-all": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-select-all": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-44.1.0.tgz",
-      "integrity": "sha512-SwZYRdXpYCu3t3+k9fxO8JXjNb/Q/OK3nmtVBNly/ZWYmORGQd3ua9XlipcnwIB8aBQqhuV/izDKqSiFZc23zA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-43.3.1.tgz",
+      "integrity": "sha512-U9dyK8yQgxGTUphRbqdUJbvfi5v7zzijCo3Kj51NxyWwOFh7SGReQxHDGn44DmSRold6lg4F1sbXeFdwu1o+WA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-44.1.0.tgz",
-      "integrity": "sha512-q4r7I7C2uG9gkBx9WlARNN5ZWp4USHVFS2kLTyMVAN1/iHAKIx03m+N3W0FTZVpXV+xscn7H6KaLcQXmWc4OiQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-43.3.1.tgz",
+      "integrity": "sha512-NOeBtScqMuBLVWFPuW0snleh7rMFkNb006yzDIG6JApnF3Vxi0JLQXub/lPHPgw5srqJ3z159DWT++exoyz/mQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-44.1.0.tgz",
-      "integrity": "sha512-cROqN/dnq8xBdxMQoe+1Zjh8bfoVePh6WSl+wjcc4OIozYe/V2QAmCODpYiVm4RntenH0IidHteSTCqtGM4L9w==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-43.3.1.tgz",
+      "integrity": "sha512-cc8H027Y2OwvYDGMTbBSzE+oZaiLMZtlUnkgiolMw/OQ59ysONYi+KqyMzBMTuaXrkP3CLM57ZbsVGASQ3IQmQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-paragraph": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-paragraph": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-44.1.0.tgz",
-      "integrity": "sha512-bj7DBo1miBf6f7LPLiNa5inziXBKt6dFQupWAgJNJvPxYeGf4jTKDeVc9FLBESJ7eOWKjmCjaNeSsV2smHTAKQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-43.3.1.tgz",
+      "integrity": "sha512-XVJq1YP4IAaWQBAyY1xlKOfzkpnclUH8zTUPaW3TZUGK5t6W/vFT+KAzYfUp7PdBb+PP8/O47FwKTvIQBkbqFw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-44.1.0.tgz",
-      "integrity": "sha512-xwqQPJQsgwEvbZb3EqjFEcvj1tmlxcX9hFL9I66oGblfYNEIX8Q4DWxbjWCDrfY2IvLO3zNUDI9J5EcxSnd9Pw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-43.3.1.tgz",
+      "integrity": "sha512-zkKe0S9gBXwveBUzUuCBPWyrzHQor/zcMCCX9YQk1StUxtRRsURNvWOoFeoG+Vf5jMGSA2gpnBgIo70WrX4A3A==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-44.1.0.tgz",
-      "integrity": "sha512-eFXTBHhvRIGflrgpNa2wP0W9IiHx2t2TxQX8881EbF/H3/LDqreyNR7LHBXXgPk1j+H5V/MOGAqG5ntlvq2SdQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-43.3.1.tgz",
+      "integrity": "sha512-VqIhhPwMgAzmPqjvQUQYaFmCFglkg203W+LSVCwrvgVZ9mVtKbkhwCHBJnLhG7qatar7Gg93bObfAFdAjsaR2A==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-44.1.0.tgz",
-      "integrity": "sha512-cBUtojLEreXNYV54B/FT1WBjV+dU5i8vsVKBmYw2QOxmaWl4i/wyEtzPh21Ytcsy2ApmIMT/X27ZppffnKcyGQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-43.3.1.tgz",
+      "integrity": "sha512-cnQ+kCPYH5GiSe5S+13Fr0vuS7DzT4Onx11fvOkssUujtAJ1e/C7hNf5Ehd+SOAgr5IzevutA/+OeR2KHGjIag==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-44.1.0.tgz",
-      "integrity": "sha512-8BbS0y1YSGnQAiA6rTps05DIJ8CcdbGYb+1XFb8QOUCzJenFzNGAe4gnlEPw0zW1C8ZjdahRY1K2Fcb16/q7TQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-43.3.1.tgz",
+      "integrity": "sha512-QgHxZtWpclzQ5SUrh1oMsGFCvjykxge5IKe96iKUyAVrhyQp60RhW8DdAElHnPUg3wwILMYE7cKMphknCxcVkQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-44.1.0.tgz",
-      "integrity": "sha512-iFrtDVkXhbHHTJIs+yw0x9X/uEH0kyjQ5pQZM5fAzX6g9TFd71iiJ2l8xBSefXRcqEEPVaMWZgikBeRHmQDyOA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-43.3.1.tgz",
+      "integrity": "sha512-CPU50tumKH7rJ6f9QEB/LHSyzKul9xP/43F1IesvOBWnOkAxQ2QI51oORT5WdKn4B0Z56ojAm48Q/ZUtsef+3w==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-44.1.0.tgz",
-      "integrity": "sha512-CudeLs2RvADdchJ6FFznsNrMYHDcOrj8CGuSgyTW9PcsnhAzUOYWuaunJ3xXd8MXwu6pGwEReVYuouc2JQQg6A==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-43.3.1.tgz",
+      "integrity": "sha512-M7npJRhLoZksnvjZ0fS+6hbAN4RebgZCE2bT9b3Z8Df2Alfy0GJEwJL5aQsYpr+78QFeytTpqzjxXLNLjOyEqA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-44.1.0.tgz",
-      "integrity": "sha512-+tDlzrhOrl3TMlj01DsGJwQEsrXZl6A7fD4gFfYS3rO9sgGZSLU+fSxOwWHdQyBp1ujiJGsGFXmKFAUZxs7M/w==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-43.3.1.tgz",
+      "integrity": "sha512-duTA7harmvZPZ2LbJ8tHnOrhx5lGk6AGavbDzK2xuicMncivm+amrkl/b771uA3Rr6gclHY77ZPcOuVaK+dp/g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-44.1.0.tgz",
-      "integrity": "sha512-lwUAtK68GfNVr1yI+VLom54K8F5bRZee8HKkzFZPgTCANYLUnmHGUNF9La7qETeqjNV6bljUnKwn/knOeserGg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-43.3.1.tgz",
+      "integrity": "sha512-PuR6uJ/SKvaXIgqTO3MUnX+00/xB/TalStiVqZqqG0xlYg47/eb6hul+4fmTPV7ahlJaon6Y3nO49TsPbbhApQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-44.1.0.tgz",
-      "integrity": "sha512-ZlFa3xi8vSCCqs4cvfxjZrcXz87i7XIKAd+eTQdwoInQDJHnGpUcM67hKIMSU3E8AjEz+tXdsaauxSofZTS+zQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-43.3.1.tgz",
+      "integrity": "sha512-aVP2FqQP7okSAorQoItcYRbOd0J2O1ubGjtvGGzl3uC5TuKAtlWYWcBfiVTHKxCCtxywPRiEgBxwoGuB5mlwhA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "ckeditor5": "43.3.1",
         "marked": "4.0.12",
         "turndown": "7.2.0",
         "turndown-plugin-gfm": "1.0.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-44.1.0.tgz",
-      "integrity": "sha512-ymG55dCUv+i0o0th4+vYMvVHhC2DXTs6J+5t40tNvdMS7apt882Tbq9vAE6iqgQZbtQVVlRpQbGD0UByBO5LVA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-43.3.1.tgz",
+      "integrity": "sha512-3xMIaH/NTNEKv+lu1cRIIPGgDJgYI1DB+5NMXNVL3UGQkXdqW7PtgFDsOnhQwTAbyKpy+fHDngLb3eZuRdDkKw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-44.1.0.tgz",
-      "integrity": "sha512-LJ2aT5nJ9I8eZT/E/RqD/iPv4fyU8MJqtGQXExEwwAfQDqkx0X5u3mv3uAR/HhyFyj6jFw+z26bTdt13wdSaEw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-43.3.1.tgz",
+      "integrity": "sha512-yrOdynVNOS72RjTjhFHzv3Ofbm0eTBKFhuibxdKFfHtTR0QIqSVB5jU+aW1+Jq5LG73E+9eYtip5paSjkqJMWQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-44.1.0.tgz",
-      "integrity": "sha512-V9xOrUqLxnrOGXOiQVu4QGLV0zam3xMCi+vVR3/jFrVEPRCY1swdC6JhT4PAYt5lPBbrlmyF7u+pZjal8I7F1Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-43.3.1.tgz",
+      "integrity": "sha512-2b0b4mZtRIHAvN/MFAVeqiGt58TZI7ixLcgJo0MHNesYlIk6v13opDWhQ9oefNe8OwJMkD3fAHMlAcg+fUqA9g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-44.1.0.tgz",
-      "integrity": "sha512-6uNuctQnPTr2WFcyKGdTQ/1gTkGmIhiZg8y9UMIY74aEW9AQfGwCaBkAO5AveaBTfmGBkSsAISS3T8k5OGsV0Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-43.3.1.tgz",
+      "integrity": "sha512-6AI2GGJveEm/2GESUY01wSPM7AeqHqVuX4Hon20uCAXHYCQkDubOHJ0yV3oFXl7iHeO6Ue2DdlSLayIUXCLoEQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-44.1.0.tgz",
-      "integrity": "sha512-tfERMEQRrvM5zdZuiWC5IjCPtUrpncXY4ewn9mcGJ5KqmLaX3e+2dN4GVZpcagwOtZNQNQBONZnuWt9ZVkquFQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-43.3.1.tgz",
+      "integrity": "sha512-16ry56X+uXuZEzGZwLS8zpX2DtWN/CHHu5pSz0r2VDZ1zUGLsq/MXutotZfzMMjgdED3x4mJRQE+WgiyRrlKDg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-44.1.0.tgz",
-      "integrity": "sha512-NIhtkFoDXNpOaPBDH6dDTU2BC3GUJ1rE5gUV0i4hrtOeERuk9EdkADCOBEHEm7UC31kCQ4si6wkry+d4oZ5FMw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-43.3.1.tgz",
+      "integrity": "sha512-LLf1KB11jeYLDpQPq0d2QVPxQxp9kEibPAF4rGD4stPpRx9d+DbwmE59Y5wVASKvYJo+yNpR9CGWsE4ZgjwTWw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-44.1.0.tgz",
-      "integrity": "sha512-97ppktKeKIhGYrRKwfzVP0DOktcaY4gFXEtKINmse8kw0C7jO4SE82sDJxWSP/3h74oncZzd/q/Qa6P65JmhWA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-43.3.1.tgz",
+      "integrity": "sha512-m7zvvYzHN/HExT0NoILXauVFI/AKQyuzPqqCI/VO1Ft5mLswXGuK6vmO1U10SmGz85etYZjEipKuouf2Anyqxg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-44.1.0.tgz",
-      "integrity": "sha512-dsjeug3TCn32idHe4XWaD8ZBtKloAHSDYzv05uEuJDTEkTnSOp8ynVxUCKlTTMeHKjpRPr5kaxJkycqnxOqsvw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-43.3.1.tgz",
+      "integrity": "sha512-L6sA6UrUPy4Q3AzF8yQGsgEadO1IcZv53Ijevk9KuD7dwLF4f9x4ukUFLlGRpoYHPAW/+RpADp2PPegjKHo9QQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-44.1.0.tgz",
-      "integrity": "sha512-jQH9745sYWpQcZXC4z1lNS4XqrTJWHljWEMa4KKTZgo6zjR/L53tRZdIKbE6O/JgaW805Xpl74cJGXJvwre8VA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-43.3.1.tgz",
+      "integrity": "sha512-oYQ8uF6hmlX7OefpJ0FflvKddAkEffg3fKMT2FAINwqxhX+O7h9RQZ79AiOkTab7HUTIkbhM5AlhFJIXiX0Z7Q==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-44.1.0.tgz",
-      "integrity": "sha512-qPjba3VFXgRnnEjlZAfv1XgfC1jNpYUWpfxlniZixvcZ1bEOzEX6rkEqBioNgGFWBU8siPTPiwI2mmT/8/58Vw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-43.3.1.tgz",
+      "integrity": "sha512-o+IhZnjMmoF2qd4l1GqQqroeIEA29QAIOYfvrdMKZGrzVGmjbvwyNkbJRyZlAYhZqX8tLDPaPGn0tl+onhWtzw==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-44.1.0.tgz",
-      "integrity": "sha512-gg/tWANOiJckvXxKqwthkvR531bPuen+lJN3y2qnqMKMQLLNbWWIUoTuE3PZRHDprT0JmTjnvlHrwsaSdpOkVg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-43.3.1.tgz",
+      "integrity": "sha512-Pq7WthQAiKa3A3q82bHqNRjQ/xlOpSX9kZHLm+CDH8XACxZbBF6Unz4JPR9zJRuQxkoFs314DM/PG6pPZQgXXA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-theme-lark": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-theme-lark": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-44.1.0.tgz",
-      "integrity": "sha512-btw7qEPjrdp/XigtXOXy1KkK481PEeuJ5xdPD2xLlWvZkF0tGbEqIpDIMxkW1w7NmmC+5Aa8qJqXkV6dN4jZ5A==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-43.3.1.tgz",
+      "integrity": "sha512-3iwrtISndl5hc+/LuSXht69xqkEv95zg8Qxv+ovREA3pvtgt5u9O0t7ELcmUeTTEs/hJkF2FDplIYQj5zIvO+g==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-44.1.0.tgz",
-      "integrity": "sha512-A6udrCj1IxuiPE8OGue/aDtoqs8ZAPsbabnT9OS46WBlDGjXaSStXD7Dx6uJwEkaRdmhdGaObi4UnF7gkHRXHA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-43.3.1.tgz",
+      "integrity": "sha512-2+ATPa5y4ZUkak5xFTTDeUPhuCAYB4OPNt/QjMvrQjpEwXoWDJ4f8GqR9oFFsqEGMm65GrUp/xIQW8WRH43Kng==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-44.1.0.tgz",
-      "integrity": "sha512-8iQUW5apSYFrsJhguW0ROPBf+gmKhtP75KIeal6GdEtYlOMA8vP/ixUhQB5HZBmecfAVULyu1fF4YfGzHelZhw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-43.3.1.tgz",
+      "integrity": "sha512-Qr3GkKELnG1EY7Bu9dGQBkGTqhVnygeHKDCTEG9m218shYsI5L6jFftGUzWmJzMpm3hNFkyYv+1YWaIoqfRzIQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-44.1.0.tgz",
-      "integrity": "sha512-Ym9ZKtQBqh5xOYGVa+va6CtYJSbhqIfVOsoCRZnMTzg3RTfwp8F78yeWUdplF6DS4JaM966yQumX9DcJGYn5AA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-43.3.1.tgz",
+      "integrity": "sha512-kAgeGx66jT31FFYwAoc43oX5ehQtiYE57OJWlPTXrDXxyq0Y+LYFW2/bp4UVYdZK+OKv9dp1Do3VQfxJoGzFjg==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "44.1.0"
+        "@ckeditor/ckeditor5-ui": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-44.1.0.tgz",
-      "integrity": "sha512-YlIpXSp2mkzgCCwqa4Dd870K4UvKsjlHRDod50G8VSz2qFCkE6PaLGGBAci1IoZ5nBXZMpCrnhrkQ1jAJwx2RA==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-43.3.1.tgz",
+      "integrity": "sha512-sK45GlrOHqWOphVnzDKe3kofVJGhSRk34UQJnyXgMN+35QJqypnJeBYBnnHWL8+nK0S4zk9oQO3PuiRH6gg/WQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-44.1.0.tgz",
-      "integrity": "sha512-Qga/eO6/4rCzK6m/JLMVq0gbgNDEV7K/J+ida1UQFYxrMric7qfriusT1q0Y+6jFYuGMdyLg0e0imORbMyw9Zw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-43.3.1.tgz",
+      "integrity": "sha512-dbR4FK6mCkI89h4Joyf1PZt0Xsq0N+sZg05Z6BpYz6GS9U35C7J9bHxN469dvaIc8bJws4eYJ5x+St3LcvlduQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "color-convert": "2.0.1",
         "color-parse": "1.4.2",
         "lodash-es": "4.17.21",
@@ -845,33 +831,33 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-44.1.0.tgz",
-      "integrity": "sha512-sULkc7Pvbc431uZCjzcAKd//jYE3B8fT8PEOFG8pYRnQJHc5GyodvH0RmXDhCtKCGtzvh1Dlpb4iSNpPNpVvJQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-43.3.1.tgz",
+      "integrity": "sha512-UxrWPlHzL/DKuxp4R5mlQvy995Ozehh5hQxY5yvL285Dzv6PY5pk627Wv/qS8AyfLMyVNiFO9bDWBIcT9igQRA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-44.1.0.tgz",
-      "integrity": "sha512-+608NL4Jl6t2PA02Ft8myPV5r2oXwD+4wTCLKg4Oh2KPQYCyGOm5vj8dLxwWNsbMXZrdPxeQOK3UHq8bxYyI6A==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-43.3.1.tgz",
+      "integrity": "sha512-uOEhCgqgiK4V/CnbnuwHU/NUOG4ioQE5KUUtVmRG2xjQKg5C1uIT2dig+wnKw8vOdwVTMD2hVt7/OC/whQuheQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-44.1.0.tgz",
-      "integrity": "sha512-PILjaPvEMuQ0qlnPAFeNTTQcLuXgGionSxaxF8HGnZolaqWnsJ11xGYxqUslNOGtdZNp/88/FC9TjCY/ksiibg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-43.3.1.tgz",
+      "integrity": "sha512-4CyM3AP+DcfuPuw+zceI3UTh3HcusnvFVeRPPw6j3Qe29/jadZYsdvkdo9KsDaiwgx0ctooKCuY9SfAcd/CZNQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
@@ -886,39 +872,39 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-44.1.0.tgz",
-      "integrity": "sha512-fTwYEW1TbbxC7PVmZtfWfwHT5aMREfBTDvH3KQWKpowTcoAiMBlQQKA/lvkRJ1bFMp4AZFjqs1IWZyap/sanAg==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-43.3.1.tgz",
+      "integrity": "sha512-d9gh0QIrrImIe2SFLo/IBLdpgC9REVkvUTv//qLbUaM2ffBboMnpJYPAB/hgl8ev4lkDvCrivlGjc/80COfGTQ==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-44.1.0.tgz",
-      "integrity": "sha512-dBG1EFJjq38wF0k1p3R2yIfZRHwgY5+hLuF1sp02q/lUJu59U/rPscfjj4dGpE4eKaqCD9z/UNEtOjPGnaJzKw==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-43.3.1.tgz",
+      "integrity": "sha512-0naXUVC6BFLnuj3lu5aTfRxmqV6py9+zqGHdJJZ0x8uSg9qcfUCLEQvA59bqzNteRya/lZeZhYKj8IcGnbB1oA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-44.1.0.tgz",
-      "integrity": "sha512-dM8jeZfRA2nodWdE1Ty3ZzaAl3M523ri9/ahLpG/JcCud2QZn9XRPrEwaIxC/1VtZg/Z2SUuI2LcPrbtPkQ0UQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-43.3.1.tgz",
+      "integrity": "sha512-W0Ic7y4/ePVqW22pHuXv5HRAbaDJFO13rUqyTZqU2H2ExZdMbJN6eT/UVhnO1XvKs/+jdKGO3LGWXt9QmmtkhA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
@@ -2753,69 +2739,68 @@
       }
     },
     "node_modules/ckeditor5": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-44.1.0.tgz",
-      "integrity": "sha512-6e1KFUE2giaSI0ZOKfAAFF5Tk7PF5DCyKVROPY9/46tti9AZpUFUzr7NhBsZjyMiMX1eqxqfsSZT7f9tKgcVAQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-43.3.1.tgz",
+      "integrity": "sha512-ZZ6nIdlr9rCCp21o9d5/mVUeVPwpQKEVxkeq1MU/Jax1w8U6rnMiQWxB954Ky/HNjhZ1v1ll2+VRzb7XA+1emA==",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-alignment": "44.1.0",
-        "@ckeditor/ckeditor5-autoformat": "44.1.0",
-        "@ckeditor/ckeditor5-autosave": "44.1.0",
-        "@ckeditor/ckeditor5-basic-styles": "44.1.0",
-        "@ckeditor/ckeditor5-block-quote": "44.1.0",
-        "@ckeditor/ckeditor5-bookmark": "44.1.0",
-        "@ckeditor/ckeditor5-ckbox": "44.1.0",
-        "@ckeditor/ckeditor5-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-cloud-services": "44.1.0",
-        "@ckeditor/ckeditor5-code-block": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-easy-image": "44.1.0",
-        "@ckeditor/ckeditor5-editor-balloon": "44.1.0",
-        "@ckeditor/ckeditor5-editor-classic": "44.1.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "44.1.0",
-        "@ckeditor/ckeditor5-editor-inline": "44.1.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-essentials": "44.1.0",
-        "@ckeditor/ckeditor5-find-and-replace": "44.1.0",
-        "@ckeditor/ckeditor5-font": "44.1.0",
-        "@ckeditor/ckeditor5-heading": "44.1.0",
-        "@ckeditor/ckeditor5-highlight": "44.1.0",
-        "@ckeditor/ckeditor5-horizontal-line": "44.1.0",
-        "@ckeditor/ckeditor5-html-embed": "44.1.0",
-        "@ckeditor/ckeditor5-html-support": "44.1.0",
-        "@ckeditor/ckeditor5-image": "44.1.0",
-        "@ckeditor/ckeditor5-indent": "44.1.0",
-        "@ckeditor/ckeditor5-language": "44.1.0",
-        "@ckeditor/ckeditor5-link": "44.1.0",
-        "@ckeditor/ckeditor5-list": "44.1.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "44.1.0",
-        "@ckeditor/ckeditor5-media-embed": "44.1.0",
-        "@ckeditor/ckeditor5-mention": "44.1.0",
-        "@ckeditor/ckeditor5-minimap": "44.1.0",
-        "@ckeditor/ckeditor5-page-break": "44.1.0",
-        "@ckeditor/ckeditor5-paragraph": "44.1.0",
-        "@ckeditor/ckeditor5-paste-from-office": "44.1.0",
-        "@ckeditor/ckeditor5-remove-format": "44.1.0",
-        "@ckeditor/ckeditor5-restricted-editing": "44.1.0",
-        "@ckeditor/ckeditor5-select-all": "44.1.0",
-        "@ckeditor/ckeditor5-show-blocks": "44.1.0",
-        "@ckeditor/ckeditor5-source-editing": "44.1.0",
-        "@ckeditor/ckeditor5-special-characters": "44.1.0",
-        "@ckeditor/ckeditor5-style": "44.1.0",
-        "@ckeditor/ckeditor5-table": "44.1.0",
-        "@ckeditor/ckeditor5-theme-lark": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-watchdog": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "@ckeditor/ckeditor5-word-count": "44.1.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-alignment": "43.3.1",
+        "@ckeditor/ckeditor5-autoformat": "43.3.1",
+        "@ckeditor/ckeditor5-autosave": "43.3.1",
+        "@ckeditor/ckeditor5-basic-styles": "43.3.1",
+        "@ckeditor/ckeditor5-block-quote": "43.3.1",
+        "@ckeditor/ckeditor5-ckbox": "43.3.1",
+        "@ckeditor/ckeditor5-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-cloud-services": "43.3.1",
+        "@ckeditor/ckeditor5-code-block": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-easy-image": "43.3.1",
+        "@ckeditor/ckeditor5-editor-balloon": "43.3.1",
+        "@ckeditor/ckeditor5-editor-classic": "43.3.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "43.3.1",
+        "@ckeditor/ckeditor5-editor-inline": "43.3.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-essentials": "43.3.1",
+        "@ckeditor/ckeditor5-find-and-replace": "43.3.1",
+        "@ckeditor/ckeditor5-font": "43.3.1",
+        "@ckeditor/ckeditor5-heading": "43.3.1",
+        "@ckeditor/ckeditor5-highlight": "43.3.1",
+        "@ckeditor/ckeditor5-horizontal-line": "43.3.1",
+        "@ckeditor/ckeditor5-html-embed": "43.3.1",
+        "@ckeditor/ckeditor5-html-support": "43.3.1",
+        "@ckeditor/ckeditor5-image": "43.3.1",
+        "@ckeditor/ckeditor5-indent": "43.3.1",
+        "@ckeditor/ckeditor5-language": "43.3.1",
+        "@ckeditor/ckeditor5-link": "43.3.1",
+        "@ckeditor/ckeditor5-list": "43.3.1",
+        "@ckeditor/ckeditor5-markdown-gfm": "43.3.1",
+        "@ckeditor/ckeditor5-media-embed": "43.3.1",
+        "@ckeditor/ckeditor5-mention": "43.3.1",
+        "@ckeditor/ckeditor5-minimap": "43.3.1",
+        "@ckeditor/ckeditor5-page-break": "43.3.1",
+        "@ckeditor/ckeditor5-paragraph": "43.3.1",
+        "@ckeditor/ckeditor5-paste-from-office": "43.3.1",
+        "@ckeditor/ckeditor5-remove-format": "43.3.1",
+        "@ckeditor/ckeditor5-restricted-editing": "43.3.1",
+        "@ckeditor/ckeditor5-select-all": "43.3.1",
+        "@ckeditor/ckeditor5-show-blocks": "43.3.1",
+        "@ckeditor/ckeditor5-source-editing": "43.3.1",
+        "@ckeditor/ckeditor5-special-characters": "43.3.1",
+        "@ckeditor/ckeditor5-style": "43.3.1",
+        "@ckeditor/ckeditor5-table": "43.3.1",
+        "@ckeditor/ckeditor5-theme-lark": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-watchdog": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "@ckeditor/ckeditor5-word-count": "43.3.1"
       }
     },
     "node_modules/color-convert": {
@@ -6962,662 +6947,649 @@
       }
     },
     "@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-44.1.0.tgz",
-      "integrity": "sha512-RCamOkjMHlhUg7MhRbP/ZZJ7mq0zk1hj6Hg25efv22WHb2SNnesiwzLtYoyc6ess72/1CYpgZPfamhxsOTXoMA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-43.3.1.tgz",
+      "integrity": "sha512-fOnEq31euR9B/awWZCOc8KfgLwwG4ACtqBhSv7Hu6VOgHa5TKWyWAdhr9ILSiUp7NMfYJoTQStbxcXZIWPqQXQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-alignment": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-44.1.0.tgz",
-      "integrity": "sha512-t+xIuGiG9pvG4lkglSQfXwoZU9zCPUvrBYISI8G0WAJXdWdmyWUN2Vj84CKQQ6LRgnqq/eybSR2O2l02psgtZw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-43.3.1.tgz",
+      "integrity": "sha512-E+04zNdNBFDNgQajrWl8iFQqA1sB29y/XDFFRK+bzhcUaWdMadr88yodjHHdcax8/zI+GzBElCvWGEGchyrL+Q==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-autoformat": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-44.1.0.tgz",
-      "integrity": "sha512-JHJh+iD9//sYsVlwdGZTV+ScPMlWjqFuR7xwF2QbU7xYGMqTy4mPnFvkT6fF73e3PZvtAzgENLU45pUAS9oo/A==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-43.3.1.tgz",
+      "integrity": "sha512-hSQxIXIObrMfxijMPmz8odOtz/wD5SwuGZWVoF5km3EtRQxZwAcQr1Vjy+VHHPo6PZ+o3YoLP+IHCaULtNobYg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-autosave": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-44.1.0.tgz",
-      "integrity": "sha512-KlkJcgu5THkfdwzYzVa9zKkADGd8J5VW5kRrRSK4oJYONA5mmiZ9UsIcoIk2QbGnDGnZW1Iih5Pjrvz0HYjIKw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-43.3.1.tgz",
+      "integrity": "sha512-28667m7ea0wBZMb3uIzgipanB4DrDvKn4o+mRUDExlRT8M14vn1u/ILX8ZJy28Rihbg2wPcVh6rP3zoQjcucHw==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-basic-styles": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-44.1.0.tgz",
-      "integrity": "sha512-/pZ0wBdXlv8AX43O/nZ4ENg8Xk/SwZZMAJKKVZa3SwtxNRmeGYTNKIEQEQouWF1PLz3SEZ8L5sS/j9AYX7f5Xw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-43.3.1.tgz",
+      "integrity": "sha512-1RBnPmgsIoxPL7wZhId2KsfPujITbEAfzHhi0c6m4kuWlkmcVXYldWvUvCvAUguAznx4LOxhKlp6RdFSPTFTbg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-block-quote": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-44.1.0.tgz",
-      "integrity": "sha512-mApNvTckUbAjeHFaPg7+Je3zTkJDDsM5FWNJJuzaRhl5TBvyW9BM+p7AN8B9cx+pj2Srzlbu+056c0jg4ibCIw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-43.3.1.tgz",
+      "integrity": "sha512-cgY4GKwMlIVLnhszPoc1ortp+T/s3TLowrwRFtWYxTKSsHWBGFlZUL6oMASPunpXvvJqHcgnKlCMxVSh2VMCkQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
-      }
-    },
-    "@ckeditor/ckeditor5-bookmark": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-44.1.0.tgz",
-      "integrity": "sha512-gzUOspXUb4sN308JbeVWLGxGdFHeYpobiBn8Zj2/Niw6y+/4ZQfssn7fLhKnoHM12bzoxYYq3DvcMUrs78Ukvg==",
-      "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-build-classic": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-44.1.0.tgz",
-      "integrity": "sha512-/zuF39CLlRz0+15yW2fOeopJ1Dasfb2kOhyNbyLnFhaYPvAGZjqAlepYdRXuQRfjclYURimHlZbvIlzALqG2EA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-43.3.1.tgz",
+      "integrity": "sha512-ilc1YyOyIhknNd1NSAiHmXZewazGuIHYl5rHPeCiBShNGTjnh9DrA5hXSk7JBc1BpAxpxd4ojKR1nJ0dvkaR7g==",
       "requires": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-autoformat": "44.1.0",
-        "@ckeditor/ckeditor5-basic-styles": "44.1.0",
-        "@ckeditor/ckeditor5-block-quote": "44.1.0",
-        "@ckeditor/ckeditor5-ckbox": "44.1.0",
-        "@ckeditor/ckeditor5-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-cloud-services": "44.1.0",
-        "@ckeditor/ckeditor5-easy-image": "44.1.0",
-        "@ckeditor/ckeditor5-editor-classic": "44.1.0",
-        "@ckeditor/ckeditor5-essentials": "44.1.0",
-        "@ckeditor/ckeditor5-heading": "44.1.0",
-        "@ckeditor/ckeditor5-image": "44.1.0",
-        "@ckeditor/ckeditor5-indent": "44.1.0",
-        "@ckeditor/ckeditor5-link": "44.1.0",
-        "@ckeditor/ckeditor5-list": "44.1.0",
-        "@ckeditor/ckeditor5-media-embed": "44.1.0",
-        "@ckeditor/ckeditor5-paragraph": "44.1.0",
-        "@ckeditor/ckeditor5-paste-from-office": "44.1.0",
-        "@ckeditor/ckeditor5-table": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-autoformat": "43.3.1",
+        "@ckeditor/ckeditor5-basic-styles": "43.3.1",
+        "@ckeditor/ckeditor5-block-quote": "43.3.1",
+        "@ckeditor/ckeditor5-ckbox": "43.3.1",
+        "@ckeditor/ckeditor5-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-cloud-services": "43.3.1",
+        "@ckeditor/ckeditor5-easy-image": "43.3.1",
+        "@ckeditor/ckeditor5-editor-classic": "43.3.1",
+        "@ckeditor/ckeditor5-essentials": "43.3.1",
+        "@ckeditor/ckeditor5-heading": "43.3.1",
+        "@ckeditor/ckeditor5-image": "43.3.1",
+        "@ckeditor/ckeditor5-indent": "43.3.1",
+        "@ckeditor/ckeditor5-link": "43.3.1",
+        "@ckeditor/ckeditor5-list": "43.3.1",
+        "@ckeditor/ckeditor5-media-embed": "43.3.1",
+        "@ckeditor/ckeditor5-paragraph": "43.3.1",
+        "@ckeditor/ckeditor5-paste-from-office": "43.3.1",
+        "@ckeditor/ckeditor5-table": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-ckbox": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-44.1.0.tgz",
-      "integrity": "sha512-J+vJckr25Oi3KjJcTYIIUFa2KIXHitknW8iNPegavCV/FFNieTezvvpjJzROlWRiy+U7CRYvgrNbSJXHx5pR6Q==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-43.3.1.tgz",
+      "integrity": "sha512-KObL9w/QBWJi0lG2zfm+x124Kzd7aVt+UaJHJEwsAPwhZvqM0LCUeR6wwb0oCN6ph5qrCjXoj09z7z8Txk5IwA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "blurhash": "2.0.5",
-        "ckeditor5": "44.1.0",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-ckfinder": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-44.1.0.tgz",
-      "integrity": "sha512-oRWHiejta6irRuO78KmtQEiYRrzcad+BycTrFsLRCIZp0hzKx5Vp5olAhXodX+d8gZaV8fJJpswdK0LTjrfKNA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-43.3.1.tgz",
+      "integrity": "sha512-Yji6c1/0H5fExDcT+NNyQQePx2cd8Ul1Xuko1UVmsLN2Vhi7VIDJjEkCFndJozd8VQqI62Obe1GTyjmapBV5+A==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-clipboard": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-44.1.0.tgz",
-      "integrity": "sha512-Z5P1P6ATLVy/c7AvI3Akt3mEqQfCnhZmz4EdAS7sF34WTayrHQ/TQjdte/0mN+6LXcQV1whhXe1xLM7GVsG+bg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-43.3.1.tgz",
+      "integrity": "sha512-Ke6fVEy1fF3AWHMtKvF1pAoDYBVOG4q+gDHD8+dcV6KPK1uA/CR0mw6TZsslQQquT4jC79y05IWu2bq1Mxv01w==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-cloud-services": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-44.1.0.tgz",
-      "integrity": "sha512-3Nr8EM6CyRpNkmm+7tbhg/4H16SY5Tqo0TLGHtXdyRxx7y2GLev5OsN01qBhSSGifALTCHyOWymxt5Qo9V5wXg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-43.3.1.tgz",
+      "integrity": "sha512-JppySF+uWedDXPTVZBsTfZCe3qedDAdWSgw0Ww/qi4/sPFcgf/MaQ0LBHbl2Ii7JlJjng82F1F2kv9Ny/Rkauw==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-code-block": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-44.1.0.tgz",
-      "integrity": "sha512-2z4ULLehgMjwxvo0a26UkA2p3MdDITGVDpt7FZkO+P9XCim/j5DdXK4/xVNXLbrOifpFq/5kfrAZvjDX0lPMIw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-43.3.1.tgz",
+      "integrity": "sha512-UGhGCPNfFXLua0TmszLSWX6BlkemaPULN1EZ+FBPsUZb757qWWWVWI9GKLmAc4jSPqOv+azU+JAZJzX9bE1oYA==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-core": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-44.1.0.tgz",
-      "integrity": "sha512-vBxHT/g37uWM5QKj0i7++clGd85htX9rPtlqzjz3I26NJQvcKCmT39Szv3oPFzAJKuUaqKso5iLq+Sw+VtQRBg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-43.3.1.tgz",
+      "integrity": "sha512-6pil2OF4auF3PKrg1Oa86CqC91ZYc+NuHih0ebM0JW/I06d+0smnJg5dw4yN7mKbghbJS8mNrusxA5cf6Hkh6w==",
       "requires": {
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-watchdog": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-watchdog": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-easy-image": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-44.1.0.tgz",
-      "integrity": "sha512-hmn9MmVebb/abTBq1ci2fYi7uK93Dt2F3lDYErqsFWCxZ4S2PQW3+qON44E5phE9aDKOLEZ/B61niGrLgcWS5g==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-43.3.1.tgz",
+      "integrity": "sha512-Cd5NojL0Vfa1SQj6uzbP3oSHvQY5ys2hXF/2jNsYKLePTCybSvGkg5REv1JifM6kSNRH1VXdad7a2LkqvXnCnA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-editor-balloon": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-44.1.0.tgz",
-      "integrity": "sha512-BVxO3WECurMZEhxIVb2JMqeMcqaqefvc/YfrWNRriVyK7muW47EH74IIZdCXSm7g5i0npEIk808sKqA0t/xR0g==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-43.3.1.tgz",
+      "integrity": "sha512-klS1FZG29nJE/XbfRXrXtwYU/9uCFdi7xGbYfaJnmyNt54h46aiquKacosbiffA87Tr5sT3Oqm3dBbNlsU158w==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-editor-classic": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-44.1.0.tgz",
-      "integrity": "sha512-rZtJ1KpJGxW8iWE0wVhp9giiYiu3XypjsmthkK8oeMf4+8wTr3ySncLKKts3/BDiAcFdJnog5lv5LQbrAVqO+Q==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-43.3.1.tgz",
+      "integrity": "sha512-wjBeXUQBuvz6CmGlb5XncJ9cHE7tozU6eoorycfSTQCzqr5uE57LWTlKclU42w7MgS2ya5V2kLnncr0ZqrZ2Vw==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-44.1.0.tgz",
-      "integrity": "sha512-pRnDrPVyIM4uCLCjhgzvRk4v63Cc1u9Nc21yx1igswvxAfhGx2BMO+JiC6+8PAHT/mOSbgFB83N+A823sms3uA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-43.3.1.tgz",
+      "integrity": "sha512-aw2iZ+WCcCu9sUAnsHhsXZWLeVPyiLhZfpZDuEWjPlvsrCfT0RfSuwMcfx7l9PREA09VR8+6MTstm61EG8dmWQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-editor-inline": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-44.1.0.tgz",
-      "integrity": "sha512-NglsnVkzioMU9XirmjyTM/DKSL/rzkBBwFaZFiTVyGfhuVzTUClPxGtxKOlML2v0Mtqg/OdRUMPMIo+qtjymeQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-43.3.1.tgz",
+      "integrity": "sha512-3iZiWl2aM1bCnS52NeBoAqCVowABhWrBlns27JEGKZ+LNPZroMie7uKuMX3YQGYE2awFnsyP6XofoJtu6CcKCA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-44.1.0.tgz",
-      "integrity": "sha512-NAMBGIDn/xMGHXv2IeLRDa84yW9OwHri9H5NdJJ4F+gFtiQbOhIhTQj4nZ8TuLIaYr2NOUrTpTrkw3frgd0lLg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-43.3.1.tgz",
+      "integrity": "sha512-HDgfTuotrHW91AZ+x+lumwo1tngRRZ87dnHT8kjSRFWAeXPSd2Kw986++Oj9K080+idZaYLF+IutAOqvCT32sw==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-engine": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-44.1.0.tgz",
-      "integrity": "sha512-+149hsqfZX+Q+ho7P64XUrIpkLqX2jGBuEWjC2ZZYujv1ZIOWOMihkpJL8jE6Vcplee6vsTXGSj2sIHNoOp+3g==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-43.3.1.tgz",
+      "integrity": "sha512-Fkv3ibQLDPVHFH0z4/+gA5wrkPVWOen+Cjv/NecNBeAszZUo+F2j9RwvQ1zHwtGb0RWj3+BWOPgo8jhSe7tFgA==",
       "requires": {
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-enter": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-44.1.0.tgz",
-      "integrity": "sha512-NmtqxEov25rYRN8Uq7MRabsqYfvL6ZNj/mvBHqn3PE9aHE+lTwD51D3zgCw1RN2sipXsvedwo3g+NynAtS/HIw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-43.3.1.tgz",
+      "integrity": "sha512-xaHnU2RbfYi8ilfN260pB3YDvJ9lE4SfiFQusyRdWkeBo5gDAGBbQY+qCC/hmxkr/yftNZfK+d7Ow93xXtqEwg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-essentials": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-44.1.0.tgz",
-      "integrity": "sha512-UWSc2lSCqztfy3LLeuHfyKU/oSbFyw/4KEbQso9DsMPQ4vdmX/sW6BoklCYF9mPJrg+zNSseJj9T/M1Q+Z6U0Q==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-43.3.1.tgz",
+      "integrity": "sha512-bZtzXhmBz8XF9J4eUxOjURmw0HJPKIqo18a6vNxg07W8z3ouHMb9ke//4z4FF9N/1dbtA7a2+jIACO6WvXrX4A==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-select-all": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-select-all": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-find-and-replace": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-44.1.0.tgz",
-      "integrity": "sha512-SwZYRdXpYCu3t3+k9fxO8JXjNb/Q/OK3nmtVBNly/ZWYmORGQd3ua9XlipcnwIB8aBQqhuV/izDKqSiFZc23zA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-43.3.1.tgz",
+      "integrity": "sha512-U9dyK8yQgxGTUphRbqdUJbvfi5v7zzijCo3Kj51NxyWwOFh7SGReQxHDGn44DmSRold6lg4F1sbXeFdwu1o+WA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-font": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-44.1.0.tgz",
-      "integrity": "sha512-q4r7I7C2uG9gkBx9WlARNN5ZWp4USHVFS2kLTyMVAN1/iHAKIx03m+N3W0FTZVpXV+xscn7H6KaLcQXmWc4OiQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-43.3.1.tgz",
+      "integrity": "sha512-NOeBtScqMuBLVWFPuW0snleh7rMFkNb006yzDIG6JApnF3Vxi0JLQXub/lPHPgw5srqJ3z159DWT++exoyz/mQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-heading": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-44.1.0.tgz",
-      "integrity": "sha512-cROqN/dnq8xBdxMQoe+1Zjh8bfoVePh6WSl+wjcc4OIozYe/V2QAmCODpYiVm4RntenH0IidHteSTCqtGM4L9w==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-43.3.1.tgz",
+      "integrity": "sha512-cc8H027Y2OwvYDGMTbBSzE+oZaiLMZtlUnkgiolMw/OQ59ysONYi+KqyMzBMTuaXrkP3CLM57ZbsVGASQ3IQmQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-paragraph": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-paragraph": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-highlight": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-44.1.0.tgz",
-      "integrity": "sha512-bj7DBo1miBf6f7LPLiNa5inziXBKt6dFQupWAgJNJvPxYeGf4jTKDeVc9FLBESJ7eOWKjmCjaNeSsV2smHTAKQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-43.3.1.tgz",
+      "integrity": "sha512-XVJq1YP4IAaWQBAyY1xlKOfzkpnclUH8zTUPaW3TZUGK5t6W/vFT+KAzYfUp7PdBb+PP8/O47FwKTvIQBkbqFw==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-horizontal-line": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-44.1.0.tgz",
-      "integrity": "sha512-xwqQPJQsgwEvbZb3EqjFEcvj1tmlxcX9hFL9I66oGblfYNEIX8Q4DWxbjWCDrfY2IvLO3zNUDI9J5EcxSnd9Pw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-43.3.1.tgz",
+      "integrity": "sha512-zkKe0S9gBXwveBUzUuCBPWyrzHQor/zcMCCX9YQk1StUxtRRsURNvWOoFeoG+Vf5jMGSA2gpnBgIo70WrX4A3A==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-html-embed": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-44.1.0.tgz",
-      "integrity": "sha512-eFXTBHhvRIGflrgpNa2wP0W9IiHx2t2TxQX8881EbF/H3/LDqreyNR7LHBXXgPk1j+H5V/MOGAqG5ntlvq2SdQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-43.3.1.tgz",
+      "integrity": "sha512-VqIhhPwMgAzmPqjvQUQYaFmCFglkg203W+LSVCwrvgVZ9mVtKbkhwCHBJnLhG7qatar7Gg93bObfAFdAjsaR2A==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-html-support": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-44.1.0.tgz",
-      "integrity": "sha512-cBUtojLEreXNYV54B/FT1WBjV+dU5i8vsVKBmYw2QOxmaWl4i/wyEtzPh21Ytcsy2ApmIMT/X27ZppffnKcyGQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-43.3.1.tgz",
+      "integrity": "sha512-cnQ+kCPYH5GiSe5S+13Fr0vuS7DzT4Onx11fvOkssUujtAJ1e/C7hNf5Ehd+SOAgr5IzevutA/+OeR2KHGjIag==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-image": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-44.1.0.tgz",
-      "integrity": "sha512-8BbS0y1YSGnQAiA6rTps05DIJ8CcdbGYb+1XFb8QOUCzJenFzNGAe4gnlEPw0zW1C8ZjdahRY1K2Fcb16/q7TQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-43.3.1.tgz",
+      "integrity": "sha512-QgHxZtWpclzQ5SUrh1oMsGFCvjykxge5IKe96iKUyAVrhyQp60RhW8DdAElHnPUg3wwILMYE7cKMphknCxcVkQ==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-indent": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-44.1.0.tgz",
-      "integrity": "sha512-iFrtDVkXhbHHTJIs+yw0x9X/uEH0kyjQ5pQZM5fAzX6g9TFd71iiJ2l8xBSefXRcqEEPVaMWZgikBeRHmQDyOA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-43.3.1.tgz",
+      "integrity": "sha512-CPU50tumKH7rJ6f9QEB/LHSyzKul9xP/43F1IesvOBWnOkAxQ2QI51oORT5WdKn4B0Z56ojAm48Q/ZUtsef+3w==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-language": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-44.1.0.tgz",
-      "integrity": "sha512-CudeLs2RvADdchJ6FFznsNrMYHDcOrj8CGuSgyTW9PcsnhAzUOYWuaunJ3xXd8MXwu6pGwEReVYuouc2JQQg6A==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-43.3.1.tgz",
+      "integrity": "sha512-M7npJRhLoZksnvjZ0fS+6hbAN4RebgZCE2bT9b3Z8Df2Alfy0GJEwJL5aQsYpr+78QFeytTpqzjxXLNLjOyEqA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-link": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-44.1.0.tgz",
-      "integrity": "sha512-+tDlzrhOrl3TMlj01DsGJwQEsrXZl6A7fD4gFfYS3rO9sgGZSLU+fSxOwWHdQyBp1ujiJGsGFXmKFAUZxs7M/w==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-43.3.1.tgz",
+      "integrity": "sha512-duTA7harmvZPZ2LbJ8tHnOrhx5lGk6AGavbDzK2xuicMncivm+amrkl/b771uA3Rr6gclHY77ZPcOuVaK+dp/g==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-list": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-44.1.0.tgz",
-      "integrity": "sha512-lwUAtK68GfNVr1yI+VLom54K8F5bRZee8HKkzFZPgTCANYLUnmHGUNF9La7qETeqjNV6bljUnKwn/knOeserGg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-43.3.1.tgz",
+      "integrity": "sha512-PuR6uJ/SKvaXIgqTO3MUnX+00/xB/TalStiVqZqqG0xlYg47/eb6hul+4fmTPV7ahlJaon6Y3nO49TsPbbhApQ==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-44.1.0.tgz",
-      "integrity": "sha512-ZlFa3xi8vSCCqs4cvfxjZrcXz87i7XIKAd+eTQdwoInQDJHnGpUcM67hKIMSU3E8AjEz+tXdsaauxSofZTS+zQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-43.3.1.tgz",
+      "integrity": "sha512-aVP2FqQP7okSAorQoItcYRbOd0J2O1ubGjtvGGzl3uC5TuKAtlWYWcBfiVTHKxCCtxywPRiEgBxwoGuB5mlwhA==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "ckeditor5": "43.3.1",
         "marked": "4.0.12",
         "turndown": "7.2.0",
         "turndown-plugin-gfm": "1.0.2"
       }
     },
     "@ckeditor/ckeditor5-media-embed": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-44.1.0.tgz",
-      "integrity": "sha512-ymG55dCUv+i0o0th4+vYMvVHhC2DXTs6J+5t40tNvdMS7apt882Tbq9vAE6iqgQZbtQVVlRpQbGD0UByBO5LVA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-43.3.1.tgz",
+      "integrity": "sha512-3xMIaH/NTNEKv+lu1cRIIPGgDJgYI1DB+5NMXNVL3UGQkXdqW7PtgFDsOnhQwTAbyKpy+fHDngLb3eZuRdDkKw==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-mention": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-44.1.0.tgz",
-      "integrity": "sha512-LJ2aT5nJ9I8eZT/E/RqD/iPv4fyU8MJqtGQXExEwwAfQDqkx0X5u3mv3uAR/HhyFyj6jFw+z26bTdt13wdSaEw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-43.3.1.tgz",
+      "integrity": "sha512-yrOdynVNOS72RjTjhFHzv3Ofbm0eTBKFhuibxdKFfHtTR0QIqSVB5jU+aW1+Jq5LG73E+9eYtip5paSjkqJMWQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-minimap": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-44.1.0.tgz",
-      "integrity": "sha512-V9xOrUqLxnrOGXOiQVu4QGLV0zam3xMCi+vVR3/jFrVEPRCY1swdC6JhT4PAYt5lPBbrlmyF7u+pZjal8I7F1Q==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-43.3.1.tgz",
+      "integrity": "sha512-2b0b4mZtRIHAvN/MFAVeqiGt58TZI7ixLcgJo0MHNesYlIk6v13opDWhQ9oefNe8OwJMkD3fAHMlAcg+fUqA9g==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-page-break": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-44.1.0.tgz",
-      "integrity": "sha512-6uNuctQnPTr2WFcyKGdTQ/1gTkGmIhiZg8y9UMIY74aEW9AQfGwCaBkAO5AveaBTfmGBkSsAISS3T8k5OGsV0Q==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-43.3.1.tgz",
+      "integrity": "sha512-6AI2GGJveEm/2GESUY01wSPM7AeqHqVuX4Hon20uCAXHYCQkDubOHJ0yV3oFXl7iHeO6Ue2DdlSLayIUXCLoEQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-paragraph": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-44.1.0.tgz",
-      "integrity": "sha512-tfERMEQRrvM5zdZuiWC5IjCPtUrpncXY4ewn9mcGJ5KqmLaX3e+2dN4GVZpcagwOtZNQNQBONZnuWt9ZVkquFQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-43.3.1.tgz",
+      "integrity": "sha512-16ry56X+uXuZEzGZwLS8zpX2DtWN/CHHu5pSz0r2VDZ1zUGLsq/MXutotZfzMMjgdED3x4mJRQE+WgiyRrlKDg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-paste-from-office": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-44.1.0.tgz",
-      "integrity": "sha512-NIhtkFoDXNpOaPBDH6dDTU2BC3GUJ1rE5gUV0i4hrtOeERuk9EdkADCOBEHEm7UC31kCQ4si6wkry+d4oZ5FMw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-43.3.1.tgz",
+      "integrity": "sha512-LLf1KB11jeYLDpQPq0d2QVPxQxp9kEibPAF4rGD4stPpRx9d+DbwmE59Y5wVASKvYJo+yNpR9CGWsE4ZgjwTWw==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-remove-format": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-44.1.0.tgz",
-      "integrity": "sha512-97ppktKeKIhGYrRKwfzVP0DOktcaY4gFXEtKINmse8kw0C7jO4SE82sDJxWSP/3h74oncZzd/q/Qa6P65JmhWA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-43.3.1.tgz",
+      "integrity": "sha512-m7zvvYzHN/HExT0NoILXauVFI/AKQyuzPqqCI/VO1Ft5mLswXGuK6vmO1U10SmGz85etYZjEipKuouf2Anyqxg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-restricted-editing": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-44.1.0.tgz",
-      "integrity": "sha512-dsjeug3TCn32idHe4XWaD8ZBtKloAHSDYzv05uEuJDTEkTnSOp8ynVxUCKlTTMeHKjpRPr5kaxJkycqnxOqsvw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-43.3.1.tgz",
+      "integrity": "sha512-L6sA6UrUPy4Q3AzF8yQGsgEadO1IcZv53Ijevk9KuD7dwLF4f9x4ukUFLlGRpoYHPAW/+RpADp2PPegjKHo9QQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-select-all": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-44.1.0.tgz",
-      "integrity": "sha512-jQH9745sYWpQcZXC4z1lNS4XqrTJWHljWEMa4KKTZgo6zjR/L53tRZdIKbE6O/JgaW805Xpl74cJGXJvwre8VA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-43.3.1.tgz",
+      "integrity": "sha512-oYQ8uF6hmlX7OefpJ0FflvKddAkEffg3fKMT2FAINwqxhX+O7h9RQZ79AiOkTab7HUTIkbhM5AlhFJIXiX0Z7Q==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-show-blocks": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-44.1.0.tgz",
-      "integrity": "sha512-qPjba3VFXgRnnEjlZAfv1XgfC1jNpYUWpfxlniZixvcZ1bEOzEX6rkEqBioNgGFWBU8siPTPiwI2mmT/8/58Vw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-43.3.1.tgz",
+      "integrity": "sha512-o+IhZnjMmoF2qd4l1GqQqroeIEA29QAIOYfvrdMKZGrzVGmjbvwyNkbJRyZlAYhZqX8tLDPaPGn0tl+onhWtzw==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-source-editing": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-44.1.0.tgz",
-      "integrity": "sha512-gg/tWANOiJckvXxKqwthkvR531bPuen+lJN3y2qnqMKMQLLNbWWIUoTuE3PZRHDprT0JmTjnvlHrwsaSdpOkVg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-43.3.1.tgz",
+      "integrity": "sha512-Pq7WthQAiKa3A3q82bHqNRjQ/xlOpSX9kZHLm+CDH8XACxZbBF6Unz4JPR9zJRuQxkoFs314DM/PG6pPZQgXXA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-theme-lark": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-theme-lark": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-special-characters": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-44.1.0.tgz",
-      "integrity": "sha512-btw7qEPjrdp/XigtXOXy1KkK481PEeuJ5xdPD2xLlWvZkF0tGbEqIpDIMxkW1w7NmmC+5Aa8qJqXkV6dN4jZ5A==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-43.3.1.tgz",
+      "integrity": "sha512-3iwrtISndl5hc+/LuSXht69xqkEv95zg8Qxv+ovREA3pvtgt5u9O0t7ELcmUeTTEs/hJkF2FDplIYQj5zIvO+g==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-style": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-44.1.0.tgz",
-      "integrity": "sha512-A6udrCj1IxuiPE8OGue/aDtoqs8ZAPsbabnT9OS46WBlDGjXaSStXD7Dx6uJwEkaRdmhdGaObi4UnF7gkHRXHA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-43.3.1.tgz",
+      "integrity": "sha512-2+ATPa5y4ZUkak5xFTTDeUPhuCAYB4OPNt/QjMvrQjpEwXoWDJ4f8GqR9oFFsqEGMm65GrUp/xIQW8WRH43Kng==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-table": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-44.1.0.tgz",
-      "integrity": "sha512-8iQUW5apSYFrsJhguW0ROPBf+gmKhtP75KIeal6GdEtYlOMA8vP/ixUhQB5HZBmecfAVULyu1fF4YfGzHelZhw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-43.3.1.tgz",
+      "integrity": "sha512-Qr3GkKELnG1EY7Bu9dGQBkGTqhVnygeHKDCTEG9m218shYsI5L6jFftGUzWmJzMpm3hNFkyYv+1YWaIoqfRzIQ==",
       "requires": {
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-theme-lark": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-44.1.0.tgz",
-      "integrity": "sha512-Ym9ZKtQBqh5xOYGVa+va6CtYJSbhqIfVOsoCRZnMTzg3RTfwp8F78yeWUdplF6DS4JaM966yQumX9DcJGYn5AA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-43.3.1.tgz",
+      "integrity": "sha512-kAgeGx66jT31FFYwAoc43oX5ehQtiYE57OJWlPTXrDXxyq0Y+LYFW2/bp4UVYdZK+OKv9dp1Do3VQfxJoGzFjg==",
       "requires": {
-        "@ckeditor/ckeditor5-ui": "44.1.0"
+        "@ckeditor/ckeditor5-ui": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-typing": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-44.1.0.tgz",
-      "integrity": "sha512-YlIpXSp2mkzgCCwqa4Dd870K4UvKsjlHRDod50G8VSz2qFCkE6PaLGGBAci1IoZ5nBXZMpCrnhrkQ1jAJwx2RA==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-43.3.1.tgz",
+      "integrity": "sha512-sK45GlrOHqWOphVnzDKe3kofVJGhSRk34UQJnyXgMN+35QJqypnJeBYBnnHWL8+nK0S4zk9oQO3PuiRH6gg/WQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-ui": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-44.1.0.tgz",
-      "integrity": "sha512-Qga/eO6/4rCzK6m/JLMVq0gbgNDEV7K/J+ida1UQFYxrMric7qfriusT1q0Y+6jFYuGMdyLg0e0imORbMyw9Zw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-43.3.1.tgz",
+      "integrity": "sha512-dbR4FK6mCkI89h4Joyf1PZt0Xsq0N+sZg05Z6BpYz6GS9U35C7J9bHxN469dvaIc8bJws4eYJ5x+St3LcvlduQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "color-convert": "2.0.1",
         "color-parse": "1.4.2",
         "lodash-es": "4.17.21",
@@ -7625,30 +7597,30 @@
       }
     },
     "@ckeditor/ckeditor5-undo": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-44.1.0.tgz",
-      "integrity": "sha512-sULkc7Pvbc431uZCjzcAKd//jYE3B8fT8PEOFG8pYRnQJHc5GyodvH0RmXDhCtKCGtzvh1Dlpb4iSNpPNpVvJQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-43.3.1.tgz",
+      "integrity": "sha512-UxrWPlHzL/DKuxp4R5mlQvy995Ozehh5hQxY5yvL285Dzv6PY5pk627Wv/qS8AyfLMyVNiFO9bDWBIcT9igQRA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-upload": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-44.1.0.tgz",
-      "integrity": "sha512-+608NL4Jl6t2PA02Ft8myPV5r2oXwD+4wTCLKg4Oh2KPQYCyGOm5vj8dLxwWNsbMXZrdPxeQOK3UHq8bxYyI6A==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-43.3.1.tgz",
+      "integrity": "sha512-uOEhCgqgiK4V/CnbnuwHU/NUOG4ioQE5KUUtVmRG2xjQKg5C1uIT2dig+wnKw8vOdwVTMD2hVt7/OC/whQuheQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0"
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-utils": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-44.1.0.tgz",
-      "integrity": "sha512-PILjaPvEMuQ0qlnPAFeNTTQcLuXgGionSxaxF8HGnZolaqWnsJ11xGYxqUslNOGtdZNp/88/FC9TjCY/ksiibg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-43.3.1.tgz",
+      "integrity": "sha512-4CyM3AP+DcfuPuw+zceI3UTh3HcusnvFVeRPPw6j3Qe29/jadZYsdvkdo9KsDaiwgx0ctooKCuY9SfAcd/CZNQ==",
       "requires": {
-        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
@@ -7658,36 +7630,36 @@
       "integrity": "sha512-KEx4Tj2Irr4ZbLG8LnaKpb0Dgd8qmLmKFWeiKkQwM3RAAeYRYOCcBVB2Y168I9KA8wRosPxgOO9jbQ92yopYHA=="
     },
     "@ckeditor/ckeditor5-watchdog": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-44.1.0.tgz",
-      "integrity": "sha512-fTwYEW1TbbxC7PVmZtfWfwHT5aMREfBTDvH3KQWKpowTcoAiMBlQQKA/lvkRJ1bFMp4AZFjqs1IWZyap/sanAg==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-43.3.1.tgz",
+      "integrity": "sha512-d9gh0QIrrImIe2SFLo/IBLdpgC9REVkvUTv//qLbUaM2ffBboMnpJYPAB/hgl8ev4lkDvCrivlGjc/80COfGTQ==",
       "requires": {
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-widget": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-44.1.0.tgz",
-      "integrity": "sha512-dBG1EFJjq38wF0k1p3R2yIfZRHwgY5+hLuF1sp02q/lUJu59U/rPscfjj4dGpE4eKaqCD9z/UNEtOjPGnaJzKw==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-43.3.1.tgz",
+      "integrity": "sha512-0naXUVC6BFLnuj3lu5aTfRxmqV6py9+zqGHdJJZ0x8uSg9qcfUCLEQvA59bqzNteRya/lZeZhYKj8IcGnbB1oA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
     "@ckeditor/ckeditor5-word-count": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-44.1.0.tgz",
-      "integrity": "sha512-dM8jeZfRA2nodWdE1Ty3ZzaAl3M523ri9/ahLpG/JcCud2QZn9XRPrEwaIxC/1VtZg/Z2SUuI2LcPrbtPkQ0UQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-43.3.1.tgz",
+      "integrity": "sha512-W0Ic7y4/ePVqW22pHuXv5HRAbaDJFO13rUqyTZqU2H2ExZdMbJN6eT/UVhnO1XvKs/+jdKGO3LGWXt9QmmtkhA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "ckeditor5": "44.1.0",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "ckeditor5": "43.3.1",
         "lodash-es": "4.17.21"
       }
     },
@@ -8759,68 +8731,67 @@
       }
     },
     "ckeditor5": {
-      "version": "44.1.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-44.1.0.tgz",
-      "integrity": "sha512-6e1KFUE2giaSI0ZOKfAAFF5Tk7PF5DCyKVROPY9/46tti9AZpUFUzr7NhBsZjyMiMX1eqxqfsSZT7f9tKgcVAQ==",
+      "version": "43.3.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-43.3.1.tgz",
+      "integrity": "sha512-ZZ6nIdlr9rCCp21o9d5/mVUeVPwpQKEVxkeq1MU/Jax1w8U6rnMiQWxB954Ky/HNjhZ1v1ll2+VRzb7XA+1emA==",
       "requires": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-alignment": "44.1.0",
-        "@ckeditor/ckeditor5-autoformat": "44.1.0",
-        "@ckeditor/ckeditor5-autosave": "44.1.0",
-        "@ckeditor/ckeditor5-basic-styles": "44.1.0",
-        "@ckeditor/ckeditor5-block-quote": "44.1.0",
-        "@ckeditor/ckeditor5-bookmark": "44.1.0",
-        "@ckeditor/ckeditor5-ckbox": "44.1.0",
-        "@ckeditor/ckeditor5-ckfinder": "44.1.0",
-        "@ckeditor/ckeditor5-clipboard": "44.1.0",
-        "@ckeditor/ckeditor5-cloud-services": "44.1.0",
-        "@ckeditor/ckeditor5-code-block": "44.1.0",
-        "@ckeditor/ckeditor5-core": "44.1.0",
-        "@ckeditor/ckeditor5-easy-image": "44.1.0",
-        "@ckeditor/ckeditor5-editor-balloon": "44.1.0",
-        "@ckeditor/ckeditor5-editor-classic": "44.1.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "44.1.0",
-        "@ckeditor/ckeditor5-editor-inline": "44.1.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "44.1.0",
-        "@ckeditor/ckeditor5-engine": "44.1.0",
-        "@ckeditor/ckeditor5-enter": "44.1.0",
-        "@ckeditor/ckeditor5-essentials": "44.1.0",
-        "@ckeditor/ckeditor5-find-and-replace": "44.1.0",
-        "@ckeditor/ckeditor5-font": "44.1.0",
-        "@ckeditor/ckeditor5-heading": "44.1.0",
-        "@ckeditor/ckeditor5-highlight": "44.1.0",
-        "@ckeditor/ckeditor5-horizontal-line": "44.1.0",
-        "@ckeditor/ckeditor5-html-embed": "44.1.0",
-        "@ckeditor/ckeditor5-html-support": "44.1.0",
-        "@ckeditor/ckeditor5-image": "44.1.0",
-        "@ckeditor/ckeditor5-indent": "44.1.0",
-        "@ckeditor/ckeditor5-language": "44.1.0",
-        "@ckeditor/ckeditor5-link": "44.1.0",
-        "@ckeditor/ckeditor5-list": "44.1.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "44.1.0",
-        "@ckeditor/ckeditor5-media-embed": "44.1.0",
-        "@ckeditor/ckeditor5-mention": "44.1.0",
-        "@ckeditor/ckeditor5-minimap": "44.1.0",
-        "@ckeditor/ckeditor5-page-break": "44.1.0",
-        "@ckeditor/ckeditor5-paragraph": "44.1.0",
-        "@ckeditor/ckeditor5-paste-from-office": "44.1.0",
-        "@ckeditor/ckeditor5-remove-format": "44.1.0",
-        "@ckeditor/ckeditor5-restricted-editing": "44.1.0",
-        "@ckeditor/ckeditor5-select-all": "44.1.0",
-        "@ckeditor/ckeditor5-show-blocks": "44.1.0",
-        "@ckeditor/ckeditor5-source-editing": "44.1.0",
-        "@ckeditor/ckeditor5-special-characters": "44.1.0",
-        "@ckeditor/ckeditor5-style": "44.1.0",
-        "@ckeditor/ckeditor5-table": "44.1.0",
-        "@ckeditor/ckeditor5-theme-lark": "44.1.0",
-        "@ckeditor/ckeditor5-typing": "44.1.0",
-        "@ckeditor/ckeditor5-ui": "44.1.0",
-        "@ckeditor/ckeditor5-undo": "44.1.0",
-        "@ckeditor/ckeditor5-upload": "44.1.0",
-        "@ckeditor/ckeditor5-utils": "44.1.0",
-        "@ckeditor/ckeditor5-watchdog": "44.1.0",
-        "@ckeditor/ckeditor5-widget": "44.1.0",
-        "@ckeditor/ckeditor5-word-count": "44.1.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-alignment": "43.3.1",
+        "@ckeditor/ckeditor5-autoformat": "43.3.1",
+        "@ckeditor/ckeditor5-autosave": "43.3.1",
+        "@ckeditor/ckeditor5-basic-styles": "43.3.1",
+        "@ckeditor/ckeditor5-block-quote": "43.3.1",
+        "@ckeditor/ckeditor5-ckbox": "43.3.1",
+        "@ckeditor/ckeditor5-ckfinder": "43.3.1",
+        "@ckeditor/ckeditor5-clipboard": "43.3.1",
+        "@ckeditor/ckeditor5-cloud-services": "43.3.1",
+        "@ckeditor/ckeditor5-code-block": "43.3.1",
+        "@ckeditor/ckeditor5-core": "43.3.1",
+        "@ckeditor/ckeditor5-easy-image": "43.3.1",
+        "@ckeditor/ckeditor5-editor-balloon": "43.3.1",
+        "@ckeditor/ckeditor5-editor-classic": "43.3.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "43.3.1",
+        "@ckeditor/ckeditor5-editor-inline": "43.3.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "43.3.1",
+        "@ckeditor/ckeditor5-engine": "43.3.1",
+        "@ckeditor/ckeditor5-enter": "43.3.1",
+        "@ckeditor/ckeditor5-essentials": "43.3.1",
+        "@ckeditor/ckeditor5-find-and-replace": "43.3.1",
+        "@ckeditor/ckeditor5-font": "43.3.1",
+        "@ckeditor/ckeditor5-heading": "43.3.1",
+        "@ckeditor/ckeditor5-highlight": "43.3.1",
+        "@ckeditor/ckeditor5-horizontal-line": "43.3.1",
+        "@ckeditor/ckeditor5-html-embed": "43.3.1",
+        "@ckeditor/ckeditor5-html-support": "43.3.1",
+        "@ckeditor/ckeditor5-image": "43.3.1",
+        "@ckeditor/ckeditor5-indent": "43.3.1",
+        "@ckeditor/ckeditor5-language": "43.3.1",
+        "@ckeditor/ckeditor5-link": "43.3.1",
+        "@ckeditor/ckeditor5-list": "43.3.1",
+        "@ckeditor/ckeditor5-markdown-gfm": "43.3.1",
+        "@ckeditor/ckeditor5-media-embed": "43.3.1",
+        "@ckeditor/ckeditor5-mention": "43.3.1",
+        "@ckeditor/ckeditor5-minimap": "43.3.1",
+        "@ckeditor/ckeditor5-page-break": "43.3.1",
+        "@ckeditor/ckeditor5-paragraph": "43.3.1",
+        "@ckeditor/ckeditor5-paste-from-office": "43.3.1",
+        "@ckeditor/ckeditor5-remove-format": "43.3.1",
+        "@ckeditor/ckeditor5-restricted-editing": "43.3.1",
+        "@ckeditor/ckeditor5-select-all": "43.3.1",
+        "@ckeditor/ckeditor5-show-blocks": "43.3.1",
+        "@ckeditor/ckeditor5-source-editing": "43.3.1",
+        "@ckeditor/ckeditor5-special-characters": "43.3.1",
+        "@ckeditor/ckeditor5-style": "43.3.1",
+        "@ckeditor/ckeditor5-table": "43.3.1",
+        "@ckeditor/ckeditor5-theme-lark": "43.3.1",
+        "@ckeditor/ckeditor5-typing": "43.3.1",
+        "@ckeditor/ckeditor5-ui": "43.3.1",
+        "@ckeditor/ckeditor5-undo": "43.3.1",
+        "@ckeditor/ckeditor5-upload": "43.3.1",
+        "@ckeditor/ckeditor5-utils": "43.3.1",
+        "@ckeditor/ckeditor5-watchdog": "43.3.1",
+        "@ckeditor/ckeditor5-widget": "43.3.1",
+        "@ckeditor/ckeditor5-word-count": "43.3.1"
       }
     },
     "color-convert": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "serve-vue": "vite --host --strictPort"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-build-classic": "44.1.0",
+    "@ckeditor/ckeditor5-build-classic": "43.3.1",
     "@ckeditor/ckeditor5-vue": "5.1.0",
     "@mdi/js": "7.4.47",
     "@popperjs/core": "2.11.8",


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5932