### PR TITLE
BOAC-6119: blurs entire peer note in demo mode

### DIFF
--- a/src/components/peer/note/PeerAdvisingNoteDetails.vue
+++ b/src/components/peer/note/PeerAdvisingNoteDetails.vue
@@ -3,8 +3,8 @@
     <div v-if="!noteDetails">
       Loading...
     </div>
-    <div v-if="noteDetails">
-      <div :class="{'demo-mode-blur': currentUser.inDemoMode}">
+    <div v-if="noteDetails" :class="{'img-blur': currentUser.inDemoMode}">
+      <div>
         <div v-if="noteDetails.subject" :id="`note-${noteDetails.id}-subject`">{{ noteDetails.subject }}</div>
         <div :id="`note-${noteDetails.id}-body`" v-html="noteDetails.body" />
       </div>
@@ -19,7 +19,6 @@
               <router-link
                 v-if="currentUser.isAdmin && noteDetails.peerAdvisingDepartmentId"
                 :id="`note-${noteDetails.id}-link-to-peer-advisor-home`"
-                :class="{'demo-mode-blur': currentUser.inDemoMode}"
                 :to="`/peer_advisor/${noteDetails.author.uid}/home`"
               >
                 {{ noteDetails.author.name }}
@@ -28,7 +27,6 @@
                 v-if="!currentUser.isAdmin || !noteDetails.peerAdvisingDepartmentId"
                 :id="`note-${noteDetails.id}-author-name`"
                 :aria-label="`${noteDetails.author.name} UC Berkeley Directory page (opens in new window)`"
-                :class="{'demo-mode-blur': currentUser.inDemoMode}"
                 :href="`https://www.berkeley.edu/directory/results?search-term=${noteDetails.author.name}`"
                 target="_blank"
               >
@@ -41,7 +39,6 @@
           </div>
           <div
             v-if="size(noteDetails.author.departments)"
-            :class="{'demo-mode-blur': currentUser.inDemoMode}"
             class="text-medium-emphasis"
           >
             <div v-for="(department, index) in noteDetails.author.departments" :key="index">
@@ -56,7 +53,7 @@
         <div v-if="noteDetails.topics && size(noteDetails.topics)" class="mt-3">
           <AdvisingNoteTopics :note="noteDetails" read-only />
         </div>
-        <div v-if="noteDetails.contactType" :class="{'demo-mode-blur': currentUser.inDemoMode}" class="mt-3">
+        <div v-if="noteDetails.contactType" class="mt-3">
           <div class="font-size-16 font-weight-bold text-medium-emphasis">Contact Type</div>
           <div :id="`note-${noteDetails.id}-contact-type`">{{ noteDetails.contactType }}</div>
         </div>

--- a/src/views/PeerAdvisorHome.vue
+++ b/src/views/PeerAdvisorHome.vue
@@ -26,7 +26,7 @@
         />
       </div>
     </div>
-    <div class="w=100">
+    <div class="w-100">
       <PeerAdvisorPaginatedNotes
         :notes="notes"
         :on-click-create-note="onClickCreateNote"


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6119

We already use the `img-blur` class on non-peer notes so that links, headers, and pill outlines are blurred in addition to text.