### PR TITLE
boac-6065 + boac-6064 + boac-6078 - PA: search now searches student name as well + templates fixes

### DIFF
--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -292,18 +292,29 @@ def search_advising_notes(
     while True:
         benchmark(f'begin local notes query (iteration {local_notes_query_iteration})')
 
-        local_search_results = Note.search(
-            search_phrase=search_phrase,
-            author_uid=author_uid,
-            student_csid=student_csid,
-            department_codes=department_codes,
-            topic=topic,
-            datetime_from=datetime_from,
-            datetime_to=datetime_to,
-            offset=(local_notes_query_batch_size * local_notes_query_iteration),
-            limit=local_notes_query_batch_size,
-            peer_advising_department_id=peer_advising_department_id,
-        )
+        if peer_advising_department_id:
+            phrases = list(filter(None, re.split(r'[- ]', search_phrase.strip().upper())))
+            student_results = data_loch.match_students_by_name_or_sid(phrases=phrases, limit=100)
+            matching_sids = [s.get('sid') for s in student_results]
+            local_search_results = Note.peer_advising_notes_search(
+                search_phrase=search_phrase,
+                offset=(local_notes_query_batch_size * local_notes_query_iteration),
+                limit=local_notes_query_batch_size,
+                peer_advising_department_id=peer_advising_department_id,
+                matching_sids=matching_sids,
+            )
+        else:
+            local_search_results = Note.search(
+                search_phrase=search_phrase,
+                author_uid=author_uid,
+                student_csid=student_csid,
+                department_codes=department_codes,
+                topic=topic,
+                datetime_from=datetime_from,
+                datetime_to=datetime_to,
+                offset=(local_notes_query_batch_size * local_notes_query_iteration),
+                limit=local_notes_query_batch_size,
+            )
         local_batch_results = local_search_results['results']
         local_total_matching_count = local_search_results['total_matching_count']
         benchmark(f'end local notes query (iteration {local_notes_query_iteration})')

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -403,6 +403,77 @@ class Note(Base):
         return api_json
 
     @classmethod
+    def peer_advising_notes_search(
+            cls,
+            search_phrase,
+            peer_advising_department_id,
+            matching_sids,
+            offset=0,
+            limit=40,
+    ):
+        notes_selector = """SELECT id, ts_rank(fts_index, plainto_tsquery('english', :search_phrase)) AS rank
+            FROM notes_fts_index
+            WHERE fts_index @@ plainto_tsquery('english', :search_phrase)"""
+        params = {
+            'search_phrase': search_phrase,
+        }
+
+        # Build a union branch that picks notes for which the student's SID is in the matching list.
+        student_branch = """
+            SELECT n.id, 0 AS rank
+            FROM notes n
+            WHERE n.sid = ANY(:matching_sids)
+            AND n.peer_advising_department_id = :peer_advising_department_id
+        """
+        params['matching_sids'] = matching_sids
+
+        # Combine both branches using UNION.
+        fts_selector = f"""
+            {notes_selector}
+            UNION
+            {student_branch}
+        """
+
+        peer_advising_department_notes_filter = 'AND notes.peer_advising_department_id = :peer_advising_department_id'
+        params.update({'peer_advising_department_id': peer_advising_department_id})
+
+        attachments_join = 'LEFT JOIN note_attachments a ON notes.id = a.note_id AND a.deleted_at IS NULL'
+        group_by_clause = 'GROUP BY notes.id, fts.rank'
+        where_clause = 'WHERE notes.is_draft IS FALSE'
+
+        def _get_query(is_count_query=False):
+            query = f"""
+                WITH fts AS ({fts_selector})
+                SELECT {'count(notes.*)' if is_count_query else 'notes.*'}
+                {', count(a.note_id) as attachment_count'}
+                FROM fts JOIN notes
+                    ON fts.id = notes.id
+                {peer_advising_department_notes_filter}
+                {attachments_join}
+                {where_clause}
+                {group_by_clause}
+            """
+            if not is_count_query:
+                query += f"""
+                    ORDER BY fts.rank DESC, notes.id
+                    OFFSET {offset} LIMIT {limit}
+                """
+            return text(query).bindparams(**params)
+        total_count_result = db.session.execute(_get_query(True))
+        rows = total_count_result.fetchall()
+        if rows:
+            total_matching_count = rows[0]['count']
+        else:
+            total_matching_count = 0
+
+        result = db.session.execute(_get_query())
+        keys = result.keys()
+        return {
+            'results': [dict(zip(keys, row)) for row in result.fetchall()],
+            'total_matching_count': total_matching_count,
+        }
+
+    @classmethod
     def search(
             cls,
             search_phrase,
@@ -412,7 +483,6 @@ class Note(Base):
             topic,
             datetime_from,
             datetime_to,
-            peer_advising_department_id,
             include_private_notes=False,
             offset=0,
             limit=40,
@@ -424,6 +494,7 @@ class Note(Base):
             params = {
                 'search_phrase': search_phrase,
             }
+
         else:
             fts_selector = 'SELECT id, 0 AS rank FROM notes WHERE deleted_at IS NULL AND is_draft IS FALSE'
             params = {}
@@ -432,11 +503,6 @@ class Note(Base):
         if author_uid:
             author_filter = 'AND notes.author_uid = :author_uid'
             params.update({'author_uid': author_uid})
-
-        peer_advising_department_notes_filter = ''
-        if peer_advising_department_id:
-            peer_advising_department_notes_filter = 'AND notes.peer_advising_department_id = :peer_advising_department_id'
-            params.update({'peer_advising_department_id': peer_advising_department_id})
 
         student_filter = ''
         if student_csid:
@@ -475,12 +541,6 @@ class Note(Base):
             topic_join = 'JOIN note_topics nt ON nt.topic = :topic AND nt.note_id = notes.id'
             params.update({'topic': topic})
 
-        attachments_join = ''
-        group_by_clause = ''
-        if peer_advising_department_id:
-            attachments_join = 'LEFT JOIN note_attachments a ON notes.id = a.note_id AND a.deleted_at IS NULL'
-            group_by_clause = 'GROUP BY notes.id, fts.rank'
-
         where_clause = 'WHERE notes.is_draft IS FALSE'
         where_clause += '' if include_private_notes else ' AND notes.is_private IS FALSE'
 
@@ -488,18 +548,14 @@ class Note(Base):
             query = f"""
                 WITH fts AS ({fts_selector})
                 SELECT {'count(notes.*)' if is_count_query else 'notes.*'}
-                {', count(a.note_id) as attachment_count' if peer_advising_department_id else ''}
                 FROM fts JOIN notes
                     ON fts.id = notes.id
                     {author_filter}
                     {student_filter}
                     {date_filter}
                     {department_filter}
-                    {peer_advising_department_notes_filter}
                 {topic_join}
-                {attachments_join}
                 {where_clause}
-                {group_by_clause}
             """
             if not is_count_query:
                 query += f"""

--- a/src/components/peer/PeerAdvisingNoteTemplateModal.vue
+++ b/src/components/peer/PeerAdvisingNoteTemplateModal.vue
@@ -3,6 +3,7 @@
     <v-dialog
       v-model="model"
       max-width="600"
+      attach="body"
     >
       <v-card>
         <template #title>
@@ -83,7 +84,7 @@
 <script setup>
 
 import {computed, onMounted, ref, watch} from 'vue'
-import {isEmpty, size} from 'lodash'
+import {cloneDeep, isEmpty, size} from 'lodash'
 import RichTextEditor from '@/components/util/RichTextEditor.vue'
 import PeerAdvisingNoteTopics from '@/components/peer/PeerAdvisingNoteTopics.vue'
 import ProgressButton from '@/components/util/ProgressButton.vue'
@@ -163,7 +164,7 @@ const assignEditedNoteTemplateValues = () => {
   if (props.selectedNoteTemplate && ['copy', 'edit', 'view'].includes(props.action)) {
     noteDetailsText.value = props.selectedNoteTemplate.body
     templateName.value = props.action === 'copy' ? props.selectedNoteTemplate.title + ' Copy' : props.selectedNoteTemplate.title
-    topicsSelected.value = props.selectedNoteTemplate.topics
+    topicsSelected.value = cloneDeep(props.selectedNoteTemplate.topics)
   } else {
     noteDetailsText.value = ''
     templateName.value = ''
@@ -225,6 +226,7 @@ const isExistingName = (name) => {
 </script>
 
 <style>
+.ck-balloon-panel{z-index:9999 !important}
 #note-template-details .ck-editor__editable {
   height: 180px;
   width: 100%;

--- a/src/components/peer/PeerAdvisingNoteTemplates.vue
+++ b/src/components/peer/PeerAdvisingNoteTemplates.vue
@@ -149,6 +149,7 @@ onMounted(() => {
 
 const getNoteTemplates = () => {
   isLoading.value = true
+  noteTemplates.value = []
   getNoteTemplatesForPeerAdvising(props.peerAdvisingDepartment.id).then(response => {
     noteTemplates.value = response
     isLoading.value = false

--- a/src/views/PeerAdvisorSearch.vue
+++ b/src/views/PeerAdvisorSearch.vue
@@ -11,7 +11,7 @@
             variant="text"
             @click="clearResults"
           >
-            Clear Search Results
+            Return to Home
           </v-btn>
         </div>
       </div>
@@ -87,8 +87,7 @@ const init = (user: BoaUser) => {
 }
 
 const clearResults = () => {
-  notes.value = []
-  totalNoteCount.value = 0
+  router.push({path: '/home'})
 }
 
 </script>


### PR DESCRIPTION
Jiras:
- https://jira-secure.berkeley.edu/browse/BOAC-6064
- https://jira-secure.berkeley.edu/browse/BOAC-6065
- https://jira-secure.berkeley.edu/browse/BOAC-6078

1. PA Search now searches the student names as well as note body
2. Took out Peer Advising Search out of `Note.search` and created a new method `Note.peer_advising_search` to simplify the search method as it was getting way too convoluted. 
3. PA advising templates - now you cannot have duplicate topics while editing a template. 
4. Added **Back to Home** button in search page