### PR TITLE
BOAC-5874, fetchUsers needs no args when used in Pax Man filters

### DIFF
--- a/src/components/admin/passenger-manifest/SearchAndFilterBoaUsers.vue
+++ b/src/components/admin/passenger-manifest/SearchAndFilterBoaUsers.vue
@@ -136,7 +136,7 @@
           density="comfortable"
           :disabled="disabled"
           :icon="mdiTransferRight"
-          @click="fetchUsers"
+          @click="() => fetchUsers()"
         />
       </div>
       <div v-if="isFetching">


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5874

 A little regression caused by CSV download work.