### PR TITLE
BOAC-6047, Peer Advisors get dedicated attachment upload/download APIs

### DIFF
--- a/boac/api/peer_advising_notes_controller.py
+++ b/boac/api/peer_advising_notes_controller.py
@@ -23,23 +23,28 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+import urllib.parse
+
 from boac.api.decorators import peer_advisor_or_peer_advisor_manager, peer_advisor_required
-from boac.api.errors import ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import get_boac_note_as_compatible_json, get_note_author_profile_of_current_user, \
-    get_note_topics_from_http_post, validate_note_contact_type
+from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
+from boac.api.util import get_boac_note_as_compatible_json, get_note_attachments_from_http_post, \
+    get_note_author_profile_of_current_user, get_note_topics_from_http_post, validate_note_contact_type
 from boac.externals import data_loch
 from boac.externals.data_loch import get_basic_student_data
-from boac.lib.berkeley import sis_term_id_for_name, term_name_for_sis_id
+from boac.lib.berkeley import is_peer_advisor, sis_term_id_for_name, term_name_for_sis_id
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param, process_input_from_rich_text_editor, to_bool_or_none
+from boac.merged.advising_note import get_author_uid, get_boa_attachment_stream
 from boac.merged.sis_terms import future_term_id
 from boac.merged.student import merge_enrollment_terms
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.note import Note
+from boac.models.note_attachment import NoteAttachment
 from boac.models.note_read import NoteRead
 from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
 from boac.models.peer_advising_topic import PeerAdvisingTopic
-from flask import current_app as app, request
+from boac.routes import login_manager
+from flask import current_app as app, request, Response
 from flask_login import current_user
 
 
@@ -93,6 +98,51 @@ def get_enrollment_terms_by_sid(sid):
             api_json[academic_calendar] = dict((sis_term_id_for_name(term_name), []) for term_name in term_names)
         api_json[academic_calendar][term_id] = sorted(enrollments, key=lambda e: e['displayName'])
     return tolerant_jsonify(dict(sorted(api_json.items(), reverse=True)))
+
+
+@app.route('/api/peer_advisor/note/<note_id>/attachments', methods=['POST'])
+@peer_advisor_required
+def add_peer_advising_attachments(note_id):
+    note = Note.find_by_id(note_id=note_id)
+    is_authorized = is_peer_advisor(current_user) and get_author_uid(note) == current_user.uid
+    if not is_authorized:
+        raise ForbiddenRequestError('Sorry, you are not the author of this note.')
+    attachments = get_note_attachments_from_http_post()
+    attachment_limit = app.config['NOTES_ATTACHMENTS_MAX_PER_NOTE']
+    if len(attachments) + len(note.attachments) > attachment_limit:
+        raise BadRequestError(f'No more than {attachment_limit} attachments may be uploaded at once.')
+    for attachment in attachments:
+        note = Note.add_attachment(
+            note_id=note_id,
+            attachment=attachment,
+        )
+    return tolerant_jsonify(
+        get_boac_note_as_compatible_json(
+            note=note,
+            note_read=NoteRead.find_or_create(current_user.get_id(), note_id),
+        ),
+    )
+
+
+@app.route('/api/peer_advisor/note/attachment/<attachment_id>', methods=['GET'])
+@peer_advisor_required
+def download_peer_advising_note_attachment(attachment_id):
+    attachment_id = int(attachment_id)
+    attachment = NoteAttachment.find_by_id(attachment_id)
+    if not attachment or not attachment.note:
+        raise ResourceNotFoundError('Note not found')
+    # Auth check
+    note = attachment.note
+    if get_author_uid(note) != current_user.uid:
+        return login_manager.unauthorized()
+    stream_data = get_boa_attachment_stream(attachment)
+    if not stream_data or not stream_data['stream']:
+        return Response('Sorry, attachment not available.', mimetype='text/html', status=404)
+    r = Response(stream_data['stream'])
+    r.headers['Content-Type'] = 'application/octet-stream'
+    encoding_safe_filename = urllib.parse.quote(stream_data['filename'].encode('utf8'))
+    r.headers['Content-Disposition'] = f"attachment; filename*=UTF-8''{encoding_safe_filename}"
+    return r
 
 
 @app.route('/api/peer_advisor/<uid>/notes')

--- a/src/api/peer-advising-notes.ts
+++ b/src/api/peer-advising-notes.ts
@@ -1,6 +1,19 @@
 import axios from 'axios'
+import {each} from 'lodash'
+import type {NoteEditSessionModel} from '@/lib/types'
 import utils from '@/api/api-utils'
 import {useContextStore} from '@/stores/context'
+
+export async function addPeerAdvisingAttachments(noteId: number, attachments: object[]): Promise<NoteEditSessionModel> {
+  const data = {}
+  each(attachments, (attachment, index) => data[`attachment[${index}]`] = attachment)
+  return new Promise(resolve => {
+    utils.postMultipartFormData(`/api/peer_advisor/note/${noteId}/attachments`, data).then(note => {
+      useContextStore().broadcast('note-updated', note)
+      resolve(note)
+    })
+  })
+}
 
 export async function getPeerAdvisorNotes(
   offset: number,

--- a/src/components/note/AdvisingNoteAttachments.vue
+++ b/src/components/note/AdvisingNoteAttachments.vue
@@ -123,6 +123,7 @@ import {addFileDropEventListeners, canUserEditNote, validateAttachment} from '@/
 import {alertScreenReader, pluralize, putFocusNextTick} from '@/lib/utils'
 import {useContextStore} from '@/stores/context'
 import {useNoteStore} from '@/stores/note-edit-session'
+import {isPeerAdvisor} from '@/lib/boa-user'
 
 const props = defineProps({
   add: {
@@ -215,7 +216,14 @@ onBeforeUnmount(() => {
 })
 
 const downloadUrl = (attachment) => {
-  return props.isDownloadable ? `${contextStore.config.apiBaseUrl}/api/notes/attachment/${attachment.id}` : null
+  let url = undefined
+  if (props.isDownloadable) {
+    const apiBaseUrl = contextStore.config.apiBaseUrl
+    url = isPeerAdvisor(currentUser) ?
+      `${apiBaseUrl}/api/peer_advisor/note/attachment/${attachment.id}` :
+      `${apiBaseUrl}/api/notes/attachment/${attachment.id}`
+  }
+  return url
 }
 
 const onAttachmentsInput = files => {

--- a/src/components/peer/note/EditPeerAdvisingNoteModal.vue
+++ b/src/components/peer/note/EditPeerAdvisingNoteModal.vue
@@ -102,7 +102,7 @@ import {computed, onMounted, ref} from 'vue'
 import {concat, get, size} from 'lodash'
 import {storeToRefs} from 'pinia'
 import {useDisplay} from 'vuetify'
-import type {BasicStudent, NoteRecipients, NoteTemplate, NoteTopic} from '@/lib/types'
+import type {BasicStudent, NoteAttachment, NoteRecipients, NoteTemplate, NoteTopic} from '@/lib/types'
 import AdvisingNoteAttachments from '@/components/note/AdvisingNoteAttachments.vue'
 import AdvisingNoteTopics from '@/components/note/AdvisingNoteTopics.vue'
 import AreYouSureModal from '@/components/util/AreYouSureModal.vue'
@@ -151,7 +151,7 @@ onMounted(() => {
   })
 })
 
-const addNoteAttachments = attachments => {
+const addNoteAttachments = (attachments: NoteAttachment[]) => {
   return new Promise<void>(resolve => {
     const pluralized = pluralize('attachment', attachments.length)
     noteStore.setAttachments(concat(model.value.attachments, attachments))

--- a/src/components/peer/note/PeerAdvisorPaginatedNotes.vue
+++ b/src/components/peer/note/PeerAdvisorPaginatedNotes.vue
@@ -53,7 +53,7 @@
                 <button
                   :id="`open-peer-advising-${note.id}`"
                   :aria-label="`Edit ${getStudentName(note)} note`"
-                  class="align-center text-left text-primary w-100"
+                  class="align-center d-flex text-primary w-100"
                   :class="{'demo-mode-blur': currentUser.inDemoMode}"
                   @click="() => toggleShowHide(note)"
                 >

--- a/src/stores/note-edit-session/note-edit-session-utils.ts
+++ b/src/stores/note-edit-session/note-edit-session-utils.ts
@@ -1,10 +1,10 @@
 import {get, isNil, isString, map, size, trim} from 'lodash'
 import type {Attachment, Cohort, CuratedGroup, NoteEditSessionModel, NoteRecipients} from '@/lib/types'
-import {addAttachments, deleteNote, updateNote} from '@/api/notes'
+import {addPeerAdvisingAttachments, createPeerAdvisingNote, updatePeerAdvisingNote} from '@/api/peer-advising-notes'
+import {deleteNote, updateNote} from '@/api/notes'
 import {getDistinctSids} from '@/api/student'
 import {useContextStore} from '@/stores/context'
 import {useNoteStore} from '@/stores/note-edit-session'
-import {createPeerAdvisingNote, updatePeerAdvisingNote} from '@/api/peer-advising-notes'
 
 export function clearNoteRecipients(): Promise<void> {
   return setNoteRecipients([], [], [])
@@ -150,7 +150,7 @@ export function updateAdvisingNote(): Promise<NoteEditSessionModel> {
           model.noteTemplateId
         ).then((note: NoteEditSessionModel) => {
           if (size(model.attachments)) {
-            addAttachments(note.id, model.attachments).then((note: NoteEditSessionModel)=> {
+            addPeerAdvisingAttachments(note.id, model.attachments).then((note: NoteEditSessionModel)=> {
               noteStore.setAttachments(note.attachments)
               noteStore.setIsSaving(false)
               noteStore.setModel(note)

--- a/tests/test_api/test_peer_advising_notes_controller.py
+++ b/tests/test_api/test_peer_advising_notes_controller.py
@@ -29,6 +29,7 @@ from boac import std_commit
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.note import Note
 from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
+from tests.util import mock_advising_note_s3_bucket
 
 admin_uid = '2040'
 ce3_advisor_uid = '2525'
@@ -62,6 +63,36 @@ class TestCreatePeerAdvisingNote:
                 sid=coe_student_sid,
             )
 
+    def test_not_authorized_to_add_attachments(self, app, client, fake_auth):
+        fake_auth.login(ce3_navcal_peer_advisor_manager_uid)
+        with mock_advising_note_s3_bucket(app):
+            base_dir = app.config['BASE_DIR']
+            attachment = f'{base_dir}/fixtures/mock_advising_note_attachment_1.txt'
+            with open(attachment, 'r') as file:
+                note = Note.create(
+                    attachments=[
+                        {
+                            'name': attachment.rsplit('/', 1)[-1],
+                            'byte_stream': file.read(),
+                        },
+                    ],
+                    author_uid=ce3_navcal_peer_advisor_uid,
+                    author_name='CE3 Peer Advisor',
+                    author_role='Peer Advisor',
+                    author_dept_codes=['ZCEEE'],
+                    body='Rock \'n Roll rang sweet as victory, under neon signs',
+                    sid='11667051',
+                    subject='',
+                )
+                std_commit(allow_test_environment=True)
+                _api_note_attachments_upload(
+                    app=app,
+                    attachments=[f'{base_dir}/fixtures/mock_advising_note_attachment_1.txt'],
+                    client=client,
+                    expected_status_code=401,
+                    note_id=note.id,
+                )
+
     def test_invalid_peer_advising_department_id(self, client, fake_auth):
         coe_mech_peer_advisor = AuthorizedUser.find_by_uid(coe_mech_peer_advisor_uid)
         user_id = coe_mech_peer_advisor.id
@@ -87,10 +118,22 @@ class TestCreatePeerAdvisingNote:
             peer_advising_department_id=self.ce3_navcal_peer_advising_department_id,
             sid=coe_student_sid,
         )
-        assert note['id']
+        note_id = note['id']
+        base_dir = app.config['BASE_DIR']
+        note = _api_note_attachments_upload(
+            app=app,
+            attachments=[
+                f'{base_dir}/fixtures/mock_advising_note_attachment_1.txt',
+                f'{base_dir}/fixtures/mock_advising_note_attachment_2.txt',
+            ],
+            client=client,
+            note_id=note_id,
+        )
+        assert note_id
         assert note['author']['uid'] == ce3_navcal_peer_advisor_uid
         assert note['peerAdvisingDepartmentId'] == self.ce3_navcal_peer_advising_department_id
         assert note['read'] is True
+        assert len(note.get('attachments')) == 2
 
 
 class TestGetPeerAdvisingNotes:
@@ -374,3 +417,24 @@ def _api_create_peer_advising_note(
     )
     assert response.status_code == expected_status_code
     return response.json
+
+
+def _api_note_attachments_upload(
+    app,
+    attachments,
+    client,
+    note_id,
+    expected_status_code=200,
+):
+    with mock_advising_note_s3_bucket(app):
+        data = {}
+        for index, path in enumerate(attachments):
+            data[f'attachment[{index}]'] = open(path, 'rb')
+        response = client.post(
+            f'/api/peer_advisor/note/{note_id}/attachments',
+            buffered=True,
+            content_type='multipart/form-data',
+            data=data,
+        )
+        assert response.status_code == expected_status_code
+        return response.json


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6047
https://jira-secure.berkeley.edu/browse/BOAC-6046

Also fixes issue where, on {{/peer_advisor/home}}, note bodies were not respecting borders.