### PR TITLE
BOAC-6115, top o' page search for Peer Advisors gives consistent results

### DIFF
--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -370,18 +370,9 @@ def search_peer_advising_notes():
     if not peer_advising_department_id:
         raise BadRequestError('Invalid peer advising department id')
 
-    feed = {}
-    feed.update(_peer_advising_notes_search(search_phrase, params))
-    return tolerant_jsonify(feed)
-
-
-def _peer_advising_notes_search(search_phrase, params):
-    peer_advising_department_id = params.get('peerAdvisingDeptId')
-    limit = int(util.get(params, 'limit', 50))
-    offset = int(util.get(params, 'offset', 0))
-    return search_advising_notes(
+    return tolerant_jsonify(search_advising_notes(
         search_phrase=search_phrase,
         peer_advising_department_id=peer_advising_department_id,
-        limit=limit,
-        offset=offset,
-    )
+        limit=int(util.get(params, 'limit', 50)),
+        offset=int(util.get(params, 'offset', 0)),
+    ))

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -273,12 +273,10 @@ def search_advising_notes(
     benchmark = get_benchmarker('search_advising_notes')
     benchmark('begin')
 
+    search_phrases = []
+    search_phrase = search_phrase.strip() if search_phrase else None
     if search_phrase:
-        search_terms = list({t.group(0) for t in list(re.finditer(TEXT_SEARCH_PATTERN, search_phrase)) if t})
-        search_phrase = ' & '.join(search_terms)
-    else:
-        search_terms = []
-
+        search_phrases = list({t.group(0) for t in list(re.finditer(TEXT_SEARCH_PATTERN, search_phrase)) if t})
     author_uid = get_uid_for_csid(app, author_csid) if (not author_uid and author_csid) else author_uid
 
     # Our offset calculations are unforuntately fussy because note parsing might reveal notes associated with students no
@@ -293,25 +291,25 @@ def search_advising_notes(
         benchmark(f'begin local notes query (iteration {local_notes_query_iteration})')
 
         if peer_advising_department_id:
-            phrases = list(filter(None, re.split(r'[- ]', search_phrase.strip().upper())))
-            student_results = data_loch.match_students_by_name_or_sid(phrases=phrases)
-            matching_sids = [s.get('sid') for s in student_results]
+            students = data_loch.match_students_by_name_or_sid(
+                phrases=list(filter(None, re.split(r'[- ]', search_phrase))),
+            )
             local_search_results = Note.peer_advising_notes_search(
-                search_phrase=search_phrase,
+                peer_advising_department_id=peer_advising_department_id,
+                search_phrases=search_phrases,
+                sids=[s.get('sid') for s in students],
                 offset=(local_notes_query_batch_size * local_notes_query_iteration),
                 limit=local_notes_query_batch_size,
-                peer_advising_department_id=peer_advising_department_id,
-                matching_sids=matching_sids,
             )
         else:
             local_search_results = Note.search(
-                search_phrase=search_phrase,
                 author_uid=author_uid,
-                student_csid=student_csid,
-                department_codes=department_codes,
-                topic=topic,
                 datetime_from=datetime_from,
                 datetime_to=datetime_to,
+                department_codes=department_codes,
+                search_phrases=search_phrases,
+                student_csid=student_csid,
+                topic=topic,
                 offset=(local_notes_query_batch_size * local_notes_query_iteration),
                 limit=local_notes_query_batch_size,
             )
@@ -321,7 +319,7 @@ def search_advising_notes(
 
         benchmark(f'begin local notes parsing (iteration {local_notes_query_iteration})')
         cutoff = min(len(local_batch_results), (offset + limit - len(notes_feed)))
-        notes_feed += _get_local_notes_search_results(local_batch_results, cutoff, search_terms)
+        notes_feed += _get_local_notes_search_results(local_batch_results, cutoff, search_phrases)
 
         benchmark(f'end local notes parsing (iteration {local_notes_query_iteration})')
 
@@ -368,7 +366,7 @@ def search_advising_notes(
     benchmark('end loch notes query')
 
     benchmark('begin loch notes parsing')
-    notes_feed += _get_loch_notes_search_results(loch_results['rows'], search_terms)
+    notes_feed += _get_loch_notes_search_results(loch_results['rows'], search_phrases)
     benchmark('end loch notes parsing')
 
     return {

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -407,77 +407,88 @@ class Note(Base):
     @classmethod
     def peer_advising_notes_search(
             cls,
-            matching_sids,
             peer_advising_department_id,
-            search_phrase,
+            search_phrases,
+            sids,
             offset=0,
             limit=40,
     ):
         params = {
-            'matching_sids': matching_sids,
+            'limit': limit,
+            'offset': offset,
             'peer_advising_department_id': peer_advising_department_id,
-            'search_phrase': search_phrase,
+            'sids': sids,
         }
-        notes_fts_index_sql = """
-            SELECT id, ts_rank(fts_index, to_tsquery('english', :search_phrase || ':*')) AS rank
-            FROM notes_fts_index
-            WHERE fts_index @@ to_tsquery('english', :search_phrase || ':*')
-        """
 
-        def _get_sql(is_count_query=False):
-            # Combine query results with UNION.
-            sql = f"""
-                WITH fts AS (
+        def _get_fts_sql(param_key, phrase, append_union_operator=False):
+            params[param_key] = phrase.upper()
+            return f"""
+                SELECT id, ts_rank(fts_index, to_tsquery('english', :{param_key} || ':*')) AS rank
+                FROM notes_fts_index
+                WHERE fts_index @@ to_tsquery('english', :{param_key} || ':*')
+                {'UNION' if append_union_operator else ''}
+            """
+        notes_fts_index_sql = ''
+        if len(search_phrases) > 1:
+            notes_fts_index_sql += _get_fts_sql('search_phrases_joined', ''.join(search_phrases), True)
+        for index, search_phrase in enumerate(search_phrases):
+            append_union_operator = index < len(search_phrases) - 1
+            notes_fts_index_sql += _get_fts_sql(f'search_phrase_{index}', search_phrase, append_union_operator)
+
+        def _get_fts_rank_query(is_count_query=False):
+            fts_rank_sql = f"""
+                SELECT {'COUNT(DISTINCT fts.id)' if is_count_query else 'DISTINCT ON (fts.id) fts.id, fts.rank'} FROM (
                     {notes_fts_index_sql}
                     UNION
-                    SELECT n.id, 0 AS rank
-                    FROM notes n
-                    WHERE n.sid = ANY(:matching_sids)
-                    AND n.peer_advising_department_id = :peer_advising_department_id
-                )
-                SELECT {'count(notes.*)' if is_count_query else 'notes.*'}, count(a.note_id) as attachment_count
-                FROM fts JOIN notes
-                    ON fts.id = notes.id
-                AND notes.peer_advising_department_id = :peer_advising_department_id
-                LEFT JOIN note_attachments a ON notes.id = a.note_id AND a.deleted_at IS NULL
-                WHERE notes.is_draft IS FALSE
-                {'' if is_count_query else 'GROUP BY notes.id, fts.rank'}
+                    SELECT id, 0 AS rank
+                    FROM notes
+                    WHERE sid = ANY(:sids) AND peer_advising_department_id = :peer_advising_department_id
+                ) AS fts
+                JOIN notes n ON n.id = fts.id
+                WHERE n.peer_advising_department_id = :peer_advising_department_id AND deleted_at IS NULL
+                {'' if is_count_query else 'OFFSET :offset LIMIT :limit'}
             """
-            if not is_count_query:
-                sql += f"""
-                    ORDER BY fts.rank DESC, notes.id
-                    OFFSET {offset} LIMIT {limit}
-                """
-            return sql
-
-        total_matching_count = db.session.execute(text(_get_sql(True)), params).first()['count']
-        results = db.session.execute(text(_get_sql()), params)
-        keys = results.keys()
+            results = db.session.execute(text(fts_rank_sql), params).fetchall()
+            return results[0]['count'] if is_count_query else results
+        total_matching_count = _get_fts_rank_query(is_count_query=True)
+        search_results = []
+        note_id_by_rank = ', '.join([f"({row['id']}, {row['rank']})" for row in _get_fts_rank_query()])
+        if note_id_by_rank:
+            sql = f"""
+                SELECT n.*, COUNT(a.note_id) AS attachment_count
+                FROM notes n
+                JOIN (VALUES {note_id_by_rank}) AS rank(id, ordering) ON rank.id = n.id
+                LEFT JOIN note_attachments a ON n.id = a.note_id AND a.deleted_at IS NULL
+                GROUP BY n.id, rank.ordering
+                ORDER BY rank.ordering
+            """
+            search_results = db.session.execute(text(sql), {'peer_advising_department_id': peer_advising_department_id})
+            keys = search_results.keys()
         return {
-            'results': [dict(zip(keys, row)) for row in results],
+            'results': [dict(zip(keys, row)) for row in search_results],
             'total_matching_count': total_matching_count,
         }
 
     @classmethod
     def search(
             cls,
-            search_phrase,
             author_uid,
-            student_csid,
-            department_codes,
-            topic,
             datetime_from,
             datetime_to,
+            department_codes,
+            search_phrases,
+            student_csid,
+            topic,
             include_private_notes=False,
-            offset=0,
             limit=40,
+            offset=0,
     ):
-        if search_phrase:
+        if search_phrases:
             fts_selector = """SELECT id, ts_rank(fts_index, plainto_tsquery('english', :search_phrase)) AS rank
                 FROM notes_fts_index
                 WHERE fts_index @@ plainto_tsquery('english', :search_phrase)"""
             params = {
-                'search_phrase': search_phrase,
+                'search_phrase': ' & '.join(search_phrases),
             }
 
         else:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6115
https://jira-secure.berkeley.edu/browse/BOAC-6131

In `note.py`, the peer-advising search (1) grabs note-id and rank per peer-advising-dept-id, and then (2) fetches note data, ordered by rank. The change in `advising_note.py` is due to peer-advising-search wanting list of phrases instead of concat'ed list. No logic change in standard (advanced) search.