### PR TITLE
BOAC-6130, drop the obsolete 'manually_added_advisees' table in boa db

### DIFF
--- a/scripts/db/migrate/2025/20250411-BOAC-6130/pre_deploy_01_drop_manually_added_advisees.sql
+++ b/scripts/db/migrate/2025/20250411-BOAC-6130/pre_deploy_01_drop_manually_added_advisees.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS public.manually_added_advisees;
+
+COMMIT;


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6130

The script has been run on `boa-dev` and BOA release instructions updated.