### PR TITLE
BOAC-6146: allows admin to download PA notes CSV

### DIFF
--- a/boac/api/decorators.py
+++ b/boac/api/decorators.py
@@ -25,8 +25,10 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from functools import wraps
 
+from boac.api.auth_utils import is_authorized_peer_advisor_manager
 from boac.api.util import can_access_admitted_students
 from boac.lib.berkeley import has_any_membership_role, is_peer_advisor, is_peer_advisor_manager
+from boac.models.peer_advising_department import PeerAdvisingDepartment
 from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
 from boac.routes import login_manager
 from flask import current_app as app, request
@@ -185,6 +187,38 @@ def peer_advisor_or_peer_advisor_manager(func):
             app.logger.warning(f'Unauthorized request to {request.path}')
             return login_manager.unauthorized()
     return _peer_advisor_or_peer_advisor_manager
+
+
+def peer_advisor_manager_in_department(func):
+    # Checks if the peer_advisor_manager is in the peer_advising_department in the request
+    @wraps(func)
+    def _peer_advisor_manager_in_department(*args, **kw):
+        # Extract the peer_advising_department_id from the request
+        peer_advising_department_id = kw.get('peer_advising_department_id') or request.view_args.get(
+            'peer_advising_department_id')
+        if peer_advising_department_id is None and request.method == 'POST':
+            peer_advising_department_id = request.get_json().get('peerAdvisingDepartmentId', None)
+        if peer_advising_department_id is None:
+            app.logger.error('Department ID missing from request.')
+            return login_manager.unauthorized()
+        peer_advising_department = PeerAdvisingDepartment.get_department_by_id(peer_advising_department_id)
+        if not peer_advising_department:
+            app.logger.error('Peer Advising department not found')
+            return login_manager.unauthorized()
+        if (current_user.is_authenticated
+                and (
+                    current_user.is_admin
+                    or is_authorized_peer_advisor_manager(
+                        peer_advising_department_id=peer_advising_department.id,
+                        peer_advisor_manager_user_id=current_user.get_id(),
+                    )
+                    or _api_key_ok()
+                )):
+            return func(*args, **kw)
+        else:
+            app.logger.warning(f'Unauthorized request to {request.path}')
+            return login_manager.unauthorized()
+    return _peer_advisor_manager_in_department
 
 
 def peer_advisor_or_peer_advisor_manager_in_department(func):

--- a/boac/api/peer_advising_note_templates_controller.py
+++ b/boac/api/peer_advising_note_templates_controller.py
@@ -38,7 +38,7 @@ from flask_login import current_user
 @peer_advisor_manager_required
 def create_peer_advising_note_template():
     params = request.get_json()
-    peer_advising_department_id = params.get('peerAdvisingDeptId', None)
+    peer_advising_department_id = params.get('peerAdvisingDepartmentId', None)
     note_body = params.get('body', None)
     topics = params.get('topics', None)
     title = params.get('title', None)

--- a/boac/api/peer_advising_reports_controller.py
+++ b/boac/api/peer_advising_reports_controller.py
@@ -26,9 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from datetime import datetime
 import re
 
-from boac.api.auth_utils import is_authorized_peer_advisor_manager
-from boac.api.decorators import peer_advisor_manager_required
-from boac.api.errors import ResourceNotFoundError
+from boac.api.decorators import peer_advisor_manager_in_department
 from boac.lib.http import response_with_csv_download, tolerant_jsonify
 from boac.lib.util import to_iso_format
 from boac.merged.calnet import get_calnet_users_for_uids
@@ -36,99 +34,74 @@ from boac.merged.peer_advising_notes_reports import get_all_peer_advising_notes,
     get_peer_advising_note_author_count, get_peer_advising_note_count_since, get_peer_advising_note_template_usage, \
     get_total_peer_advising_notes
 from boac.models.peer_advising_department import PeerAdvisingDepartment
-from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
 from flask import current_app as app
-from flask_login import current_user
 
 
 @app.route('/api/peer_advising/<peer_advising_department_id>/notes/csv', methods=['POST'])
-@peer_advisor_manager_required
+@peer_advisor_manager_in_department
 def get_peer_advising_csv_download(peer_advising_department_id):
-    if PeerAdvisingDepartmentMember.is_user_in_peer_advising_department(
-        peer_advising_department_id=peer_advising_department_id,
-        user_id=current_user.get_id(),
-    ):
-        rows = []
-        for row in get_all_peer_advising_notes(peer_advising_department_id=peer_advising_department_id):
-            # Line breaks in CSV cause problems
-            body = (row['body'] or '').replace('\n', ' ').replace('\r', ' ').strip()
-            body = re.sub(r'\s+', ' ', body)
-            row['body'] = body
-            rows.append(row)
-        return response_with_csv_download(
-            rows=sorted(rows, key=lambda row: row['created_at'], reverse=True),
-            filename_prefix='boa_peer_advising_notes',
-            fieldnames=[
-                'author_name',
-                'author_uid',
-                'author_role',
-                'author_dept_codes',
-                'body',
-                'contact_type',
-                'peer_advising_department_name',
-                'sid',
-                'student_first_name',
-                'student_last_name',
-                'topics',
-                'created_at',
-                'updated_at',
-            ],
-        )
-    else:
-        return app.login_manager.unauthorized()
+    rows = []
+    for row in get_all_peer_advising_notes(peer_advising_department_id=peer_advising_department_id):
+        # Line breaks in CSV cause problems
+        body = (row['body'] or '').replace('\n', ' ').replace('\r', ' ').strip()
+        body = re.sub(r'\s+', ' ', body)
+        row['body'] = body
+        rows.append(row)
+    return response_with_csv_download(
+        rows=sorted(rows, key=lambda row: row['created_at'], reverse=True),
+        filename_prefix='boa_peer_advising_notes',
+        fieldnames=[
+            'author_name',
+            'author_uid',
+            'author_role',
+            'author_dept_codes',
+            'body',
+            'contact_type',
+            'peer_advising_department_name',
+            'sid',
+            'student_first_name',
+            'student_last_name',
+            'topics',
+            'created_at',
+            'updated_at',
+        ],
+    )
 
 
 @app.route('/api/peer_advising/<peer_advising_department_id>/report/notes')
-@peer_advisor_manager_required
+@peer_advisor_manager_in_department
 def peer_advising_notes_report(peer_advising_department_id):
+    today = datetime.today()
+    timeframe_month = f"{today.year}-{f'0{today.month}' if today.month < 10 else today.month}"
     peer_advising_department = PeerAdvisingDepartment.get_department_by_id(peer_advising_department_id)
-    if not peer_advising_department:
-        raise ResourceNotFoundError('Peer Advising department not found')
-    if current_user.is_admin or is_authorized_peer_advisor_manager(
-        peer_advising_department_id=peer_advising_department.id,
-        peer_advisor_manager_user_id=current_user.get_id(),
-    ):
-        today = datetime.today()
-        timeframe_month = f"{today.year}-{f'0{today.month}' if today.month < 10 else today.month}"
-        return tolerant_jsonify({
-            'currentMonth': {
-                'label': f"{today.strftime('%b')} {today.strftime('%Y')}",
-                'month': today.month,
-                'noteCount': get_peer_advising_note_count_since(
-                    peer_advising_department_id=peer_advising_department.id,
-                    timeframe_month=timeframe_month,
-                ),
-                'peerAdvisingDepartmentId': int(peer_advising_department_id),
-                'peerAdvisors': _peer_advisors_with_note_counts(
-                    peer_advising_department_id=peer_advising_department.id,
-                    timeframe_month=timeframe_month,
-                ),
-                'year': today.year,
-            },
-            'distinctPeerAdvisorAuthors': get_peer_advising_note_author_count(peer_advising_department.id),
-            'noteTemplates': get_peer_advising_note_template_usage(peer_advising_department.id),
-            'peerAdvisingDepartment': peer_advising_department.to_api_json(),
-            'totalPeerAdvisingNoteCount': get_total_peer_advising_notes(peer_advising_department.id),
-        })
-    else:
-        return app.login_manager.unauthorized()
+    return tolerant_jsonify({
+        'currentMonth': {
+            'label': f"{today.strftime('%b')} {today.strftime('%Y')}",
+            'month': today.month,
+            'noteCount': get_peer_advising_note_count_since(
+                peer_advising_department_id=peer_advising_department.id,
+                timeframe_month=timeframe_month,
+            ),
+            'peerAdvisingDepartmentId': int(peer_advising_department_id),
+            'peerAdvisors': _peer_advisors_with_note_counts(
+                peer_advising_department_id=peer_advising_department.id,
+                timeframe_month=timeframe_month,
+            ),
+            'year': today.year,
+        },
+        'distinctPeerAdvisorAuthors': get_peer_advising_note_author_count(peer_advising_department.id),
+        'noteTemplates': get_peer_advising_note_template_usage(peer_advising_department.id),
+        'peerAdvisingDepartment': peer_advising_department.to_api_json(),
+        'totalPeerAdvisingNoteCount': get_total_peer_advising_notes(peer_advising_department.id),
+    })
 
 
 @app.route('/api/peer_advising/<peer_advising_department_id>/report/historical')
-@peer_advisor_manager_required
+@peer_advisor_manager_in_department
 def peer_advising_historical_report(peer_advising_department_id):
-    peer_advising_department = PeerAdvisingDepartment.get_department_by_id(peer_advising_department_id)
-    if not peer_advising_department:
-        raise ResourceNotFoundError('Peer Advising department not found')
-    if current_user.is_admin or is_authorized_peer_advisor_manager(
-        peer_advising_department_id=peer_advising_department.id,
-        peer_advisor_manager_user_id=current_user.get_id(),
-    ):
-        return tolerant_jsonify(_historical_peer_advisors_with_note_counts(
-            peer_advising_department_id=peer_advising_department.id,
-        ))
-    else:
-        return app.login_manager.unauthorized()
+    return tolerant_jsonify(_historical_peer_advisors_with_note_counts(
+        peer_advising_department_id=peer_advising_department_id,
+    ))
 
 
 def _historical_peer_advisors_with_note_counts(peer_advising_department_id):

--- a/boac/api/peer_advising_users_controller.py
+++ b/boac/api/peer_advising_users_controller.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.auth_utils import is_authorized_peer_advisor_manager
-from boac.api.decorators import peer_advisor_manager_required, peer_advisor_required
+from boac.api.decorators import peer_advisor_manager_in_department, peer_advisor_manager_required, peer_advisor_required
 from boac.api.errors import ResourceNotFoundError
 from boac.api.util import authorized_users_api_feed
 from boac.externals import data_loch
@@ -40,72 +40,63 @@ from flask_login import current_user
 
 
 @app.route('/api/peer_advising/create_peer_advisor', methods=['POST'])
-@peer_advisor_manager_required
+@peer_advisor_manager_in_department
 def create_peer_advisor():
     params = request.get_json()
-    peer_advising_department_id = params.get('peerAdvisingDeptId')
+    peer_advising_department_id = params.get('peerAdvisingDepartmentId')
     uid = params.get('uid')
-    if is_authorized_peer_advisor_manager(
-            peer_advising_department_id=peer_advising_department_id,
-            peer_advisor_manager_user_id=current_user.get_id(),
-    ):
-        peer_advisor = AuthorizedUser.create_or_restore(
-            uid,
-            automate_degree_progress_permission=False,
-            can_access_advising_data=False,
-            can_access_canvas_data=False,
-            created_by=current_user.uid,
-            degree_progress_permission=None,
-        )
-        PeerAdvisingDepartmentMember.create_or_update_membership(
-            authorized_user_id=peer_advisor.id,
-            peer_advising_department_id=peer_advising_department_id,
-            role_type='peer_advisor',
-        )
-        api_json = authorized_users_api_feed([peer_advisor])[0]
-        return tolerant_jsonify(api_json)
-    else:
-        return app.login_manager.unauthorized()
+    peer_advisor = AuthorizedUser.create_or_restore(
+        uid,
+        automate_degree_progress_permission=False,
+        can_access_advising_data=False,
+        can_access_canvas_data=False,
+        created_by=current_user.uid,
+        degree_progress_permission=None,
+    )
+    PeerAdvisingDepartmentMember.create_or_update_membership(
+        authorized_user_id=peer_advisor.id,
+        peer_advising_department_id=peer_advising_department_id,
+        role_type='peer_advisor',
+    )
+    api_json = authorized_users_api_feed([peer_advisor])[0]
+    return tolerant_jsonify(api_json)
 
 
 @app.route('/api/peer_advising/department/<peer_advising_department_id>/<role_type>')
-@peer_advisor_manager_required
+@peer_advisor_manager_in_department
 def get_peer_advising_department(peer_advising_department_id, role_type):
     include_deleted = request.args.get('includeDeleted', False)
     include_note_counts = to_bool_or_none(request.args.get('includeNoteCounts')) or False
     peer_advising_department = PeerAdvisingDepartment.get_department_by_id(peer_advising_department_id)
-    if peer_advising_department:
-        university_dept = UniversityDept.find_by_id(peer_advising_department.university_dept_id)
-        users = AuthorizedUser.get_peer_advising_users(
+    university_dept = UniversityDept.find_by_id(peer_advising_department.university_dept_id)
+    users = AuthorizedUser.get_peer_advising_users(
+        peer_advising_department_id=peer_advising_department_id,
+        role_type=role_type,
+    )
+    if include_deleted:
+        users = users + AuthorizedUser.get_peer_advising_users(
             peer_advising_department_id=peer_advising_department_id,
             role_type=role_type,
+            status='deleted',
         )
-        if include_deleted:
-            users = users + AuthorizedUser.get_peer_advising_users(
-                peer_advising_department_id=peer_advising_department_id,
-                role_type=role_type,
-                status='deleted',
-            )
-        users = authorized_users_api_feed(users)
-        if include_note_counts:
-            note_counts_per_uid = Note.get_note_counts_per_uid(
-                peer_advising_department_id=peer_advising_department.id,
-                uids=[u['uid'] for u in users],
-            )
-            for user in users:
-                user['noteCount'] = note_counts_per_uid.get(user['uid'], 0)
-        users = sorted([{**user, **{'role': role_type}} for user in users], key=lambda u: u['lastName'] or u['uid'])
-        api_json = {
-            **peer_advising_department.to_api_json(),
-            **{
-                'peerAdvisingDepartmentMembers': users,
-                'universityDeptCode': university_dept.dept_code,
-                'universityDeptName': university_dept.dept_name,
-            },
-        }
-        return tolerant_jsonify(api_json)
-    else:
-        raise ResourceNotFoundError('Peer Advising Department not found.')
+    users = authorized_users_api_feed(users)
+    if include_note_counts:
+        note_counts_per_uid = Note.get_note_counts_per_uid(
+            peer_advising_department_id=peer_advising_department.id,
+            uids=[u['uid'] for u in users],
+        )
+        for user in users:
+            user['noteCount'] = note_counts_per_uid.get(user['uid'], 0)
+    users = sorted([{**user, **{'role': role_type}} for user in users], key=lambda u: u['lastName'] or u['uid'])
+    api_json = {
+        **peer_advising_department.to_api_json(),
+        **{
+            'peerAdvisingDepartmentMembers': users,
+            'universityDeptCode': university_dept.dept_code,
+            'universityDeptName': university_dept.dept_name,
+        },
+    }
+    return tolerant_jsonify(api_json)
 
 
 @app.route('/api/peer_advising/student/<sid>')

--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -362,7 +362,7 @@ def _notes_search(search_phrase, params):
 def search_peer_advising_notes():
     params = util.remove_none_values(request.get_json())
 
-    peer_advising_department_id = params.get('peerAdvisingDeptId', None)
+    peer_advising_department_id = params.get('peerAdvisingDepartmentId', None)
     search_phrase = util.get(params, 'searchPhrase', '').strip()
     if not search_phrase:
         raise BadRequestError('Invalid or empty search input')

--- a/src/api/peer-advising-notes.ts
+++ b/src/api/peer-advising-notes.ts
@@ -72,10 +72,10 @@ export function createPeerAdvisingNote(
   return axios.post(`${utils.apiBaseUrl()}/api/peer_advising/note/create`, data).then(response => response.data)
 }
 
-export async function createPeerAdvisingNoteTemplate(peerAdvisingDeptId: number, body: string, title, topics: []) {
+export async function createPeerAdvisingNoteTemplate(peerAdvisingDepartmentId: number, body: string, title, topics: []) {
   const url: string = `${utils.apiBaseUrl()}/api/peer_advising/note_template/create`
   const noteTemplate = {
-    peerAdvisingDeptId: peerAdvisingDeptId,
+    peerAdvisingDepartmentId: peerAdvisingDepartmentId,
     body: body,
     topics: topics,
     title: title

--- a/src/api/peer-advising-users.ts
+++ b/src/api/peer-advising-users.ts
@@ -2,9 +2,9 @@ import axios from 'axios'
 import utils from '@/api/api-utils'
 import type {DepartmentMembershipRole} from '@/lib/types'
 
-export function createPeerAdvisor(peerAdvisingDeptId: number, uid: string) {
+export function createPeerAdvisor(peerAdvisingDepartmentId: number, uid: string) {
   const url: string = `${utils.apiBaseUrl()}/api/peer_advising/create_peer_advisor`
-  return axios.post(url, {peerAdvisingDeptId, uid})
+  return axios.post(url, {peerAdvisingDepartmentId, uid})
     .then(response => response.data)
 }
 
@@ -18,15 +18,15 @@ export function getStudentEnrollments(sid: string) {
   return axios.get(url).then(response => response.data)
 }
 
-export function deletePeerAdvisor(peerAdvisingDeptId: number, userId: number) {
+export function deletePeerAdvisor(peerAdvisingDepartmentId: number, userId: number) {
   const headers = {'Content-Type': 'application/json'}
-  const url: string = `${utils.apiBaseUrl()}/api/peer_advising/delete_peer_advisor/${peerAdvisingDeptId}/${userId}`
+  const url: string = `${utils.apiBaseUrl()}/api/peer_advising/delete_peer_advisor/${peerAdvisingDepartmentId}/${userId}`
   return axios.delete(url, {headers})
 }
 
-export async function restorePeerAdvisor(peerAdvisingDeptId: number, userId: number) {
+export async function restorePeerAdvisor(peerAdvisingDepartmentId: number, userId: number) {
   const headers = {'Content-Type': 'application/json'}
-  const url: string = `${utils.apiBaseUrl()}/api/peer_advising/restore_peer_advisor/${peerAdvisingDeptId}/${userId}`
+  const url: string = `${utils.apiBaseUrl()}/api/peer_advising/restore_peer_advisor/${peerAdvisingDepartmentId}/${userId}`
   return axios.get(url, {headers}).then(response => response.data)
 }
 

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -53,7 +53,7 @@ export function peerAdvisorSearch(phrase: string, peerAdvisingDepartmentId: numb
     return axios
     .post(`${utils.apiBaseUrl()}/api/peer_advising/notes/search`, {
       searchPhrase: phrase,
-      peerAdvisingDeptId: peerAdvisingDepartmentId,
+      peerAdvisingDepartmentId: peerAdvisingDepartmentId,
       offset: offset || 0,
       limit: limit || 50
     })

--- a/tests/test_api/test_peer_advising_note_templates_controller.py
+++ b/tests/test_api/test_peer_advising_note_templates_controller.py
@@ -55,7 +55,7 @@ class TestCreatePeerAdvisingNoteTemplate:
     def test_not_authenticated(self, client, mock_peer_advising_note_template):
         """Returns 401 if not authenticated."""
         data = {
-            'peerAdvisingDeptId': self.ce3_navcal_peer_advising_department_id,
+            'peerAdvisingDepartmentId': self.ce3_navcal_peer_advising_department_id,
             'body': mock_peer_advising_note_template.body,
             'title': mock_peer_advising_note_template.title,
             'topics': [t.topic for t in mock_peer_advising_note_template.topics],
@@ -66,7 +66,7 @@ class TestCreatePeerAdvisingNoteTemplate:
         """Returns 401 if current user is an admin (or lacks proper advising access)."""
         fake_auth.login(qcadv_advisor_uid)
         data = {
-            'peerAdvisingDeptId': self.ce3_navcal_peer_advising_department_id,
+            'peerAdvisingDepartmentId': self.ce3_navcal_peer_advising_department_id,
             'body': mock_peer_advising_note_template.body,
             'title': mock_peer_advising_note_template.title,
             'topics': [t.topic for t in mock_peer_advising_note_template.topics],
@@ -76,7 +76,7 @@ class TestCreatePeerAdvisingNoteTemplate:
     def test_invalid_parameters(self, client, fake_auth, mock_peer_advising_note_template):
         """Returns 400 if required parameters are missing."""
         fake_auth.login(peer_advisor_manager_uid)
-        # Missing peerAdvisingDeptId.
+        # Missing peerAdvisingDepartmentId.
         data = {
             'body': mock_peer_advising_note_template.body,
             'title': mock_peer_advising_note_template.title,
@@ -88,7 +88,7 @@ class TestCreatePeerAdvisingNoteTemplate:
         """Creates a peer advising note template and returns its JSON."""
         fake_auth.login(peer_advisor_manager_uid)
         data = {
-            'peerAdvisingDeptId': self.ce3_navcal_peer_advising_department_id,
+            'peerAdvisingDepartmentId': self.ce3_navcal_peer_advising_department_id,
             'body': mock_peer_advising_note_template.body,
             'title': mock_peer_advising_note_template.title,
             'topics': [t.topic for t in mock_peer_advising_note_template.topics],

--- a/tests/test_api/test_peer_advising_search_controller.py
+++ b/tests/test_api/test_peer_advising_search_controller.py
@@ -65,7 +65,7 @@ def _api_search(
         content_type='application/json',
         data=json.dumps({
             'searchPhrase': phrase,
-            'peerAdvisingDeptId': peer_advising_department_id,
+            'peerAdvisingDepartmentId': peer_advising_department_id,
         }),
     )
 

--- a/tests/test_api/test_peer_advising_users_controller.py
+++ b/tests/test_api/test_peer_advising_users_controller.py
@@ -84,7 +84,7 @@ class TestCreatePeerAdvisor:
             expected_status_code=200,
     ):
         data = {
-            'peerAdvisingDeptId': peer_advising_department_id,
+            'peerAdvisingDepartmentId': peer_advising_department_id,
             'uid': uid,
         }
         response = client.post(
@@ -175,7 +175,7 @@ class TestGetPeerAdvisingDepartment:
         api_json = self._api_get_peer_advising_department(
             client=client,
             include_note_counts=True,
-            peer_advising_department_id=2,
+            peer_advising_department_id=peer_advisor_manager['peerAdvisingDepartmentId'],
             role_type='peer_advisor',
         )
         assert api_json['name']


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6146

I refactored the authorization on peer advising endpoints so that each time we're checking if a user is a peer advisor manager, we're also making sure they belong to the right department.

@johncrossman @mohamalnadi Is this a good idea? I assume PAMs should not be allowed to request data for a department they aren't a member of.