### PR TITLE
BOAC-6047, /peer_advisor/home: indicate attachments of newly created note

### DIFF
--- a/src/api/peer-advising-notes.ts
+++ b/src/api/peer-advising-notes.ts
@@ -54,11 +54,7 @@ export function createPeerAdvisingNote(
     topics,
     noteTemplateId
   }
-  return axios.post(`${utils.apiBaseUrl()}/api/peer_advising/note/create`, data).then(response => {
-    const data = response.data
-    useContextStore().broadcast('peer-advising-note-created', data)
-    return data
-  })
+  return axios.post(`${utils.apiBaseUrl()}/api/peer_advising/note/create`, data).then(response => response.data)
 }
 
 export function updatePeerAdvisingNote(

--- a/src/components/header/HeaderMenu.vue
+++ b/src/components/header/HeaderMenu.vue
@@ -37,7 +37,7 @@
             color="primary"
             density="comfortable"
             size="large"
-            text="Peer Advisor Manager Dashboard"
+            text="Peer Advising Manager Dashboard"
             :to="`/peer/management/${peerAdvisingDepartmentId}`"
             variant="text"
           />

--- a/src/stores/note-edit-session/note-edit-session-utils.ts
+++ b/src/stores/note-edit-session/note-edit-session-utils.ts
@@ -149,15 +149,16 @@ export function updateAdvisingNote(): Promise<NoteEditSessionModel> {
           model.topics,
           model.noteTemplateId
         ).then((note: NoteEditSessionModel) => {
-          if (size(model.attachments)) {
-            addPeerAdvisingAttachments(note.id, model.attachments).then((note: NoteEditSessionModel)=> {
-              noteStore.setAttachments(note.attachments)
-              noteStore.setIsSaving(false)
-              noteStore.setModel(note)
-              resolve(note)
-            })
-          } else {
+          const done = (note: NoteEditSessionModel) => {
+            noteStore.setIsSaving(false)
+            useContextStore().broadcast('peer-advising-note-created', note)
             resolve(note)
+          }
+          if (size(model.attachments)) {
+            addPeerAdvisingAttachments(note.id, model.attachments).then(done)
+          } else {
+            useContextStore().broadcast('peer-advising-note-created', note)
+            done(note)
           }
         })
       } else {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6047

After note creation, the list was refreshing. But, if new note had attachments then the attachment indicator was not shown.