### PR TITLE
BOAC-5943, 'sequence' needed on peer_advising_topics.id

### DIFF
--- a/scripts/db/migrate/2025/20250122-BOAC-5841/pre_deploy_01_peer_advising.sql
+++ b/scripts/db/migrate/2025/20250122-BOAC-5841/pre_deploy_01_peer_advising.sql
@@ -46,6 +46,16 @@ CREATE TABLE IF NOT EXISTS peer_advising_topics (
   deleted_at TIMESTAMP WITH TIME ZONE
 );
 
+CREATE SEQUENCE IF NOT EXISTS peer_advising_topics_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+ALTER SEQUENCE peer_advising_topics_id_seq OWNER TO app_boa;
+ALTER SEQUENCE peer_advising_topics_id_seq OWNED BY peer_advising_topics.id;
+ALTER TABLE ONLY peer_advising_topics ALTER COLUMN id SET DEFAULT nextval('peer_advising_topics_id_seq'::regclass);
+
 -- Drop all foreign keys if they exist
 ALTER TABLE ONLY peer_advising_departments
     DROP CONSTRAINT IF EXISTS peer_advising_departments_university_dept_id_fkey;


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5943

I neglected to add this in previous PR.  It has already been run on boa-dev db and this `peer_advising_topics_id_seq` sequence is already in `schema.sql`.