### PR TITLE
BOAC-5947, proper use of include_deleted in '/api/user/by_uid/<uid>' API

### DIFF
--- a/boac/api/user_controller.py
+++ b/boac/api/user_controller.py
@@ -73,8 +73,8 @@ def calnet_profile_by_user_id(user_id):
 @app.route('/api/user/by_uid/<uid>')
 @advisor_required
 def user_by_uid(uid):
-    ignore_deleted = to_bool_or_none(util.get(request.args, 'ignoreDeleted'))
-    user = _find_user_by_uid(uid, ignore_deleted)
+    include_deleted = to_bool_or_none(request.args.get('includeDeleted')) if current_user.is_admin else False
+    user = _find_user_by_uid(uid, bool(include_deleted))
     if user:
         users_feed = authorized_users_api_feed([user])
         return tolerant_jsonify(users_feed[0])
@@ -419,12 +419,8 @@ def _delete_existing_memberships(user_id):
         )
 
 
-def _find_user_by_uid(uid, ignore_deleted=True):
-    if uid:
-        ignore_deleted_ = True if ignore_deleted is None else ignore_deleted
-        return AuthorizedUser.find_by_uid(uid, ignore_deleted=ignore_deleted_)
-    else:
-        return None
+def _find_user_by_uid(uid, include_deleted=False):
+    return AuthorizedUser.find_by_uid(uid, ignore_deleted=not include_deleted) if uid else None
 
 
 def _get_inputs_for_csv_download(api_json):

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -82,11 +82,8 @@ export async function getPeerAdvisingUsers(
   })
 }
 
-export function getUserByUid(uid: string, ignoreDeleted?: boolean) {
-  let url = `${utils.apiBaseUrl()}/api/user/by_uid/${uid}`
-  if (!isNil(ignoreDeleted)) {
-    url += `?ignoreDeleted=${ignoreDeleted}`
-  }
+export function getUserByUid(uid: string, includeDeleted: boolean) {
+  const url = `${utils.apiBaseUrl()}/api/user/by_uid/${uid}?includeDeleted=${includeDeleted}`
   return axios.get(url).then(response => response.data)
 }
 

--- a/src/components/admin/DevAuth.vue
+++ b/src/components/admin/DevAuth.vue
@@ -38,7 +38,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import {get, trim} from 'lodash'
 import {onMounted, ref} from 'vue'
 import {useRouter} from 'vue-router'
@@ -80,6 +80,7 @@ const logIn = () => {
       },
       error => {
         props.reportError(error)
+        isLoggingIn.value = false
       }
     )
   } else if (uid.value) {

--- a/src/components/admin/passenger-manifest/BoaUsers.vue
+++ b/src/components/admin/passenger-manifest/BoaUsers.vue
@@ -295,7 +295,7 @@ const onClickEditUser = (index, uid) => {
 const onUpdateUser = (index, uid) => {
   dialogs.value[index] = false
   editUserModel.value = undefined
-  getUserByUid(uid, false).then(data => {
+  getUserByUid(uid, true).then(data => {
     manifestStore.onUpdateUser(data)
   })
 }

--- a/src/components/admin/passenger-manifest/SearchAndFilterBoaUsers.vue
+++ b/src/components/admin/passenger-manifest/SearchAndFilterBoaUsers.vue
@@ -202,7 +202,7 @@ watch(() => filter.value.status, () => putFocusNextTick('submit-user-search-filt
 
 const onUpdateAutocompleteModel = (uid: string) => {
   manifestStore.setIsFetching(true)
-  getUserByUid(uid).then(user => {
+  getUserByUid(uid, true).then(user => {
     manifestStore.setUsers([user])
     autocompleteInput.value = userSelection.value = undefined
     manifestStore.setIsFetching(false)

--- a/src/layouts/Login.vue
+++ b/src/layouts/Login.vue
@@ -23,17 +23,18 @@
           <div v-if="config.devAuthEnabled" class="mt-3">
             <DevAuth :report-error="reportError" />
           </div>
-          <v-alert
-            v-if="error"
-            aria-live="polite"
-            class="font-weight-medium ma-2"
-            density="compact"
-            :icon="mdiAlert"
-            type="error"
-            variant="tonal"
-          >
-            {{ error }}
-          </v-alert>
+          <div class="mt-3 mx-7">
+            <v-alert
+              v-if="error"
+              aria-live="polite"
+              class="font-weight-medium text-left"
+              density="compact"
+              :icon="mdiAlert"
+              :text="error"
+              type="error"
+              variant="tonal"
+            />
+          </div>
           <div class="contact-us">
             If you have questions or feedback then contact us at
             <a :href="`mailto:${config.supportEmailAddress}`" target="_blank">
@@ -47,27 +48,27 @@
   </v-app>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import {mdiAlert} from '@mdi/js'
 import {nextTick, ref} from 'vue'
-import {trim} from 'lodash'
+import {toString, trim} from 'lodash'
 import {useRoute} from 'vue-router'
-import {useContextStore} from '@/stores/context'
+import DevAuth from '@/components/admin/DevAuth.vue'
 import {getCasLoginURL} from '@/api/auth'
-import DevAuth from '@/components/admin/DevAuth'
+import {useContextStore} from '@/stores/context'
 
 const config = useContextStore().config
-const error = ref(undefined)
+const error = ref<string | undefined>(undefined)
 const route = useRoute()
 
-nextTick(() => reportError(route.query.error))
+nextTick(() => reportError(toString(route.query.error)))
 
 const logIn = () => {
   getCasLoginURL().then(data => window.location.href = data.casLoginUrl)
 }
 
-const reportError = message => {
-  error.value = trim(message) || null
+const reportError = (message: string) => {
+  error.value = trim(message) || undefined
 }
 </script>
 

--- a/src/views/PassengerManifest.vue
+++ b/src/views/PassengerManifest.vue
@@ -153,7 +153,7 @@ const fetchUsers = (isCsvDownloadRequest?: boolean) => {
         uidOfUser = manifestStore.uidBeingEdited.uid
       }
       if (uidOfUser) {
-        getUserByUid(uidOfUser, false).then(data => afterFetchUsers([data]))
+        getUserByUid(uidOfUser, true).then(data => afterFetchUsers([data]))
       }
     } else {
       throw new TypeError(`Invalid filter type: ${filter.type}`)

--- a/src/views/PeerAdvisorHome.vue
+++ b/src/views/PeerAdvisorHome.vue
@@ -73,7 +73,7 @@ onMounted(() => {
   const currentUser = contextStore.currentUser
   if (currentUser.isAdmin) {
     const uid = route.params.uid.toString()
-    getUserByUid(uid, true).then(init)
+    getUserByUid(uid, false).then(init)
   } else {
     init(currentUser)
   }

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -186,37 +186,38 @@ class TestCalnetProfileByUid:
 class TestUserByUid:
     """User by UID API."""
 
+    @classmethod
+    def _api_get_user_by_uid(cls, client, include_deleted, uid, expected_status_code=200):
+        response = client.get(f'/api/user/by_uid/{uid}?includeDeleted={include_deleted}')
+        assert response.status_code == expected_status_code
+        return response.json
+
     def test_not_authenticated(self, client):
         """Returns 401 when not authenticated."""
-        user = AuthorizedUser.find_by_uid(asc_advisor_uid)
-        response = client.get(f'/api/user/by_uid/{user.uid}')
-        assert response.status_code == 401
+        self._api_get_user_by_uid(client, False, asc_advisor_uid, expected_status_code=401)
 
     def test_user_not_found(self, client, fake_auth):
         """404 when user not found."""
         fake_auth.login(admin_uid)
-        assert client.get('/api/user/by_uid/99999999999999999').status_code == 404
+        self._api_get_user_by_uid(client, True, '99999999999999999', expected_status_code=404)
 
     def test_deleted_user_not_found(self, client, fake_auth):
-        """404 is default if get deleted user by UID."""
+        """404 if search deleted user with include_deleted set to False."""
         fake_auth.login(admin_uid)
-        assert client.get(f'/api/user/by_uid/{deleted_user_uid}').status_code == 404
-        assert client.get(f'/api/user/by_uid/{deleted_user_uid}?ignoreDeleted=true').status_code == 404
+        self._api_get_user_by_uid(client, False, deleted_user_uid, expected_status_code=404)
 
     def test_get_deleted_user_by_uid(self, client, fake_auth):
-        """Get deleted user by UID if specific param is passed."""
+        """Get deleted user."""
         fake_auth.login(admin_uid)
-        response = client.get(f'/api/user/by_uid/{deleted_user_uid}?ignoreDeleted=false')
-        assert response.status_code == 200
-        assert response.json['uid'] == deleted_user_uid
+        api_json = self._api_get_user_by_uid(client, True, deleted_user_uid)
+        assert api_json['uid'] == deleted_user_uid
 
     def test_user_by_csid(self, client, fake_auth):
         """Delivers CalNet profile."""
         fake_auth.login(admin_uid)
-        response = client.get('/api/user/by_uid/1133399')
-        assert response.status_code == 200
-        assert response.json['csid'] == '800700600'
-        assert response.json['uid'] == '1133399'
+        api_json = self._api_get_user_by_uid(client, False, coe_advisor_uid)
+        assert api_json['csid'] == '800700600'
+        assert api_json['uid'] == coe_advisor_uid
 
 
 class TestUniversityDeptMember:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5947

Admin-only usages of this API can leverage `include_deleted` arg; for non-admins that value is always false. 
PR includes a fix to /login page where dev-auth inputs were disabled on error. 