### PR TITLE
BOAC-5003, enable SQLALCHEMY_WARN_20 when running pytest

### DIFF
--- a/config/test.py
+++ b/config/test.py
@@ -25,9 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import os
 
-
 _db_port = os.environ.get('PGPORT') or '5432'
-
 
 ALERT_INFREQUENT_ACTIVITY_ENABLED = False
 ALERT_WITHDRAWAL_ENABLED = False
@@ -42,7 +40,7 @@ DATA_LOCH_RDS_URI = f'postgresql://boac:boac@localhost:{_db_port}/boac_loch_test
 
 INDEX_HTML = 'tests/static/test-index.html'
 
-LOGGING_LOCATION = 'STDOUT'
+LOGGING_LOCATION = 'boa-test.log'
 
 SQLALCHEMY_DATABASE_URI = f'postgresql://boac:boac@localhost:{_db_port}/boac_test'
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,9 @@ commands = npm run lint-vue-fix {posargs}
 commands = npm run build-vue
 
 [testenv:test]
-passenv = PGPORT
+pass_env = PGPORT
+setenv =
+    SQLALCHEMY_WARN_20=1
 commands = pytest --durations=10 {posargs: -p no:warnings tests}
 
 [testenv:lint-bea]


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5003

Prep for the move to SQLAlchemy 2.x.  This will put a myriad of deprecation warnings to `boa-test.log` file.