### PR TITLE
BOAC-5482: fixes keyboard navigation in curated groups menu

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -136,6 +136,14 @@
   min-width: 300px;
   width: 100% !important;
 }
+.curated-group-menu-item-create {
+  bottom: 0;
+  position: sticky;
+}
+.curated-group-menu-item-submit {
+  bottom: 49px;
+  position: sticky;
+}
 .date-input-opacity-override .v-field__input {
   opacity: 1 !important;
 }

--- a/src/components/curated/dropdown/CuratedGroupSelector.vue
+++ b/src/components/curated/dropdown/CuratedGroupSelector.vue
@@ -50,7 +50,9 @@
         <v-list
           v-model:selected="selectedCuratedGroups"
           :aria-label="`Select one or more ${domainLabel(true)}s`"
+          class="pb-1"
           density="compact"
+          max-height="400"
           select-strategy="leaf"
           variant="flat"
         >
@@ -59,12 +61,14 @@
           </v-list-item>
           <v-list-item
             v-for="group in myCuratedGroups"
+            :id="`${idFragment}-${group.id}`"
             :key="group.id"
             :aria-checked="!!find(selectedCuratedGroups, {'id': group.id})"
             class="v-list-item-override py-0"
             density="compact"
             role="checkbox"
             :value="group"
+            @focus="scrollToItem(`${idFragment}-${group.id}`)"
           >
             <template #prepend="{isSelected}">
               <v-list-item-action start>
@@ -87,37 +91,33 @@
               </v-list-item-action>
             </template>
           </v-list-item>
+          <v-list-item class="curated-group-menu-item-submit px-3">
+            <v-btn
+              :id="`submit-${idFragment}`"
+              :aria-label="`Add students to selected ${domainLabel(true)}s`"
+              class="px-6 my-1"
+              color="primary"
+              :disabled="!size(selectedCuratedGroups) || isConfirming || isSaving"
+              height="32"
+              text="Add"
+              @click.stop="onSubmit"
+              @keydown.enter.stop="onSubmit"
+            />
+          </v-list-item>
+          <v-list-item class="curated-group-menu-item-create align-center border-t-sm pt-2 px-3" density="compact">
+            <v-btn
+              :id="`create-${idFragment}`"
+              :aria-label="`Create a new ${domainLabel(false)}`"
+              color="primary"
+              :prepend-icon="mdiPlus"
+              :text="`Create New ${domainLabel(true)}`"
+              slim
+              variant="text"
+              @click.stop="showModal = true"
+              @keydown.enter.stop="showModal = true"
+            />
+          </v-list-item>
         </v-list>
-        <div>
-          <v-list>
-            <v-list-item class="border-t-sm pt-4">
-              <v-btn
-                :id="`submit-${idFragment}`"
-                :aria-label="`Add students to selected ${domainLabel(true)}s`"
-                class="px-6"
-                color="primary"
-                :disabled="!size(selectedCuratedGroups) || isConfirming || isSaving"
-                height="32"
-                text="Add"
-                @click.stop="onSubmit"
-                @keydown.enter.stop="onSubmit"
-              />
-            </v-list-item>
-            <v-list-item class="px-1" density="compact">
-              <v-btn
-                :id="`create-${idFragment}`"
-                :aria-label="`Create a new ${domainLabel(false)}`"
-                color="primary"
-                :prepend-icon="mdiPlus"
-                :text="`Create New ${domainLabel(true)}`"
-                slim
-                variant="text"
-                @click.stop="showModal = true"
-                @keydown.enter.stop="showModal = true"
-              />
-            </v-list-item>
-          </v-list>
-        </div>
       </v-menu>
     </div>
     <CreateCuratedGroupModal
@@ -273,6 +273,16 @@ const refresh = () => {
   isSelectAllChecked.value = size(sids.value) === size(props.students)
 }
 
+const scrollToItem = elementId => {
+  const {scrollX, scrollY} = window
+  const element = document.getElementById(elementId)
+  if (element) {
+    element.scrollIntoView({behavior: 'smooth', block: 'center'})
+    // Preserve the window's original coordinates to prevent the page behind the menu from scrolling.
+    window.scroll(scrollX, scrollY)
+  }
+}
+
 const toggle = checked => {
   sids.value = []
   if (checked) {
@@ -290,4 +300,5 @@ const toggle = checked => {
 <style scoped>
 .button-container {
   min-width: 15rem;
-}</style>
+}
+</style>

--- a/src/components/curated/dropdown/ManageStudent.vue
+++ b/src/components/curated/dropdown/ManageStudent.vue
@@ -53,7 +53,9 @@
       <v-list
         v-model:selected="selectedGroupIds"
         :aria-label="`${props.student.name}\'s ${domainLabel(true)} memberships`"
+        class="pb-1"
         density="compact"
+        max-height="400"
         select-strategy="leaf"
         variant="flat"
       >
@@ -62,12 +64,14 @@
         </v-list-item>
         <v-list-item
           v-for="group in filteredCuratedGroups"
+          :id="`${idFragment}-${group.id}`"
           :key="group.id"
           :aria-checked="!!includes(selectedGroupIds, group.id)"
           density="compact"
           class="v-list-item-override py-0"
           role="checkbox"
           :value="group.id"
+          @focus="scrollToItem(`${idFragment}-${group.id}`)"
         >
           <template #prepend="{isSelected}">
             <v-list-item-action start>
@@ -90,37 +94,33 @@
             </v-list-item-action>
           </template>
         </v-list-item>
+        <v-list-item class="curated-group-menu-item-submit px-3">
+          <v-btn
+            :id="`submit-${idFragment}`"
+            :aria-label="`Apply changes to ${student.name}'s ${domainLabel(true)} memberships`"
+            class="px-6 my-1"
+            color="primary"
+            :disabled="!size(xor(existingGroupMemberships, selectedGroupIds)) || isAdding || isRemoving"
+            height="32"
+            text="Apply"
+            @click.stop="onSubmit"
+            @keydown.enter.stop="onSubmit"
+          />
+        </v-list-item>
+        <v-list-item class="curated-group-menu-item-create align-center border-t-sm pt-2 px-3" density="compact">
+          <v-btn
+            :id="`create-${idFragment}`"
+            color="primary"
+            :prepend-icon="mdiPlus"
+            slim
+            variant="text"
+            @click.stop="showModal = true"
+            @keydown.enter.stop="showModal = true"
+          >
+            Create New {{ domainLabel(true) }}
+          </v-btn>
+        </v-list-item>
       </v-list>
-      <div>
-        <v-list>
-          <v-list-item>
-            <v-btn
-              :id="`submit-${idFragment}`"
-              :aria-label="`Apply changes to ${student.name}'s ${domainLabel(true)} memberships`"
-              class="px-6"
-              color="primary"
-              :disabled="!size(xor(existingGroupMemberships, selectedGroupIds)) || isAdding || isRemoving"
-              height="32"
-              text="Apply"
-              @click.stop="onSubmit"
-              @keydown.enter.stop="onSubmit"
-            />
-          </v-list-item>
-          <v-list-item class="align-center border-t-sm mt-2 pt-2 px-1" density="compact">
-            <v-btn
-              :id="`create-${idFragment}`"
-              color="primary"
-              :prepend-icon="mdiPlus"
-              slim
-              variant="text"
-              @click.stop="showModal = true"
-              @keydown.enter.stop="showModal = true"
-            >
-              Create New {{ domainLabel(true) }}
-            </v-btn>
-          </v-list-item>
-        </v-list>
-      </div>
     </v-menu>
     <CreateCuratedGroupModal
       :cancel="onModalCancel"
@@ -276,10 +276,14 @@ const onSubmit = () => {
 const onUpdateMenuModelValue = isOpen => {
   isMenuOpen.value = isOpen
   refresh()
-  if (!isMenuOpen.value) {
+  if (isOpen) {
+    document.documentElement.classList.add('modal-open')
+  } else {
+    document.documentElement.classList.remove('modal-open')
     contextStore.broadcast('curated-group-deselect-all', props.domain)
   }
 }
+
 const onUpdateMyCuratedGroups = domain => {
   if (domain === props.domain) {
     refresh()
@@ -289,6 +293,16 @@ const onUpdateMyCuratedGroups = domain => {
 const refresh = () => {
   selectedGroupIds.value = clone(existingGroupMemberships.value)
   groupsLoading.value = false
+}
+
+const scrollToItem = elementId => {
+  const {scrollX, scrollY} = window
+  const element = document.getElementById(elementId)
+  if (element) {
+    element.scrollIntoView({behavior: 'smooth', block: 'center'})
+    // Preserve the window's original coordinates to prevent the page behind the menu from scrolling.
+    window.scroll(scrollX, scrollY)
+  }
 }
 </script>
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -34,6 +34,7 @@ export const ANONYMOUS_USER: BoaUser = {
   myDraftNoteCount: undefined as number | undefined,
   name: undefined,
   preferences: {
+    sortBy: undefined as string | undefined,
     termId: undefined as string | undefined
   },
   title: undefined,


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5482

The Apply and Create New Curated Group buttons will stick to the bottom of the menu so they're always visible, and will be reachable via up/down arrow. The rest of the menu items will be scrollable. 