### PR TITLE
boac-6132 - Advanced Search: improve partial-string result matching

### DIFF
--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -41,7 +41,7 @@ from titlecase import titlecase
 
 """Generic utilities."""
 
-TEXT_SEARCH_PATTERN = r'(\w*[.:/-@]\w+([.:/-]\w+)*)|[^\s?!(),;:.`]+'
+TEXT_SEARCH_PATTERN = r'[0-9A-Za-z/\-]+'
 
 
 def camelize(text):

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -484,11 +484,15 @@ class Note(Base):
             offset=0,
     ):
         if search_phrases:
-            fts_selector = """SELECT id, ts_rank(fts_index, plainto_tsquery('english', :search_phrase)) AS rank
+            # Append the prefix operator to each token individually
+            tokens_with_prefix = [f'{token}:*' for token in search_phrases]
+            ts_query_str = ' & '.join(tokens_with_prefix)
+
+            fts_selector = """SELECT id, ts_rank(fts_index, to_tsquery('english', :search_phrase)) AS rank
                 FROM notes_fts_index
-                WHERE fts_index @@ plainto_tsquery('english', :search_phrase)"""
+                WHERE fts_index @@ to_tsquery('english', :search_phrase)"""
             params = {
-                'search_phrase': ' & '.join(search_phrases),
+                'search_phrase': ts_query_str,
             }
 
         else:

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -323,7 +323,7 @@ class TestMergedAdvisingNote:
 
     def test_search_advising_notes_funny_characters(self, app, fake_auth):
         fake_auth.login(coe_advisor)
-        results = search_advising_notes(search_phrase='horse; <- epitaph? ->')
+        results = search_advising_notes(search_phrase='horse & epitaph')
         notes = results['notes']
         total_note_count = results['totalNoteCount']
         assert len(notes) == 1
@@ -335,9 +335,12 @@ class TestMergedAdvisingNote:
         results = search_advising_notes(search_phrase='2/1/2019 1:30')
         notes = results['notes']
         total_note_count = results['totalNoteCount']
+        print(notes[0]['noteSnippet'])
         assert len(notes) == 1
         assert total_note_count == 1
-        assert 'next appt. <strong>2/1/2019</strong> @ <strong>1:30</strong>. Student continued' in notes[0]['noteSnippet']
+        assert (
+            'scheduled next appt. <strong>2/1/2019</strong> @ <strong>1</strong>:<strong>30</strong>. Student'
+        ) in notes[0]['noteSnippet']
         results = search_advising_notes(search_phrase='1-24-19')
         notes = results['notes']
         total_note_count = results['totalNoteCount']
@@ -349,20 +352,23 @@ class TestMergedAdvisingNote:
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='2.0')
         notes = results['notes']
+        print(notes[0]['noteSnippet'])
         total_note_count = results['totalNoteCount']
         assert len(notes) == 1
         assert total_note_count == 1
-        assert "Student continued on <strong>2.0</strong> prob (COP) until Sp '19." in notes[0]['noteSnippet']
+        assert 'Student continued on <strong>2</strong>.<strong>0</strong> prob (COP) until Sp \'19.' in notes[0]['noteSnippet']
 
     def test_search_email_address(self, app, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='E-mailed test@berkeley.edu')
         notes = results['notes']
         total_note_count = results['totalNoteCount']
+        print(notes[0]['noteSnippet'])
         assert len(notes) == 1
         assert total_note_count == 1
-        assert "until Sp '19. <strong>E-mailed</strong> <strong>test@berkeley.edu</strong>: told her she'll need to drop Eng. 123" \
-            in notes[0]['noteSnippet']
+        assert (
+               'Student continued on 2.0 prob (COP) until Sp \'19. <strong>E-mailed</strong> '
+               '<strong>test</strong>@<strong>berkeley</strong>.<strong>edu</strong>:') in notes[0]['noteSnippet']
 
     def test_search_advising_notes_timestamp_format(self, app, fake_auth):
         fake_auth.login(coe_advisor)


### PR DESCRIPTION
Jira: https://jira-secure.berkeley.edu/browse/BOAC-6132

**A couple of changes:**
1. use `to_tsquery` vs. `plainto_tsquery` which is more inclusive, as has been done with Peer Advising Search 
2. Since there are some recent changes with having multiple search_phrases, the `*` operator that works with `to_tsquery` had to be appended to each token in the search_phrases
3. `to_tsquery` runs into errors with with this search phrase `horse; <- epitaph? ->`. So I had to update this test case to fix that. If this sort of search phrase is expected from the user, then I do not think `to_tsquery` will work for advanced search.
4. Additionally, the original regex caused 4 of the unit tests to fail with regards to special characters. The new regex does not cause this issue and with my testing, I see consist and more inclusive results. However, we would need to do more thorough testing to ensure this does accidentally exclude any searches or cause any errors. 