### PR TITLE
BOAC-5905, in search results, sort notes by updated_at, descending

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -962,7 +962,7 @@ def search_sis_advising(
     sql = f"""SELECT DISTINCT {query_columns} FROM {query_tables}
         {topic_join}
         WHERE {where_clause}
-        ORDER BY rank DESC, an.id"""
+        ORDER BY an.created_at DESC, rank DESC"""
 
     if offset is not None and offset > 0:
         sql += ' OFFSET %(offset)s'

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -449,7 +449,7 @@ class Note(Base):
                 JOIN (VALUES {note_id_by_rank}) AS rank(id, ordering) ON rank.id = n.id
                 LEFT JOIN note_attachments a ON n.id = a.note_id AND a.deleted_at IS NULL
                 GROUP BY n.id, rank.ordering
-                ORDER BY rank.ordering
+                ORDER BY n.updated_at DESC, rank.ordering
             """
             search_results = db.session.execute(text(sql))
             keys = search_results.keys()
@@ -548,7 +548,7 @@ class Note(Base):
             """
             if not is_count_query:
                 query += f"""
-                    ORDER BY fts.rank DESC, notes.id
+                    ORDER BY notes.updated_at DESC, fts.rank DESC
                     OFFSET {offset} LIMIT {limit}
                 """
             return text(query).bindparams(**params)

--- a/src/components/search/AdvisingNoteSnippet.vue
+++ b/src/components/search/AdvisingNoteSnippet.vue
@@ -2,7 +2,7 @@
   <div
     :id="`advising-note-search-result-${note.id}`"
     :class="{'demo-mode-blur': currentUser.inDemoMode}"
-    class="pb-2"
+    class="mt-2"
   >
     <h3 class="advising-note-search-result-header">
       <router-link
@@ -22,16 +22,21 @@
       />
       ({{ note.studentSid }})
     </h3>
-    <div
-      :id="`advising-note-search-result-snippet-${note.id}`"
-      class="advising-note-search-result-snippet"
-      v-html="note.noteSnippet"
-    />
-    <div :class="{'demo-mode-blur': currentUser.inDemoMode}" class="advising-note-search-result-footer">
-      <span v-if="note.advisorName" :id="`advising-note-search-result-advisor-${note.id}`">
-        {{ note.advisorName }} -
-      </span>
-      <span v-if="lastModified">{{ lastModified }}</span>
+    <div class="ml-1">
+      <div
+        :id="`advising-note-search-result-snippet-${note.id}`"
+        class="advising-note-search-result-snippet"
+        v-html="note.noteSnippet"
+      />
+      <div
+        :class="{'demo-mode-blur': currentUser.inDemoMode}"
+        class="advising-note-search-result-footer font-size-15 font-weight-bold text-grey"
+      >
+        <span v-if="note.advisorName" :id="`advising-note-search-result-advisor-${note.id}`">
+          {{ note.advisorName }} -
+        </span>
+        <span v-if="lastModified" :id="`advising-note-last-modified-${note.id}`">{{ lastModified }}</span>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/search/AppointmentSnippet.vue
+++ b/src/components/search/AppointmentSnippet.vue
@@ -2,7 +2,7 @@
   <div
     :id="`appointment-search-result-${appointment.id}`"
     :class="{'demo-mode-blur': currentUser.inDemoMode}"
-    class="advising-note-search-result"
+    class="advising-note-search-result mt-2"
   >
     <h3 v-if="appointment.student" class="advising-note-search-result-header">
       <router-link
@@ -30,16 +30,23 @@
         <i>No student record found.</i>
       </div>
     </div>
-    <div
-      :id="`appointment-search-result-snippet-${appointment.id}`"
-      class="advising-note-search-result-snippet"
-      v-html="appointment.detailsSnippet"
-    />
-    <div :class="{'demo-mode-blur': currentUser.inDemoMode}" class="advising-note-search-result-footer mb-2">
-      <span v-if="appointment.advisorName" :id="`appointment-search-result-advisor-${appointment.id}`">
-        {{ appointment.advisorName }} -
-      </span>
-      <span v-if="createdAt">{{ DateTime.fromISO(createdAt, 'yyyy-MM-dd').setZone(timezone).toLocaleString(DateTime.DATE_MED) }}</span>
+    <div class="ml-1">
+      <div
+        :id="`appointment-search-result-snippet-${appointment.id}`"
+        class="advising-note-search-result-snippet"
+        v-html="appointment.detailsSnippet"
+      />
+      <div
+        :class="{'demo-mode-blur': currentUser.inDemoMode}"
+        class="advising-note-search-result-footer font-size-15 font-weight-bold text-grey"
+      >
+        <span v-if="appointment.advisorName" :id="`appointment-search-result-advisor-${appointment.id}`">
+          {{ appointment.advisorName }} -
+        </span>
+        <span v-if="createdAt" :id="`appointment-created-at-date-${appointment.id}`">
+          {{ DateTime.fromISO(createdAt, 'yyyy-MM-dd').setZone(timezone).toLocaleString(DateTime.DATE_MED) }}
+        </span>
+      </div>
     </div>
   </div>
 </template>

--- a/tests/test_api/test_search_controller.py
+++ b/tests/test_api/test_search_controller.py
@@ -442,7 +442,7 @@ class TestNoteSearch:
     def test_search_includes_notes_if_requested(self, coe_advisor, client):
         """Includes notes in search results if notes param is true."""
         api_json = _api_search(client, 'Brigitte', notes=True)
-        self._assert(api_json, note_count=2, note_ids=['11667051-00001', '11667051-00002'])
+        self._assert(api_json, note_count=2, note_ids=['11667051-00002', '11667051-00001'])
 
     def test_search_note_with_null_body(self, asc_advisor, client):
         """Finds newly created BOA note when note body is null."""
@@ -573,7 +573,7 @@ class TestNoteSearch:
             notes=True,
             note_options={'offset': '1'},
         )
-        self._assert(api_json, note_count=2, note_ids=['9000000000-00002', '9100000000-00001'])
+        self._assert(api_json, note_count=2, note_ids=['9100000000-00001', '9000000000-00002'])
 
     def test_search_notes_no_canvas_data_access(self, user_factory, client, fake_auth):
         """A user with no access to Canvas data can still search for notes."""

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -301,8 +301,8 @@ class TestMergedAdvisingNote:
         total_note_count = results['totalNoteCount']
         assert len(notes) == 2
         assert total_note_count == 2
-        assert notes[0]['noteSnippet'] == 'I am <strong>confounded</strong> by this <strong>confounding</strong> student'
-        assert '<strong>confounded</strong> that of himself' in notes[1]['noteSnippet']
+        assert '<strong>confounded</strong> that of himself' in notes[0]['noteSnippet']
+        assert notes[1]['noteSnippet'] == 'I am <strong>confounded</strong> by this <strong>confounding</strong> student'
 
     def test_search_advising_notes_multiple_terms(self, app, fake_auth):
         fake_auth.login(coe_advisor)
@@ -394,8 +394,8 @@ class TestMergedAdvisingNote:
         assert len(notes) == 3
         assert total_note_count == 3
         assert notes[0]['noteSnippet'] == '<strong>Confound</strong> this note - and its successors and assigns'
-        assert notes[1]['noteSnippet'].startswith('I am <strong>confounded</strong>')
-        assert notes[2]['noteSnippet'].startswith('...pity the founder')
+        assert notes[1]['noteSnippet'].startswith('...pity the founder')
+        assert notes[2]['noteSnippet'].startswith('I am <strong>confounded</strong>')
 
     def test_search_advising_notes_paginates_new_and_old(self, app, fake_auth):
         fake_auth.login(coe_advisor)
@@ -419,8 +419,8 @@ class TestMergedAdvisingNote:
         total_note_count = results['totalNoteCount']
         assert len(notes) == 3
         assert notes[0]['noteSnippet'] == 'Planned redundancy - <strong>Confounded</strong> note 5'
-        assert notes[1]['noteSnippet'].startswith('I am <strong>confounded</strong>')
-        assert notes[2]['noteSnippet'].startswith('...pity the founder')
+        assert notes[1]['noteSnippet'].startswith('...pity the founder')
+        assert notes[2]['noteSnippet'].startswith('I am <strong>confounded</strong>')
 
     def test_search_advising_notes_narrowed_by_author(self, app, fake_auth):
         """Narrows results for both new and legacy advising notes by author SID."""


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5905

* appointments are sorted by created_at (descending) because updated_at is not reliable for appts
* this applies to peer-advisor search, too
* I added minor format tweaks (and element IDs) in search results