### PR TITLE
BOAC-6150, when it comes to linting, I like it Ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ export BOAC_LOCAL_CONFIGS=/Volumes/XYZ/boac_config
 
 ## Run tests, lint the code
 
-We use [Tox](https://tox.readthedocs.io) for continuous integration. Under the hood, you'll find [PyTest](https://docs.pytest.org), [Flake8](http://flake8.pycqa.org) and [ESLint](https://eslint.org/).
+We use [Tox](https://tox.readthedocs.io) for continuous integration.
+Under the hood, you'll find [PyTest](https://docs.pytest.org), [Ruff](https://github.com/astral-sh/ruff) and [ESLint](https://eslint.org/).
 ```
 # Run tests and linters with Tox's parallel mode:
 tox -p

--- a/bea/conftest.py
+++ b/bea/conftest.py
@@ -62,7 +62,7 @@ from boac.factory import create_app
 import pytest
 
 
-os.environ['BOAC_ENV'] = 'bea'  # noqa
+os.environ['BOAC_ENV'] = 'bea'
 
 _app = create_app()
 

--- a/bea/pages/peer_advising_note_table.py
+++ b/bea/pages/peer_advising_note_table.py
@@ -38,8 +38,7 @@ class PeerAdvisingNoteTable(StudentPageAdvisingNote):
 
     def visible_peer_note_ids(self):
         els = self.elements((By.XPATH, '//button[contains(@id, "open-peer-advising-")]'))
-        ids = [el.get_dom_attribute('id').split('-')[-1] for el in els]
-        return ids
+        return [el.get_dom_attribute('id').split('-')[-1] for el in els]
 
     def show_more_peer_notes(self):
         self.wait_for_element_and_click(self.SHOW_MORE_NOTES_BTN)

--- a/bea/pages/student_page_advising_note.py
+++ b/bea/pages/student_page_advising_note.py
@@ -397,8 +397,7 @@ class StudentPageAdvisingNote(StudentPageTimeline, CreateNoteModal):
 
     def note_export_file_names(self, student):
         names = self.downloaded_zip_file_name_list(self.notes_export_zip_file_name(student))
-        names = list(map(lambda n: n.lower(), names))
-        return names
+        return list(map(lambda n: n.lower(), names))
 
     def expected_note_export_file_names(self, student, notes, downloader):
         names = [self.notes_export_csv_file_name(student)]

--- a/boac/api/admin_reports_controller.py
+++ b/boac/api/admin_reports_controller.py
@@ -195,5 +195,4 @@ def _peer_advising_notes_granular_dept_report(university_dept_id):
 
 
 def _term():
-    term_id = request.args.get('term') or current_term_id()
-    return term_id
+    return request.args.get('term') or current_term_id()

--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -47,7 +47,7 @@ def refresh_request_handler(term_id):
     JobProgress().start({
         'term_id': term_id,
     })
-    app.logger.warn('About to start background thread')
+    app.logger.warning('About to start background thread')
     thread = Thread(
         target=background_thread_refresh,
         daemon=True,
@@ -97,8 +97,7 @@ def background_thread_refresh(app_arg, term_id):
             load_term(term_id)
             JobProgress().end()
         except Exception as e:
-            app.logger.exception(e)
-            app.logger.error('Background thread is stopping')
+            app.logger.exception('Background thread is stopping', exc_info=e)
             JobProgress().update(f'An unexpected error occured: {e}')
             raise e
 

--- a/boac/api/cachejob_controller.py
+++ b/boac/api/cachejob_controller.py
@@ -33,8 +33,7 @@ from flask import current_app as app, request
 
 
 def term():
-    term_id = request.args.get('term') or current_term_id(use_cache=False)
-    return term_id
+    return request.args.get('term') or current_term_id(use_cache=False)
 
 
 @app.route('/api/admin/cachejob')

--- a/boac/api/student_controller.py
+++ b/boac/api/student_controller.py
@@ -150,7 +150,7 @@ def _put_degree_checks_json(student):
 def _student_search_result_json(student, include_email_address_in_label=False):
     label = f"{student.get('first_name', '')} {student.get('last_name', '')} ({student.get('sid')})".strip()
     if include_email_address_in_label and student.get('email_address', None):
-        label += f" – {student.get('email_address')}"
+        label += f" - {student.get('email_address')}"
     return {
         'label': label,
         'sid': student.get('sid'),

--- a/boac/externals/calnet.py
+++ b/boac/externals/calnet.py
@@ -66,8 +66,7 @@ class Client:
         self.server = server
 
     def connect(self):
-        conn = ldap3.Connection(self.server, user=self.bind, password=self.password, auto_bind=ldap3.AUTO_BIND_TLS_BEFORE_BIND)
-        return conn
+        return ldap3.Connection(self.server, user=self.bind, password=self.password, auto_bind=ldap3.AUTO_BIND_TLS_BEFORE_BIND)
 
     def search_csids(self, csids, search_expired=False):
         all_out = []

--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -66,7 +66,7 @@ def _safe_execute(sql, cursor, **kwargs):
         cursor.execute(sql, kwargs)
         query_time = datetime.now().timestamp() - ts
     except psycopg2.Error as e:
-        app.logger.error(f'SQL {sql} threw {e}')
+        app.logger.exception(f'Error running SQL: {sql}', exc_info=e)
         return None
     rows = [dict(r) for r in cursor.fetchall()]
     app.logger.debug(f'Query returned {len(rows)} rows in {query_time} seconds:\n{sql}\n{kwargs}')
@@ -1010,11 +1010,11 @@ def get_advisor_uids_for_affiliations(program, affiliations):
 
 
 def get_coe_ethnicity_codes(scope=()):
-    # TODO Scoping remains in place for the moment, as ethnicity is still a COE-specific category.
+    # TODO: Scoping remains in place for the moment, as ethnicity is still a COE-specific category.
     query_tables = _student_query_tables_for_scope(scope)
     if not query_tables:
         return []
-    # TODO 'Z' is an international visa status rather than an ethnicity, and should be suppressed for now.
+    # TODO: 'Z' is an international visa status rather than an ethnicity, and should be suppressed for now.
     # BOAC will handle international status separately from ethnicity after switching to campus-wide demographic
     # data.
     return safe_execute_rds(f"""SELECT DISTINCT s.ethnicity AS ethnicity_code
@@ -1104,7 +1104,7 @@ def get_other_visa_types():
     return safe_execute_rds(sql)
 
 
-def get_students_query(     # noqa
+def get_students_query(  # noqa: C901, PLR0912, PLR0913, PLR0915
     academic_career=None,
     academic_career_status=None,
     academic_division=None,
@@ -1660,7 +1660,7 @@ def _naturalize_order(column_name):
 
 
 def _number_range_to_sql(column, numrange):
-    # TODO BOAC currently expresses range criteria using Postgres-specific numrange syntax, which must be
+    # TODO: BOAC currently expresses range criteria using Postgres-specific numrange syntax, which must be
     # translated into vanilla SQL for use against Redshift. If we end up keeping these criteria in Redshift
     # long-term, we should look into migrating stored ranges.
     numrange_syntax = re.compile('^numrange\(([0-9\.NUL]+), ([0-9\.NUL]+), \'(.)(.)\'\)$')

--- a/boac/externals/s3.py
+++ b/boac/externals/s3.py
@@ -46,8 +46,7 @@ def stream_object(bucket, key):
     try:
         return smart_open.open(s3_url, 'rb', transport_params=dict(session=session))
     except Exception as e:
-        app.logger.error(f'S3 stream operation failed (bucket={bucket}, key={key})')
-        app.logger.exception(e)
+        app.logger.exception(f'S3 stream operation failed (bucket={bucket}, key={key})', exc_info=e)
         return None
 
 

--- a/boac/lib/background.py
+++ b/boac/lib/background.py
@@ -114,7 +114,7 @@ def _bg_executor(app, method):
                     advisory_unlock(app, lock_connection, BACKGROUND_THREAD_LOCK_ID)
                     app.logger.debug('Background task complete.')
             else:
-                app.logger.warn('Was not granted advisory lock, will not run background method.')
+                app.logger.warning('Was not granted advisory lock, will not run background method.')
 
 
 def try_advisory_lock(app, connection, lock_id):
@@ -123,7 +123,7 @@ def try_advisory_lock(app, connection, lock_id):
     if locked:
         app.logger.info(f'Granted advisory lock {lock_id} for PID {pid}')
     else:
-        app.logger.warn(f'Was not granted advisory lock {lock_id} for PID {pid}')
+        app.logger.warning(f'Was not granted advisory lock {lock_id} for PID {pid}')
     return locked
 
 

--- a/boac/lib/http.py
+++ b/boac/lib/http.py
@@ -86,7 +86,7 @@ def request(url, headers={}, method='get', auth=None, auth_params=None, **kwargs
     app.logger.debug({'message': 'HTTP request', 'url': url, 'method': method, 'headers': sanitize_headers(headers)})
     response = None
     try:
-        # TODO handle methods other than GET
+        # TODO: handle methods other than GET
 
         # By default, the urllib3 package used by Requests will log all request parameters at DEBUG level.
         # If authorization credentials were provided as params, keep them out of log files.
@@ -100,7 +100,7 @@ def request(url, headers={}, method='get', auth=None, auth_params=None, **kwargs
             urllib_logger.setLevel(saved_level)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        app.logger.error(e)
+        app.logger.exception(e)
         return ResponseExceptionWrapper(e, response)
     else:
         return response

--- a/boac/lib/mockingbird.py
+++ b/boac/lib/mockingbird.py
@@ -61,7 +61,7 @@ class MockResponse:
         self.headers = headers
         self.body = body
 
-    def __call__(self, *args):
+    def __call__(self):
         return self.status, self.headers, self.body
 
 
@@ -267,7 +267,7 @@ def register_mock(request_function, response):
     A MockResponse object may be supplied, or, if dynamic behavior is required, a function that returns a MockResponse.
     """
     if isinstance(response, MockResponse):
-        response_function = lambda *args: response
+        response_function = lambda *args: response  # noqa: ARG005
     else:
         response_function = response
 
@@ -317,7 +317,7 @@ def _write_fixture(func, fixture_output_path, pattern, suffix):
         json_path = f'{fixture_output_path}/{pattern_from_args}.{suffix}'
 
         if not response:
-            app.logger.warn(f'Error response, will not write fixture to {json_path}')
+            app.logger.warning(f'Error response, will not write fixture to {json_path}')
             return response
 
         response_body = response.json() if hasattr(response, 'json') else response

--- a/boac/lib/mockingdata.py
+++ b/boac/lib/mockingdata.py
@@ -46,14 +46,14 @@ class MockRows:
     def __init__(self, csv_in):
         self.csv_in = csv_in
 
-    def __call__(self, *args):
+    def __call__(self):
         if self.csv_in is None:
             return None
         # Unless otherwise instructed, `pandas` will interpret numeric strings as numbers instead of strings.
-        df = pandas.read_csv(self.csv_in, dtype={'ldap_uid': object, 'sis_section_num': object, 'uid': object})
+        data_frames = pandas.read_csv(self.csv_in, dtype={'ldap_uid': object, 'sis_section_num': object, 'uid': object})
         # `pandas` also likes to store its numbers as numpy.int64, which is not JSON serializable, so we have
         # to pipe the dataframe through JSON conversion before returning.
-        result = json.loads(df.to_json(None, 'records'))
+        result = json.loads(data_frames.to_json(None, 'records'))
         # Be kind, rewind.
         if hasattr(self.csv_in, 'seek'):
             self.csv_in.seek(0)
@@ -167,7 +167,7 @@ def register_mock(request_function, response):
     A MockRows object may be supplied, or, if dynamic behavior is required, a function that returns a MockRows.
     """
     if isinstance(response, MockRows):
-        response_function = lambda *args: response
+        response_function = lambda *args: response  # noqa: ARG005
     else:
         response_function = response
     _register_mock(request_function, response_function)

--- a/boac/lib/sis_advising.py
+++ b/boac/lib/sis_advising.py
@@ -37,7 +37,7 @@ from flask import current_app as app
 def get_sis_advising_topics(ids):
     topics = data_loch.get_sis_advising_topics(ids)
     topics_by_id = {}
-    for note_or_appointment_id, topics in groupby(topics, key=itemgetter('advising_note_id')):
+    for note_or_appointment_id, topics in groupby(topics, key=itemgetter('advising_note_id')):  # noqa: B020
         topics_by_id[note_or_appointment_id] = [topic['note_topic'] for topic in topics]
     return topics_by_id
 
@@ -53,7 +53,7 @@ def get_sis_advising_attachments(ids):
             'sisFilename': sis_file_name,
             'displayName': sis_file_name if attachment.get('created_by') == 'UCBCONVERSION' else attachment.get('user_file_name'),
         }
-    for note_or_appointment_id, attachments in groupby(attachments, key=itemgetter('advising_note_id')):
+    for note_or_appointment_id, attachments in groupby(attachments, key=itemgetter('advising_note_id')):  # noqa: B020
         attachments_by_id[note_or_appointment_id] = [_attachment_to_json(a) for a in attachments]
     return attachments_by_id
 

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -232,7 +232,7 @@ def get_attachment_filename(attachment_id, path_to_attachment):
     if match:
         return match[1]
     else:
-        app.logger.warn(
+        app.logger.warning(
             f'Note attachment S3 filename did not match expected format: ID = {attachment_id}, filename = {raw_filename}')
         return raw_filename
 

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -651,7 +651,7 @@ def _filter_notes(download_type, notes):
 def _get_asc_advising_note_topics(sid):
     topics = data_loch.get_asc_advising_note_topics(sid)
     topics_by_id = {}
-    for advising_note_id, topics in groupby(topics, key=itemgetter('id')):
+    for advising_note_id, topics in groupby(topics, key=itemgetter('id')):  # noqa: B020
         topics_by_id[advising_note_id] = [topic['topic'] for topic in topics]
     return topics_by_id
 
@@ -659,7 +659,7 @@ def _get_asc_advising_note_topics(sid):
 def _get_e_i_advising_note_topics(sid):
     topics = data_loch.get_e_i_advising_note_topics(sid)
     topics_by_id = {}
-    for advising_note_id, topics in groupby(topics, key=itemgetter('id')):
+    for advising_note_id, topics in groupby(topics, key=itemgetter('id')):  # noqa: B020
         topics_by_id[advising_note_id] = [topic['topic'] for topic in topics]
     return topics_by_id
 
@@ -667,6 +667,6 @@ def _get_e_i_advising_note_topics(sid):
 def _get_eop_advising_note_topics(sid):
     topics = data_loch.get_eop_advising_note_topics(sid)
     topics_by_id = {}
-    for advising_note_id, topics in groupby(topics, key=itemgetter('id')):
+    for advising_note_id, topics in groupby(topics, key=itemgetter('id')):  # noqa: B020
         topics_by_id[advising_note_id] = [topic['topic'] for topic in topics]
     return topics_by_id

--- a/boac/merged/advising_notes_reports.py
+++ b/boac/merged/advising_notes_reports.py
@@ -73,13 +73,13 @@ def low_assignment_scores(term_id=None):
                             max_score = score_info['courseDeciles'][9]
                             if score_info['student']['raw'] < (max_score * 0.7):
                                 sids_with_low_raw_scores.add(sid)
-    app.logger.warn(f'Total of {len(examined_sids)} students in classes. {len(low_sids)} with low scores in a class.')
-    app.logger.warn(f'Low scorers: {sorted(low_sids)}')
-    app.logger.warn(f'  {len(multiple_low_sids)} Low scorers in multiple sites: {sorted(multiple_low_sids)}')
-    app.logger.warn(f'  {len(sids_with_low_raw_scores)} Low scorers with raw score < 70% of max: {sorted(sids_with_low_raw_scores)}')
-    app.logger.warn(f'Total of {len(primary_sections)} primary sections. '
-                    f'{len(primary_sections_with_scored_assignments)} have scores. '
-                    f'{len(primary_sections_with_plottable_assignments)} have a reasonable range of scores.')
+    app.logger.warning(f'Total of {len(examined_sids)} students in classes. {len(low_sids)} with low scores in a class.')
+    app.logger.warning(f'Low scorers: {sorted(low_sids)}')
+    app.logger.warning(f'  {len(multiple_low_sids)} Low scorers in multiple sites: {sorted(multiple_low_sids)}')
+    app.logger.warning(f'  {len(sids_with_low_raw_scores)} Low scorers with raw score < 70% of max: {sorted(sids_with_low_raw_scores)}')
+    app.logger.warning(f'Total of {len(primary_sections)} primary sections. '
+                       f'{len(primary_sections_with_scored_assignments)} have scores. '
+                       f'{len(primary_sections_with_plottable_assignments)} have a reasonable range of scores.')
     return {
         'sids': sorted(examined_sids),
         'low_sids': sorted(low_sids),

--- a/boac/merged/sis_sections.py
+++ b/boac/merged/sis_sections.py
@@ -45,7 +45,7 @@ def get_sis_section(term_id, sis_section_id):
         return False
 
     # If there are multiple rows, all values should be repeated except for meeting schedules and/or instructors.
-    section = {
+    return {
         'termId': term_id,
         'termName': term_name_for_sis_id(term_id),
         'sectionId': rows[0]['sis_section_id'],
@@ -56,7 +56,6 @@ def get_sis_section(term_id, sis_section_id):
         'units': _maximum_units(rows[0]),
         'meetings': _get_meetings(rows),
     }
-    return section
 
 
 def _get_meetings(section_rows):

--- a/boac/merged/student.py
+++ b/boac/merged/student.py
@@ -131,7 +131,7 @@ def get_course_student_profiles(term_id, section_id, offset=None, limit=None, fe
         if featured_enrollment_rows:
             sids = [str(featured_enrollment_rows[0]['sid'])] + sids
 
-    # TODO It's probably more efficient to store class profiles in the loch, rather than distilling them
+    # TODO: It's probably more efficient to store class profiles in the loch, rather than distilling them
     # on the fly from full profiles.
     students = get_full_student_profiles(sids)
 
@@ -244,7 +244,7 @@ def get_student_profile_summaries(sids, term_id=None):
         merge_coe_student_profile_data(profiles_by_sid)
         benchmark('end COE profile merge')
 
-    # TODO Many views require no term enrollment information other than a units count. This datum too should be
+    # TODO: Many views require no term enrollment information other than a units count. This datum too should be
     # stored in the loch without BOAC having to crunch it.
     if not term_id:
         term_id = current_term_id()
@@ -320,7 +320,7 @@ def get_term_units_by_sid(term, sids):
     return term_units_dict
 
 
-def query_students(
+def query_students(  # noqa: PLR0913
     academic_career=None,
     academic_career_status=None,
     academic_division=None,
@@ -672,10 +672,10 @@ def _suppress_canvas_sites(enrollment_term):
 
 def _construct_student_profile(student):
     if not student:
-        return
+        return None
     profiles = get_full_student_profiles([student['sid']])
     if not profiles or not profiles[0]:
-        return
+        return None
     profile = profiles[0]
     sis_profile = profile.get('sisProfile', None)
     if sis_profile and 'level' in sis_profile:
@@ -734,7 +734,7 @@ def _merge_asc_student_profile_data(profiles_by_sid, scope):
 
 
 def _omit_zombie_waitlisted_enrollments(past_term):
-    # TODO Even for current terms, it may be a mistake when SIS data sources show both active and waitlisted
+    # TODO: Even for current terms, it may be a mistake when SIS data sources show both active and waitlisted
     # section enrollments for a single class, but that needs confirmation.
     for course in past_term['enrollments']:
         sections = course['sections']
@@ -744,6 +744,6 @@ def _omit_zombie_waitlisted_enrollments(past_term):
                 if enrollment.get('enrollmentStatus') != 'W':
                     fixed_sections.append(enrollment)
             if not fixed_sections:
-                app.logger.warn(f'SIS provided only waitlisted enrollments in a past term: {past_term}')
+                app.logger.warning(f'SIS provided only waitlisted enrollments in a past term: {past_term}')
             else:
                 course['sections'] = fixed_sections

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -51,7 +51,7 @@ def _get_current_term_start():
 class Alert(Base):
     __tablename__ = 'alerts'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     sid = db.Column(db.String(80), nullable=False)
     alert_type = db.Column(db.String(80), nullable=False)
     key = db.Column(db.String(255), nullable=False)
@@ -171,14 +171,13 @@ class Alert(Base):
         sids = list(alert_counts_by_sid.keys())
 
         def result_to_dict(result):
-            result_dict = {
+            return {
                 'sid': result.get('sid'),
                 'uid': result.get('uid'),
                 'firstName': result.get('first_name'),
                 'lastName': result.get('last_name'),
                 'alertCount': alert_counts_by_sid.get(result.get('sid')),
             }
-            return result_dict
         benchmark('begin get_basic_student_data query')
         students = data_loch.get_basic_student_data(sids)
         benchmark('end get_basic_student_data query')

--- a/boac/models/authorized_user.py
+++ b/boac/models/authorized_user.py
@@ -44,7 +44,7 @@ class AuthorizedUser(Base):
 
     SEARCH_HISTORY_ITEM_MAX_LENGTH = 256
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     automate_degree_progress_permission = db.Column(db.Boolean, nullable=False)
     can_access_advising_data = db.Column(db.Boolean, nullable=False)
     can_access_canvas_data = db.Column(db.Boolean, nullable=False)

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -52,7 +52,7 @@ class CohortFilter(Base):
     __tablename__ = 'cohort_filters'
     __transient_sids = []
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     domain = db.Column(cohort_domain_type, nullable=False)
     owner_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False)
     name = db.Column(db.String(255), nullable=False)

--- a/boac/models/cohort_filter_event.py
+++ b/boac/models/cohort_filter_event.py
@@ -42,7 +42,7 @@ cohort_filter_event_type = ENUM(
 class CohortFilterEvent(db.Model):
     __tablename__ = 'cohort_filter_events'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     cohort_filter_id = db.Column(db.Integer, db.ForeignKey('cohort_filters.id'), nullable=False)
     sid = db.Column(db.String(80), nullable=False)
     event_type = db.Column(cohort_filter_event_type, nullable=False)

--- a/boac/models/curated_group.py
+++ b/boac/models/curated_group.py
@@ -36,7 +36,7 @@ from sqlalchemy import text
 class CuratedGroup(Base):
     __tablename__ = 'student_groups'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     domain = db.Column(cohort_domain_type, nullable=False)
     name = db.Column(db.String(255), nullable=False)
     owner_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False)

--- a/boac/models/degree_progress_category.py
+++ b/boac/models/degree_progress_category.py
@@ -48,7 +48,7 @@ degree_progress_category_type = ENUM(
 class DegreeProgressCategory(Base):
     __tablename__ = 'degree_progress_categories'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     accent_color = db.Column(db.String(255))
     category_type = db.Column(degree_progress_category_type, nullable=False)
     course_units = db.Column(NUMRANGE)

--- a/boac/models/degree_progress_course.py
+++ b/boac/models/degree_progress_course.py
@@ -45,7 +45,7 @@ ACCENT_COLOR_CODES = {
 class DegreeProgressCourse(Base):
     __tablename__ = 'degree_progress_courses'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     accent_color = db.Column(db.String(255))
     category_id = db.Column(db.Integer, db.ForeignKey('degree_progress_categories.id'))
     degree_check_id = db.Column(db.Integer, db.ForeignKey('degree_progress_templates.id'), nullable=False)

--- a/boac/models/degree_progress_template.py
+++ b/boac/models/degree_progress_template.py
@@ -41,7 +41,7 @@ from sqlalchemy.dialects.postgresql import ARRAY
 class DegreeProgressTemplate(Base):
     __tablename__ = 'degree_progress_templates'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     advisor_dept_codes = db.Column(ARRAY(db.String), nullable=False)
     created_by = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False)
     degree_name = db.Column(db.String(255), nullable=False)
@@ -307,7 +307,7 @@ def _get_enrollment_sections(sid):
     enrollments = data_loch.get_enrollments_for_sid(sid=sid)
     for index, term in enumerate(merge_enrollment_terms(enrollments)):
         for enrollment in term.get('enrollments', []):
-            if 'UGRD' == enrollment.get('academicCareer', 'UGRD'):
+            if enrollment.get('academicCareer', 'UGRD') == 'UGRD':
                 for section in enrollment['sections']:
                     section['displayName'] = enrollment['displayName']
                     section['termId'] = term['termId']

--- a/boac/models/degree_progress_unit_requirement.py
+++ b/boac/models/degree_progress_unit_requirement.py
@@ -32,7 +32,7 @@ from dateutil.tz import tzutc
 class DegreeProgressUnitRequirement(Base):
     __tablename__ = 'degree_progress_unit_requirements'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     created_by = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False)
     min_units = db.Column(db.Integer, nullable=False)
     name = db.Column(db.String(255), nullable=False)

--- a/boac/models/development_db.py
+++ b/boac/models/development_db.py
@@ -42,10 +42,10 @@ from boac.models.topic import Topic
 from boac.models.university_dept import UniversityDept
 from boac.models.university_dept_member import UniversityDeptMember
 # Models below are included so that db.create_all will find them.
-from boac.models.alert import Alert # noqa
-from boac.models.db_relationships import AlertView  # noqa
-from boac.models.job_progress import JobProgress # noqa
-from boac.models.json_cache import JsonCache # noqa
+from boac.models.alert import Alert  # noqa: F401
+from boac.models.db_relationships import AlertView  # noqa: F401
+from boac.models.job_progress import JobProgress  # noqa: F401
+from boac.models.json_cache import JsonCache  # noqa: F401
 from flask import current_app as app
 from sqlalchemy.sql import text
 

--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -42,7 +42,7 @@ cache_thread = threading.local()
 
 class JsonCache(Base):
     __tablename__ = 'json_cache'
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     key = db.Column(db.String, nullable=False, unique=True)
     json = db.Column(JSONB)
 
@@ -112,7 +112,7 @@ def insert_row(key, json):
         db.session.add(row)
         std_commit()
     except IntegrityError:
-        app.logger.warn(f'Conflict for key {key}; will attempt to return stowed JSON')
+        app.logger.warning(f'Conflict for key {key}; will attempt to return stowed JSON')
         stowed = JsonCache.query.filter_by(key=key).first()
         if stowed is not None:
             return stowed.json
@@ -142,8 +142,8 @@ def log_table_sizes():
         std_commit()
         sizes = [dict(r) for r in dbresp.fetchall()]
         for s in sizes:
-            app.logger.info('Table ' + s['table_name'] + ' currently uses ' + s['total'])
+            app.logger.info(f"Table {s['table_name']} currently uses {s['total']}")
         return sizes
     except SQLAlchemyError as err:
-        app.logger.error(f'SQL {sql} threw {err}')
+        app.logger.exception(f'SQL {sql} threw {err}', exc_info=err)
         return None

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -56,7 +56,7 @@ note_contact_type_enum = ENUM(
 class Note(Base):
     __tablename__ = 'notes'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     author_uid = db.Column(db.String(255), nullable=False)
     author_name = db.Column(db.String(255), nullable=False)
     author_role = db.Column(db.String(255), nullable=False)

--- a/boac/models/note_attachment.py
+++ b/boac/models/note_attachment.py
@@ -33,7 +33,7 @@ from sqlalchemy import and_
 class NoteAttachment(db.Model):
     __tablename__ = 'note_attachments'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     note_id = db.Column(db.Integer, db.ForeignKey('notes.id'), nullable=False)
     path_to_attachment = db.Column('path_to_attachment', db.String(255), nullable=False)
     uploaded_by_uid = db.Column('uploaded_by_uid', db.String(255), nullable=False)

--- a/boac/models/note_template.py
+++ b/boac/models/note_template.py
@@ -36,7 +36,7 @@ from sqlalchemy import and_
 class NoteTemplate(Base):
     __tablename__ = 'note_templates'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     body = db.Column(db.Text, nullable=False)
     creator_id = db.Column(db.Integer, db.ForeignKey('authorized_users.id'), nullable=False)
     deleted_at = db.Column(db.DateTime, nullable=True)

--- a/boac/models/note_template_attachment.py
+++ b/boac/models/note_template_attachment.py
@@ -33,7 +33,7 @@ from sqlalchemy import and_
 class NoteTemplateAttachment(db.Model):
     __tablename__ = 'note_template_attachments'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     note_template_id = db.Column(db.Integer, db.ForeignKey('note_templates.id'), nullable=False)
     path_to_attachment = db.Column('path_to_attachment', db.String(255), nullable=False)
     uploaded_by_uid = db.Column('uploaded_by_uid', db.String(255), nullable=False)

--- a/boac/models/note_template_topic.py
+++ b/boac/models/note_template_topic.py
@@ -30,7 +30,7 @@ from sqlalchemy import and_
 class NoteTemplateTopic(db.Model):
     __tablename__ = 'note_template_topics'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     note_template_id = db.Column(db.Integer, db.ForeignKey('note_templates.id'), nullable=False)
     topic = db.Column(db.String(50), nullable=False)
     note_template = db.relationship('NoteTemplate', back_populates='topics')

--- a/boac/models/note_topic.py
+++ b/boac/models/note_topic.py
@@ -30,7 +30,7 @@ from sqlalchemy import and_
 class NoteTopic(db.Model):
     __tablename__ = 'note_topics'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     note_id = db.Column(db.Integer, db.ForeignKey('notes.id'), nullable=False)
     topic = db.Column(db.String(50), nullable=False)
     author_uid = db.Column(db.String(255), db.ForeignKey('authorized_users.uid'), nullable=False)

--- a/boac/models/peer_advising_department.py
+++ b/boac/models/peer_advising_department.py
@@ -30,7 +30,7 @@ from boac.models.base import Base
 class PeerAdvisingDepartment(Base):
     __tablename__ = 'peer_advising_departments'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     name = db.Column(db.String(255), nullable=False)
     university_dept_id = db.Column(db.Integer, db.ForeignKey('university_depts.id'), nullable=False)
 

--- a/boac/models/peer_advising_topic.py
+++ b/boac/models/peer_advising_topic.py
@@ -32,7 +32,7 @@ from boac.lib.util import to_iso_format, utc_now
 class PeerAdvisingTopic(db.Model):
     __tablename__ = 'peer_advising_topics'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     topic = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
     deleted_at = db.Column(db.DateTime, nullable=True)

--- a/boac/models/tool_setting.py
+++ b/boac/models/tool_setting.py
@@ -31,7 +31,7 @@ from boac.models.base import Base
 class ToolSetting(Base):
     __tablename__ = 'tool_settings'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     key = db.Column(db.String(255), nullable=False, unique=True)
     value = db.Column(db.String(255), nullable=False)
 

--- a/boac/models/topic.py
+++ b/boac/models/topic.py
@@ -33,7 +33,7 @@ from sqlalchemy import text
 class Topic(db.Model):
     __tablename__ = 'topics'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     topic = db.Column(db.String(255), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
     deleted_at = db.Column(db.DateTime, nullable=True)
@@ -73,7 +73,7 @@ class Topic(db.Model):
 
     @classmethod
     def find_by_id(cls, topic_id):
-        return cls.query.filter(cls.id == topic_id).first()  # noqa: E711
+        return cls.query.filter(cls.id == topic_id).first()
 
     @classmethod
     def get_usage_statistics(cls):

--- a/boac/models/university_dept.py
+++ b/boac/models/university_dept.py
@@ -31,7 +31,7 @@ from sqlalchemy.sql import text
 class UniversityDept(Base):
     __tablename__ = 'university_depts'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     dept_code = db.Column(db.String(80), nullable=False)
     dept_name = db.Column(db.String(255), nullable=False)
     authorized_users = db.relationship(

--- a/boac/models/user_login.py
+++ b/boac/models/user_login.py
@@ -23,7 +23,6 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-
 from datetime import datetime
 
 from boac import db, std_commit
@@ -33,7 +32,7 @@ from sqlalchemy.sql import desc
 class UserLogin(db.Model):
     __tablename__ = 'user_logins'
 
-    id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
+    id = db.Column(db.Integer, nullable=False, primary_key=True)
     uid = db.Column(db.String(255), db.ForeignKey('authorized_users.uid'), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
 

--- a/config/bea.py
+++ b/config/bea.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import logging
 import os
 
-ADMIN_PASSWORD = 'secret'
+ADMIN_PASSWORD = 'secret'  # noqa: S105
 ADMIN_UID = '123456'
 ADMIN_USERNAME = 'secret'
 

--- a/config/default.py
+++ b/config/default.py
@@ -117,7 +117,7 @@ DEPARTMENTS_SUPPORTING_DROP_INS = []
 DEPARTMENTS_SUPPORTING_SAME_DAY_APPTS = []
 
 DEVELOPER_AUTH_ENABLED = False
-DEVELOPER_AUTH_PASSWORD = 'another secret'
+DEVELOPER_AUTH_PASSWORD = 'another secret'  # noqa: S105
 
 # Notify BOA users when they are accessing boa-dev, boa-qa, and boa-demo. Unlike service announcements, this
 # warning can only be unpublished by setting config to None.
@@ -137,7 +137,7 @@ INDEX_HTML = 'dist/static/index.html'
 
 LDAP_HOST = 'ldap-test.berkeley.edu'
 LDAP_BIND = 'mybind'
-LDAP_PASSWORD = 'secret'
+LDAP_PASSWORD = 'secret'  # noqa: S105
 
 LEGACY_EARLIEST_TERM = 'Fall 2001'
 
@@ -163,7 +163,7 @@ PHOTO_SIGNED_URL_EXPIRES_IN_SECONDS = 15 * 60
 PING_FREQUENCY = 900000
 
 # Used to encrypt session cookie.
-SECRET_KEY = 'secret'
+SECRET_KEY = 'secret'  # noqa: S105
 
 # Save DB changes at the end of a request.
 SQLALCHEMY_COMMIT_ON_TEARDOWN = True
@@ -185,5 +185,5 @@ USER_SEARCH_HISTORY_MAX_SIZE = 5
 VUE_LOCALHOST_BASE_URL = None
 
 # We keep these out of alphabetical sort above for readability's sake.
-HOST = '0.0.0.0'
+HOST = '0.0.0.0'  # noqa: S104
 PORT = 5000

--- a/consoler.py
+++ b/consoler.py
@@ -24,7 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.factory import create_app
-from pprintpp import pprint as pp # noqa
+from pprintpp import pprint as pp  # noqa: F401
 
 """Run Flask-wrapped code from a Python console.
 
@@ -59,5 +59,5 @@ app = create_app()
 ac = app.app_context()
 ac.push()
 
-print('You are now in a Flask app context. To run normal app teardown processes, type:')
-print('   ac.pop()')
+print('You are now in a Flask app context. To run normal app teardown processes, type:')  # noqa: T201
+print('   ac.pop()')  # noqa: T201

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ moto==3.1.16
 pytest==8.3.5
 pytest-flask==1.3.0
 responses==0.25.7
+ruff==0.11.6
 tox==4.25.0
 
 # For BEA

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,78 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".ebextensions",
+    ".git",
+    ".idea",
+    ".platform",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    "__pycache__",
+    "dist",
+    "fixtures",
+    "node_modules",
+    "public",
+    "src",
+    "venv"
+]
+extend-exclude = ["config/development-local.py"]
+
+# Same as Black.
+line-length = 150
+indent-width = 4
+
+# Python version
+target-version = "py311"
+
+[lint]
+select = ['ALL']
+
+# TODO: Rules we want to enable:
+# B006, B007, B008, C402, C403, C408, C417, DTZ002, DTZ005, DTZ007, FBT002, FBT003, ISC002, PERF102, PIE800, PIE800,
+# PIE804, PLR1714, PLR5501, PLW2901, PTH113, RET503, RET505, RET506, RET506, RET508, RUF015, SIM102, SIM108, SIM115,
+# SIM118, SIM210, SIM401, SIM910, SLF001, TRY300, TRY401, UP012, UP015, UP017, UP028
+
+# Rules to ignore
+ignore = [
+    "ANN", "ANN202", "ARG001", "B006", "B007", "B008", "B023", "B904", "B905", "C401", "C402", "C403", "C408", "C416",
+    "C417", "D10", "D203", "D211", "D212", "D213", "DTZ", "E731", "EM101", "EM102", "FBT002", "FBT003", "FIX002",
+    "FLY002", "G004", "I001", "ICN001", "INP001", "ISC002", "PERF102", "PERF401", "PIE800", "PIE804", "PLC0206",
+    "PLC1802", "PLR1714", "PLR1736", "PLR2004", "PLR5501", "PLW0603", "PLW2901", "PTH", "Q000", "RET503", "RET505",
+    "RET506", "RET506", "RET508", "RUF005", "RUF012", "RUF015", "S101", "S108", "S311", "S603", "S608", "SIM102",
+    "SIM108", "SIM115", "SIM118", "SIM210", "SIM401", "SIM910", "SLF001", "TD002", "TD003", "TRY003", "TRY201",
+    "TRY300", "TRY401", "UP012", "UP015", "UP017", "UP028", "W605"
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.pylint]
+max-args = 21
+max-branches = 15
+max-statements = 58
+
+[lint.mccabe]
+max-complexity = 13
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[lint.per-file-ignores]
+"bea/*" = [
+    "ARG", "B010", "B018", "C419", "C901", "ERA001", "PLE0704", "PLR091", "PLR1704", "PT026", "Q004", "RUF", "SIM",
+    "TD004", "TRY", "UP"
+]

--- a/scripts/db/migrate/2018/20180327-BOAC-613/copy_advisor_lists_to_student_groups_table.py
+++ b/scripts/db/migrate/2018/20180327-BOAC-613/copy_advisor_lists_to_student_groups_table.py
@@ -53,14 +53,14 @@ def main(app):
                         if Student.find_by_sid(sid):
                             group = StudentGroup.get_or_create_my_primary(owner.id)
                             StudentGroup.add_student(group.id, sid)
-                            print(f'[INFO] Student {sid} added to the \'My Students\' group owned by UID {owner.uid}')
+                            print(f'[INFO] Student {sid} added to the \'My Students\' group owned by UID {owner.uid}')  # noqa: T201
                         else:
-                            print(f'[WARN] Student {sid} does not exist')
+                            print(f'[WARN] Student {sid} does not exist')  # noqa: T201
                     else:
-                        print(f'[WARN] AuthorizedUser {owner_uid} does not exist')
+                        print(f'[WARN] AuthorizedUser {owner_uid} does not exist')  # noqa: T201
     else:
-        print(f'[ERROR] File not found: {advisor_watchlists_data}')
-    print('\nDone. Enjoy the rest of your day.\n')
+        print(f'[ERROR] File not found: {advisor_watchlists_data}')  # noqa: T201
+    print('\nDone. Enjoy the rest of your day.\n')  # noqa: T201
 
 
 main()

--- a/scripts/db/migrate/2018/20180418-BOAC-782/pre_deploy_02_migrate_asc_advisors.py
+++ b/scripts/db/migrate/2018/20180418-BOAC-782/pre_deploy_02_migrate_asc_advisors.py
@@ -47,7 +47,7 @@ def main(app):
     result = connection.execute(text('SELECT id FROM university_depts WHERE dept_code = \'UWASC\''))
     university_dept_id = result.fetchall()[0][0]
 
-    print(f'[INFO] Inserted \'Athletic Study Center\' department in db (university_dept_id = {university_dept_id})')
+    print(f'[INFO] Inserted \'Athletic Study Center\' department in db (university_dept_id = {university_dept_id})')  # noqa: T201
 
     for user in AuthorizedUser.query.all():
         if user.is_advisor or user.is_director:
@@ -58,9 +58,9 @@ def main(app):
                     ({university_dept_id}, {user.id}, {user.is_advisor}, {user.is_director}, now(), now())
             """
             connection.execute(text(sql))
-            print(f'[INFO] User {user.uid} added to \'Athletic Study Center\' with is_advisor={user.is_advisor} and is_director={user.is_director}')
+            print(f'[INFO] User {user.uid} added to \'Athletic Study Center\' with is_advisor={user.is_advisor} and is_director={user.is_director}')  # noqa: T201
     connection.close()
-    print('\nDone.\n')
+    print('\nDone.\n')  # noqa: T201
 
 
 main()

--- a/scripts/db/migrate/2018/20180809-BOAC-1147/create_my_students_cohort_per_uid.py
+++ b/scripts/db/migrate/2018/20180809-BOAC-1147/create_my_students_cohort_per_uid.py
@@ -46,11 +46,11 @@ def main(app):
             label=label,
             advisor_ldap_uid=uid,
         )
-        print(f'Cohort created: {cohort}')
+        print(f'Cohort created: {cohort}')  # noqa: T201
     else:
-        print('ERROR: Failed to create cohort')
+        print('ERROR: Failed to create cohort')  # noqa: T201
 
-    print('\nDone.\n')
+    print('\nDone.\n')  # noqa: T201
 
 
 main()

--- a/scripts/db/migrate/2018/20180822-BOAC-1165/alter_advisor_uid_key_in_cohort_json.py
+++ b/scripts/db/migrate/2018/20180822-BOAC-1165/alter_advisor_uid_key_in_cohort_json.py
@@ -51,7 +51,7 @@ def main(app):
             # Update db
             cohort.filter_criteria = json.dumps(criteria)
             std_commit()
-            print(f'Cohort {cohort.id} updated to have {pluralized_key}: {criteria[pluralized_key]}')
+            print(f'Cohort {cohort.id} updated to have {pluralized_key}: {criteria[pluralized_key]}')  # noqa: T201
 
 
 main()

--- a/scripts/db/migrate/2019/20190716-BOAC-2256/alter_ethnicities_key_in_cohort_json.py
+++ b/scripts/db/migrate/2019/20190716-BOAC-2256/alter_ethnicities_key_in_cohort_json.py
@@ -51,7 +51,7 @@ def main(app):
             # Update db
             cohort.filter_criteria = json.dumps(criteria)
             std_commit()
-            print(f'Cohort {cohort.id} updated to have {coe_key}: {criteria[coe_key]}')
+            print(f'Cohort {cohort.id} updated to have {coe_key}: {criteria[coe_key]}')  # noqa: T201
 
 
 main()

--- a/scripts/db/migrate/2019/20190716-BOAC-2256/alter_urm_key_in_cohort_json.py
+++ b/scripts/db/migrate/2019/20190716-BOAC-2256/alter_urm_key_in_cohort_json.py
@@ -50,7 +50,7 @@ def main(app):
             # Update db
             cohort.filter_criteria = json.dumps(criteria)
             std_commit()
-            print(f'Cohort {cohort.id} updated to have {coe_key}: {criteria[coe_key]}')
+            print(f'Cohort {cohort.id} updated to have {coe_key}: {criteria[coe_key]}')  # noqa: T201
 
 
 main()

--- a/scripts/db/migrate/2019/20190716-BOAC-2384/alter_advisor_uid_key_in_cohort_json.py
+++ b/scripts/db/migrate/2019/20190716-BOAC-2384/alter_advisor_uid_key_in_cohort_json.py
@@ -51,7 +51,7 @@ def main(app):
             # Update db
             cohort.filter_criteria = json.dumps(criteria)
             std_commit()
-            print(f'Cohort {cohort.id} updated to have {coe_key}: {criteria[coe_key]}')
+            print(f'Cohort {cohort.id} updated to have {coe_key}: {criteria[coe_key]}')  # noqa: T201
 
 
 main()

--- a/scripts/db/migrate/2019/20190924-BOAC-2620/post_deploy_01_gpa_json_in_cohort_filter.py
+++ b/scripts/db/migrate/2019/20190924-BOAC-2620/post_deploy_01_gpa_json_in_cohort_filter.py
@@ -33,8 +33,8 @@ from boac.lib import scriptify
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../..')))
 
 
-@scriptify.in_app  # noqa: C901
-def main(app):  # noqa: C901
+@scriptify.in_app
+def main(app):  # noqa: C901, PLR0912
     from boac import std_commit
     from boac.models.cohort_filter import CohortFilter
 
@@ -84,7 +84,7 @@ def main(app):  # noqa: C901
                         print(f"""
                             [INFO] Cohort {cohort.id}:
                                 'gpaRanges'=[{old_values_joined}] converted to 'gpaRanges'=[{joined}]
-                        """)
+                        """)  # noqa: T201
                         db_update_needed = True
 
                 elif key == 'lastNameRange':
@@ -93,7 +93,7 @@ def main(app):  # noqa: C901
                         [INFO] Cohort {cohort.id}:
                             'lastNameRange'={old_values_joined} converted to
                             'lastNameRanges'=[{criteria['lastNameRanges']}]
-                    """)
+                    """)  # noqa: T201
                     db_update_needed = True
 
         if db_update_needed:
@@ -102,8 +102,8 @@ def main(app):  # noqa: C901
             std_commit()
 
     if errors:
-        print('\n[ERROR] Invalid ranges were found (see below) and not migrated.')
-        print('\n'.join(errors))
+        print('\n[ERROR] Invalid ranges were found (see below) and not migrated.')  # noqa: T201
+        print('\n'.join(errors))  # noqa: T201
 
 
 main()

--- a/scripts/scriptpath.py
+++ b/scripts/scriptpath.py
@@ -27,7 +27,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import os
 import sys
 
-from boac.lib import scriptify # noqa
+from boac.lib import scriptify  # noqa: F401
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/scripts/student_api_fixtures.py
+++ b/scripts/student_api_fixtures.py
@@ -54,10 +54,10 @@ def main(app):
             else:
                 failures.append(csid)
 
-    print(f'Complete. Generated fixtures for {success_count} CSIDs.')
+    print(f'Complete. Generated fixtures for {success_count} CSIDs.')  # noqa: T201
     if len(failures):
-        print(f'Failed to generate fixtures for {len(failures)} CSIDs:')
-        print(failures)
+        print(f'Failed to generate fixtures for {len(failures)} CSIDs:')  # noqa: T201
+        print(failures)  # noqa: T201
 
 
 main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,8 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from tests.util import mock_advising_note_s3_bucket, override_config
 
-os.environ['BOAC_ENV'] = 'test'  # noqa
-os.environ['EC2_INSTANCE_ID'] = 'test: EC2_INSTANCE_ID'  # noqa
+os.environ['BOAC_ENV'] = 'test'
+os.environ['EC2_INSTANCE_ID'] = 'test: EC2_INSTANCE_ID'
 
 DATA_LOCH_TEST_DATA_BY_DEPT = {
     'COENG': {
@@ -108,7 +108,7 @@ DATA_LOCH_TEST_DATA_BY_DEPT = {
 }
 
 
-class FakeAuth(object):
+class FakeAuth:
     def __init__(self, the_app, the_client):
         self.app = the_app
         self.client = the_client
@@ -119,12 +119,11 @@ class FakeAuth(object):
                 'uid': uid,
                 'password': self.app.config['DEVELOPER_AUTH_PASSWORD'],
             }
-            user_profile = self.client.post(
+            return self.client.post(
                 '/api/auth/dev_auth_login',
                 data=json.dumps(params),
                 content_type='application/json',
             ).json
-        return user_profile
 
 
 # Because app and db fixtures are only created once per pytest run, individual tests
@@ -144,12 +143,12 @@ def app(request):
     # Pop the context after running tests.
     def teardown():
         ctx.pop()
-    request.addfinalizer(teardown)
+    request.addfinalizer(teardown)  # noqa: PT021
 
     return _app
 
 
-# TODO Perform DB schema creation and deletion outside an app context, enabling test-specific app configurations.
+# TODO: Perform DB schema creation and deletion outside an app context, enabling test-specific app configurations.
 @pytest.fixture(scope='session')
 def db(app):
     """Fixture database object, shared by all tests."""
@@ -160,12 +159,12 @@ def db(app):
     return development_db.load(load_test_data=True)
 
 
-@pytest.fixture(autouse=True, scope='function')
+@pytest.fixture(autouse=True)
 def logout():
     logout_user()
 
 
-@pytest.fixture(scope='function', autouse=True)
+@pytest.fixture(autouse=True)
 def db_session(db):
     """Fixture database session used for the scope of a single test.
 
@@ -195,7 +194,7 @@ def db_session(db):
     return _session
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def fake_auth(app, db, client):
     """Shortcut to start an authenticated session."""
     yield FakeAuth(app, client)
@@ -227,7 +226,7 @@ def fake_sts(app):
     mock_sts().stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_alerts(client, db_session):
     """Create assignment and midterm grade alerts."""
     # Create three canned alerts for the current term and one for the previous term.
@@ -261,7 +260,7 @@ def create_alerts(client, db_session):
     Alert.update_all_for_term(2178)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_advising_note(app, db):
     """Create advising note with attachment (mock s3)."""
     note = _create_mock_note(
@@ -279,7 +278,7 @@ def mock_advising_note(app, db):
     std_commit(allow_test_environment=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_note_draft(app, db):
     """Create advising note draft with attachment (mock s3)."""
     note = _create_mock_note(
@@ -296,7 +295,7 @@ def mock_note_draft(app, db):
     std_commit(allow_test_environment=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_note_template(app, db):
     """Create advising note template with attachment (mock s3)."""
     with mock_advising_note_s3_bucket(app):
@@ -328,7 +327,7 @@ def mock_note_template(app, db):
             NoteTemplate.delete(note_template_id=note_template.id)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_private_advising_note(app, db):
     """Create a private advising note with attachment (mock s3)."""
     note = _create_mock_note(
@@ -344,7 +343,7 @@ def mock_private_advising_note(app, db):
     std_commit(allow_test_environment=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def user_factory(app, db):
     def _user_factory(
             automate_degree_progress_permission=None,
@@ -480,7 +479,7 @@ def _create_user(
         )
     is_coe = 'COENG' in dept_codes
     authorized_user = AuthorizedUser(
-        automate_degree_progress_permission=is_coe if automate_degree_progress_permission is None else automate_degree_progress_permission,  # noqa: E501
+        automate_degree_progress_permission=is_coe if automate_degree_progress_permission is None else automate_degree_progress_permission,
         can_access_canvas_data=can_access_canvas_data,
         created_by='0',
         degree_progress_permission=degree_progress_permission,
@@ -501,7 +500,7 @@ def _create_user(
     return authorized_user
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_peer_advising_note_template(app, db):
     """Create peer advising note template."""
     timestamp = datetime.now().timestamp()
@@ -526,7 +525,7 @@ def mock_peer_advising_note_template(app, db):
     NoteTemplate.delete(note_template_id=note_template.id)
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_peer_advising_note(fake_auth, db):
     """Create a Peer Advising Note."""
     # Set up the test by creating a note authored by CE3 Peer Advisor.

--- a/tests/test_api/test_admin_reports_controller.py
+++ b/tests/test_api/test_admin_reports_controller.py
@@ -129,7 +129,7 @@ class TestBoaNotesMonthlyCountReport:
         fake_auth.login(l_s_director_uid)
         self._api_notes_report(client)
 
-    def test_admin(self, client, fake_auth, mock_advising_note):
+    def test_admin(self, client, fake_auth, mock_advising_note):  # noqa: ARG002
         """Admin can access BOA notes monthly count report."""
         fake_auth.login(admin_uid)
         report = self._api_notes_report(client)

--- a/tests/test_api/test_admit_controller.py
+++ b/tests/test_api/test_admit_controller.py
@@ -29,21 +29,6 @@ asc_advisor_id = '1081940'
 ce3_advisor_id = '2525'
 
 
-@pytest.fixture()
-def admin_login(fake_auth):
-    fake_auth.login(admin_uid)
-
-
-@pytest.fixture()
-def asc_advisor_login(fake_auth):
-    fake_auth.login(asc_advisor_id)
-
-
-@pytest.fixture()
-def ce3_advisor_login(fake_auth):
-    fake_auth.login(ce3_advisor_id)
-
-
 @pytest.mark.usefixtures('db_session')
 class TestAdmitBySid:
     """Admit by SID API."""
@@ -60,12 +45,14 @@ class TestAdmitBySid:
         """Returns 401 if not authenticated."""
         self._api_admit_by_sid(client=client, sid=self.admit_sid, expected_status_code=401)
 
-    def test_admit_by_sid_non_ce3_advisor(self, client, asc_advisor_login):
+    def test_admit_by_sid_non_ce3_advisor(self, client, fake_auth):
         """Returns 401 if user is a non-CE3 advisor."""
+        fake_auth.login(asc_advisor_id)
         self._api_admit_by_sid(client=client, sid=self.admit_sid, expected_status_code=401)
 
-    def test_admit_by_sid_ce3_advisor(self, client, ce3_advisor_login):
+    def test_admit_by_sid_ce3_advisor(self, client, fake_auth):
         """Returns admit data if user is a CE3 advisor."""
+        fake_auth.login(ce3_advisor_id)
         response = self._api_admit_by_sid(client=client, sid=self.admit_sid)
         assert response['sid'] == self.admit_sid
 
@@ -84,12 +71,14 @@ class TestAllAdmits:
         """Returns 401 if not authenticated."""
         self._api_all_admits(client=client, expected_status_code=401)
 
-    def test_all_admits_non_ce3_advisor(self, client, asc_advisor_login):
+    def test_all_admits_non_ce3_advisor(self, client, fake_auth):
         """Returns 401 if user is a non-CE3 advisor."""
+        fake_auth.login(asc_advisor_id)
         self._api_all_admits(client=client, expected_status_code=401)
 
-    def test_all_admits_ce3_advisor(self, client, ce3_advisor_login):
+    def test_all_admits_ce3_advisor(self, client, fake_auth):
         """Returns admit data if user is a CE3 advisor."""
+        fake_auth.login(ce3_advisor_id)
         response = self._api_all_admits(client=client)
         assert len(response['students']) == 3
         assert response['totalStudentCount'] == 3

--- a/tests/test_api/test_alerts_controller.py
+++ b/tests/test_api/test_alerts_controller.py
@@ -43,7 +43,7 @@ class TestAlertsController:
     def _get_dismissed(cls, alerts):
         return list(filter(lambda a: a['dismissed'], alerts))
 
-    def test_dismiss_alerts(self, create_alerts, fake_auth, client):
+    def test_dismiss_alerts(self, create_alerts, fake_auth, client):  # noqa: ARG002
         """Can dismiss alerts for one user without affecting visibility for other users."""
         fake_auth.login(admin_uid)
         advisor_1_alerts = self._get_alerts(client, 61889)
@@ -65,7 +65,7 @@ class TestAlertsController:
         assert len(advisor_2_alerts) == 4
         assert len(self._get_dismissed(advisor_2_alerts)) == 0
 
-    def test_duplicate_dismiss_alerts(self, create_alerts, fake_auth, client):
+    def test_duplicate_dismiss_alerts(self, create_alerts, fake_auth, client):  # noqa: ARG002
         """Shrugs off duplicate dismissals."""
         fake_auth.login(admin_uid)
         advisor_1_alerts = self._get_alerts(client, 61889)
@@ -75,14 +75,14 @@ class TestAlertsController:
         response = client.get('/api/alerts/' + str(alert_id) + '/dismiss')
         assert response.status_code == 200
 
-    def test_dismiss_nonexistent_alerts(self, create_alerts, fake_auth, client):
+    def test_dismiss_nonexistent_alerts(self, create_alerts, fake_auth, client):  # noqa: ARG002
         """Politely handles nonexistent alert dismissals."""
         fake_auth.login(admin_uid)
         response = client.get('/api/alerts/99999999/dismiss')
         assert response.status_code == 400
         assert response.json['message'] == 'No alert found for id 99999999'
 
-    def test_deactivate_alerts(self, create_alerts, fake_auth, client):
+    def test_deactivate_alerts(self, create_alerts, fake_auth, client):  # noqa: ARG002
         """Can programmatically deactivate alerts, removing them for all users."""
         Alert.query.filter_by(key='2178_800900300').first().deactivate()
 
@@ -98,7 +98,7 @@ class TestAlertsController:
         assert next((a for a in advisor_2_alerts if a['key'] == '2178_500600700'), None)
         assert len(self._get_dismissed(advisor_1_alerts)) == 0
 
-    def test_alert_dismissal_updates_cohort_alert_counts(self, db, create_alerts, fake_auth, client):
+    def test_alert_dismissal_updates_cohort_alert_counts(self, db, create_alerts, fake_auth, client):  # noqa: ARG002
         fake_auth.login(asc_advisor_uid)
         cohort_id = all_cohorts_owned_by(asc_advisor_uid)[0]['id']
         response = client.get(f'/api/cohort/{cohort_id}')

--- a/tests/test_api/test_appointments_controller.py
+++ b/tests/test_api/test_appointments_controller.py
@@ -36,12 +36,12 @@ l_s_advisor_no_advising_data_uid = '19735'
 student_sid = '3456789012'
 
 
-@pytest.fixture()
+@pytest.fixture
 def coe_advisor_id():
     return AuthorizedUser.get_id_per_uid(coe_advisor_uid)
 
 
-@pytest.fixture()
+@pytest.fixture
 def l_s_advisor_id():
     return AuthorizedUser.get_id_per_uid(l_s_college_advisor_uid)
 
@@ -67,18 +67,18 @@ class TestMarkAppointmentRead:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_mark_read_not_authenticated(self, app, client):
+    def test_mark_read_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         self._mark_appointment_read(client, '11667051-00010', expected_status_code=401)
 
-    def test_user_without_advising_data_access(self, app, client, fake_auth):
+    def test_user_without_advising_data_access(self, client, fake_auth):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_no_advising_data_uid)
         self._mark_appointment_read(client, '11667051-00010', expected_status_code=401)
         fake_auth.login(l_s_advisor_no_advising_data_uid)
         self._mark_appointment_read(client, '11667051-00010', expected_status_code=401)
 
-    def test_advisor_read_legacy_appointment(self, app, client, fake_auth):
+    def test_advisor_read_legacy_appointment(self, client, fake_auth):
         """L&S advisor reads an imported SIS appointment."""
         appointment_id = '11667051-00010'
         user_id = AuthorizedUser.get_id_per_uid(l_s_college_advisor_uid)

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -40,17 +40,17 @@ coe_advisor_uid = '1022796'
 @pytest.mark.usefixtures('db_session')
 class TestCacheUtils:
 
-    def test_creates_alert_for_midterm_grade(self, app):
+    def test_creates_alert_for_midterm_grade(self):
         from boac.api.cache_utils import refresh_alerts
         refresh_alerts(2178)
         alerts = Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')
         alert = next((a for a in alerts if a['alertType'] == 'midterm'), None)
         assert alert
-        assert 'midterm' == alert['alertType']
-        assert '2178_90100' == alert['key']
-        assert 'BURMESE 1A midpoint deficient grade of D+.' == alert['message']
+        assert alert['alertType'] == 'midterm'
+        assert alert['key'] == '2178_90100'
+        assert alert['message'] == 'BURMESE 1A midpoint deficient grade of D+.'
 
-    def test_update_curated_group_lists(self, app):
+    def test_update_curated_group_lists(self):
         from boac.api.cache_utils import update_curated_group_lists
         curated_group = CuratedGroup.create(
             owner_id=AuthorizedUser.find_by_uid('6446').id,
@@ -72,7 +72,7 @@ class TestCacheUtils:
         assert sid_not_in_data_loch not in final_sids
         assert set(final_sids) == set(original_sids)
 
-    def test_load_filtered_cohort_counts(self, app):
+    def test_load_filtered_cohort_counts(self):
         from boac.api.cache_utils import load_filtered_cohort_counts
         cohorts = all_cohorts_owned_by(admin_uid)
         assert len(cohorts)
@@ -85,7 +85,7 @@ class TestCacheUtils:
 
 class TestRefreshCalnetAttributes:
 
-    def test_removes_and_restores(self, app):
+    def test_removes_and_restores(self):
         from boac.api.cache_utils import refresh_calnet_attributes
         from boac.models import json_cache
         from boac.models.json_cache import JsonCache
@@ -108,7 +108,7 @@ class TestRefreshCalnetAttributes:
 class TestRefreshCurrentTermIndex:
     """Test current term index refresh."""
 
-    def test_refresh_current_term_index(self, app):
+    def test_refresh_current_term_index(self):
         """Deletes existing index from the cache and adds a fresh one."""
         from boac.api.cache_utils import refresh_current_term_index
         from boac.models import json_cache
@@ -129,7 +129,7 @@ class TestRefreshCurrentTermIndex:
 
 class TestRefreshDepartmentMemberships:
 
-    def test_adds_coe_advisors(self, app):
+    def test_adds_coe_advisors(self):
         """Adds COE advisors newly found in the loch."""
         # Note: You will not find this UID in development_db (test data setup). It is seeded in loch.sql test data.
         coe_uid = '1234567'
@@ -192,7 +192,7 @@ class TestRefreshDepartmentMemberships:
         assert user.created_by == '0'
         assert user.department_memberships[0].automate_membership is True
 
-    def test_removes_coe_advisors(self, app):
+    def test_removes_coe_advisors(self):
         """Removes COE advisors not found in the loch."""
         dept_coe = UniversityDept.query.filter_by(dept_code='COENG').first()
         bad_user = AuthorizedUser.create_or_restore(uid='666', created_by='2040')
@@ -218,7 +218,7 @@ class TestRefreshDepartmentMemberships:
         assert next((u for u in coe_users if u.uid == '666'), None) is None
         assert AuthorizedUser.query.filter_by(uid='666').first().deleted_at
 
-    def test_respects_automate_memberships_flag(self, app, db):
+    def test_respects_automate_memberships_flag(self, db):
         dept_coe = UniversityDept.query.filter_by(dept_code='COENG').first()
         manually_added_user = AuthorizedUser.create_or_restore(
             uid='1024',
@@ -256,7 +256,7 @@ class TestRefreshDepartmentMemberships:
         assert next((u for u in coe_users if u.uid == '1024'), None) is None
         assert not AuthorizedUser.find_by_uid(uid='1024')
 
-    def test_replaces_non_automated_user_with_automated_user(self, app, db):
+    def test_replaces_non_automated_user_with_automated_user(self):
         authorized_user_id = AuthorizedUser.query.filter_by(uid='1133397').first().id
         memberships = UniversityDeptMember.query.filter_by(authorized_user_id=authorized_user_id).all()
         assert len(memberships) == 1

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -49,7 +49,7 @@ class TestCohortById:
         cls.coe_owned_cohort = next((c for c in all_cohorts_owned_by(coe_advisor_uid) if c['name'] == 'Radioactive Women and Men'), None)
         cls.asc_owned_cohort = next((c for c in all_cohorts_owned_by(asc_advisor_uid) if c['name'] == 'All sports'), None)
 
-    def test_students_with_alert_counts(self, client, fake_auth, create_alerts, db_session):
+    def test_students_with_alert_counts(self, client, fake_auth, create_alerts):  # noqa: ARG002
         """Pre-load students into cache for consistent alert data."""
         fake_auth.login(asc_advisor_uid)
         Alert.update_all_for_term(2178)
@@ -97,7 +97,7 @@ class TestCohortById:
         assert students_with_alerts[0]['sid'] == '11667051'
         assert students_with_alerts[0]['alertCount'] == 3
 
-    def test_get_cohort(self, client, fake_auth, create_alerts):
+    def test_get_cohort(self, client, fake_auth, create_alerts):  # noqa: ARG002
         """Returns a well-formed response with filtered cohort and alert count per student."""
         fake_auth.login(coe_advisor_uid)
         cohort_id = self.coe_owned_cohort['id']
@@ -119,7 +119,7 @@ class TestCohortById:
         cohort_id = all_cohorts_owned_by(admin_uid)[0]['id']
         api_get_cohort(client, cohort_id, expected_status_code=404)
 
-    def test_undeclared_major(self, app, client, fake_auth):
+    def test_undeclared_major(self, client, fake_auth):
         """Get cohort: Undeclared Major."""
         fake_auth.login(asc_advisor_uid)
         cohort = all_cohorts_owned_by(asc_advisor_uid)[-1]
@@ -201,7 +201,6 @@ class TestCohortById:
 
     def test_includes_cohort_member_academic_standing(self, client, fake_auth):
         fake_auth.login(asc_advisor_uid)
-        # cohort_id = self.asc_owned_cohort['id']
         api_json = api_get_cohort(
             client,
             cohort_id=self.asc_owned_cohort['id'],
@@ -462,7 +461,6 @@ class TestCohortsEveryone:
         assert len(api_json) == 1
         for index, user in enumerate(api_json):
             cohorts = user['cohorts']
-            # count = len(cohorts)
             assert len(cohorts)
             if 0 < index < len(cohorts):
                 # Verify order
@@ -502,7 +500,7 @@ class TestCohortsEveryone:
 
 class TestCohortCreate:
 
-    def test_create_cohort(self, app, client, fake_auth):
+    def test_create_cohort(self, client, fake_auth):
         """Creates custom cohort, owned by current user."""
         fake_auth.login(asc_advisor_uid)
         data = {
@@ -552,7 +550,7 @@ class TestCohortCreate:
         data = {
             'name': 'Complex',
             'filters': [
-                {'key': 'majors', 'value': 'Gender and Women''s Studies'},
+                {'key': 'majors', 'value': 'Gender and Womens Studies'},
                 {'key': 'gpaRanges', 'value': gpa_range_1},
                 {'key': 'levels', 'value': 'Junior'},
                 {'key': 'gpaRanges', 'value': gpa_range_2},
@@ -582,7 +580,7 @@ class TestCohortCreate:
         # Majors
         majors = criteria.get('majors')
         assert len(majors) == 2
-        assert 'Gender and Women''s Studies' in majors
+        assert 'Gender and Womens Studies' in majors
         # Minors
         minors = criteria.get('minors')
         assert len(minors) == 1
@@ -738,7 +736,7 @@ class TestCohortUpdate:
             'name': 'Hack the name!',
         }
         response = self._post_cohort_update(client, data)
-        assert 403 == response.status_code
+        assert response.status_code == 403
 
     def test_update_filters(self, client, fake_auth):
         fake_auth.login(asc_advisor_uid)
@@ -758,7 +756,7 @@ class TestCohortUpdate:
         # First, we POST an empty name
         cohort_id = cohort['id']
         response = self._post_cohort_update(client, {'id': cohort_id})
-        assert 400 == response.status_code
+        assert response.status_code == 400
         # Now, we POST a valid name
         gpa_range = {'min': 2, 'max': 2.499}
         data = {
@@ -769,7 +767,7 @@ class TestCohortUpdate:
             ],
         }
         response = self._post_cohort_update(client, data)
-        assert 200 == response.status_code
+        assert response.status_code == 200
         updated_cohort = response.json
         assert updated_cohort['alertCount'] is not None
         assert updated_cohort['criteria']['majors'] == ['Engineering Undeclared UG']
@@ -937,8 +935,8 @@ class TestCohortPerFilters:
         )
         students = api_json['students']
         assert len(students) == api_json.get('totalStudentCount')
-        assert ['Doolittle', 'Farestveit', 'Jayaprakash', 'Kerschen'] == [s['lastName'] for s in students]
-        assert [3.495, 3.9, 3.501, 3.005] == [s['cumulativeGPA'] for s in students]
+        assert [s['lastName'] for s in students] == ['Doolittle', 'Farestveit', 'Jayaprakash', 'Kerschen']
+        assert [s['cumulativeGPA'] for s in students] == [3.495, 3.9, 3.501, 3.005]
         criteria = api_json['criteria']
         assert len(criteria['gpaRanges']) == 2
         assert len(criteria['lastNameRanges']) == 1
@@ -1514,7 +1512,7 @@ class TestDownloadCsvPerFilters:
                 assert 'Junior' in row
                 assert 'English BA' in row
                 assert ',Engineering; Undergrad Letters & Science,' in row
-                assert 'BURMESE 1A' in row or 'MED ST 205' in row or 'NUC ENG 124' in row or 'PHYSED 11' in row or 'SOCIOL 198'
+                assert 'BURMESE 1A' in row or 'MED ST 205' in row or 'NUC ENG 124' in row or 'PHYSED 11' in row or 'SOCIOL 198' in row
 
     def test_download_csv_custom_columns(self, client, fake_auth):
         """Advisor can generate a CSV with the columns they want."""
@@ -1641,7 +1639,6 @@ class TestDownloadCsvPerFilters:
         assert 'csv' in response.content_type
         csv = str(response.data)
         assert ','.join(self.admit_keys) in csv
-        print(csv)
         assert (
             '19938035,00005852,RES,Transfer,Spring,No,No,College of Letters and Science,'
             'Ralph,,Burgess,1984-09-04,984.110.7693x347,681-857-8070,9590 Chang Extensions,'
@@ -1951,7 +1948,7 @@ class TestCohortFilterOptions:
         for label, option_group in api_json.items():
             for entry in option_group:
                 # Verify the 'default' filters are not present.
-                assert 'unitRanges' != entry['key']
+                assert entry['key'] != 'unitRanges'
                 assert entry['domain'] == 'admitted_students'
 
 
@@ -1970,13 +1967,13 @@ class TestTranslateToFilterOptions:
     def test_translate_criteria_when_empty(self, client, fake_auth):
         """Empty criteria translates to zero rows."""
         fake_auth.login(coe_advisor_uid)
-        assert [] == self._api_translate_to_filter_options(
+        assert self._api_translate_to_filter_options(
             client,
             json_data={
                 'criteria': {},
             },
             owner_uid=coe_advisor_uid,
-        )
+        ) == []
 
     def test_translate_criteria_with_boolean(self, client, fake_auth):
         """Filter-criteria with boolean is properly translated."""

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -29,22 +29,22 @@ import simplejson as json
 from tests.util import override_config
 
 
-@pytest.fixture()
+@pytest.fixture
 def admin_session(fake_auth):
     fake_auth.login('2040')
 
 
-@pytest.fixture()
+@pytest.fixture
 def advisor_session(fake_auth):
     fake_auth.login('1081940')
 
 
-@pytest.fixture()
+@pytest.fixture
 def announcement_unpublished():
     return _update_service_announcement(text='Not reddy four prime tyme', is_published=False)
 
 
-@pytest.fixture()
+@pytest.fixture
 def announcement_published():
     return _update_service_announcement(text='Papa was a rodeo', is_published=True)
 
@@ -97,15 +97,15 @@ class TestServiceAnnouncement:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, client, announcement_published):
+    def test_not_authenticated(self, client, announcement_published):  # noqa: ARG002
         """Returns None to anonymous user."""
         assert self._api_service_announcement(client) is None
 
-    def test_advisor_cannot_read_unpublished(self, client, advisor_session, announcement_unpublished):
+    def test_advisor_cannot_read_unpublished(self, client, advisor_session, announcement_unpublished):  # noqa: ARG002
         """Advisor does not have access to the unpublished announcement."""
         assert self._api_service_announcement(client) is None
 
-    def test_admin_can_read_unpublished(self, client, admin_session, announcement_unpublished):
+    def test_admin_can_read_unpublished(self, client, admin_session, announcement_unpublished):  # noqa: ARG002
         """Admin has access to the unpublished announcement."""
         api_json = self._api_service_announcement(client)
         assert api_json == {
@@ -113,7 +113,7 @@ class TestServiceAnnouncement:
             'isPublished': False,
         }
 
-    def test_announcement_published(self, client, advisor_session, announcement_published):
+    def test_announcement_published(self, client, advisor_session, announcement_published):  # noqa: ARG002
         """All users get the service announcement."""
         assert self._api_service_announcement(client) == announcement_published
 
@@ -149,15 +149,15 @@ class TestUpdateAnnouncement:
         """Rejects anonymous user's attempt to publish."""
         self._publish_announcement(client, publish=True, expected_status_code=401)
 
-    def test_not_authorized_update(self, client, advisor_session):
+    def test_not_authorized_update(self, client, advisor_session):  # noqa: ARG002
         """Rejects advisor's attempt to update."""
         self._update_announcement(client, text='Abigail, Belle of Kilronan', expected_status_code=401)
 
-    def test_not_authorized_publish(self, client, advisor_session):
+    def test_not_authorized_publish(self, client, advisor_session):  # noqa: ARG002
         """Rejects advisor's attempt to publish."""
         self._publish_announcement(client, publish=True, expected_status_code=401)
 
-    def test_update_service_announcement(self, client, admin_session, announcement_published):
+    def test_update_service_announcement(self, client, admin_session, announcement_published):  # noqa: ARG002
         """Admin can update the service announcement text."""
         text = """
         Papa was a rodeo, Mama was a rock'n'roll band

--- a/tests/test_api/test_course_controller.py
+++ b/tests/test_api/test_course_controller.py
@@ -33,12 +33,12 @@ student_sid = '11667051'
 section_id = 90100
 
 
-@pytest.fixture()
+@pytest.fixture
 def asc_advisor(fake_auth):
     fake_auth.login(asc_advisor_uid)
 
 
-@pytest.fixture()
+@pytest.fixture
 def coe_advisor(fake_auth):
     fake_auth.login(coe_advisor_uid)
 
@@ -55,12 +55,12 @@ class TestCourseController:
         fake_auth.login(advisor.uid)
         assert client.get('/api/section/2182/1').status_code == 403
 
-    def test_api_route_not_found(self, coe_advisor, client):
+    def test_api_route_not_found(self, coe_advisor, client):  # noqa: ARG002
         """Returns a 404 for non-existent section_id."""
         response = client.get('/api/section/2222/1')
         assert response.status_code == 404
 
-    def test_get_section(self, coe_advisor, client):
+    def test_get_section(self, coe_advisor, client):  # noqa: ARG002
         """Returns section info from data loch."""
         response = client.get(f'/api/section/{term_id}/{section_id}')
         assert response.status_code == 200
@@ -75,7 +75,7 @@ class TestCourseController:
         assert section['meetings'][0]['time'] == '12:00 pm - 12:59 pm'
         assert section['meetings'][0]['location'] == 'Wheeler 999'
 
-    def test_section_student_details(self, coe_advisor, client):
+    def test_section_student_details(self, coe_advisor, client):  # noqa: ARG002
         """Includes per-student details."""
         response = client.get(f'/api/section/{term_id}/{section_id}')
         students = response.json['students']
@@ -96,7 +96,7 @@ class TestCourseController:
         assert students[0]['enrollment']['midtermGrade'] == 'D+'
         assert isinstance(students[0].get('alertCount'), int)
 
-    def test_section_student_analytics(self, coe_advisor, client):
+    def test_section_student_analytics(self, coe_advisor, client):  # noqa: ARG002
         section_id = 90200
         response = client.get(f'/api/section/{term_id}/{section_id}')
         students = response.json['students']
@@ -119,7 +119,7 @@ class TestCourseController:
         assert students[0]['analytics']['assignmentsSubmitted']['percentile'] == 64
         assert students[0]['analytics']['currentScore']['percentile'] == 42.5
 
-    def test_section_mean_course_analytics(self, coe_advisor, client):
+    def test_section_mean_course_analytics(self, coe_advisor, client):  # noqa: ARG002
         """Calculates mean course analytics across all sites associated with the section."""
         section_id = 90200
         response = client.get(f'/api/section/{term_id}/{section_id}')
@@ -134,20 +134,20 @@ class TestCourseController:
         assert mean_metrics['gpa']['2175'] == 3.055
         assert mean_metrics['gpa']['2172'] == 3.23
 
-    def test_section_student_athletics_asc(self, asc_advisor, client):
+    def test_section_student_athletics_asc(self, asc_advisor, client):  # noqa: ARG002
         """Includes athletics for ASC advisors."""
         response = client.get(f'/api/section/{term_id}/{section_id}')
         students = response.json['students']
         assert len(students[0]['athleticsProfile']['athletics']) == 2
         assert isinstance(students[0].get('alertCount'), int)
 
-    def test_section_student_athletics_non_asc(self, coe_advisor, client):
+    def test_section_student_athletics_non_asc(self, coe_advisor, client):  # noqa: ARG002
         """Does not include athletics for non-ASC advisors."""
         response = client.get(f'/api/section/{term_id}/{section_id}')
         students = response.json['students']
         assert 'athletics' not in students[0]
 
-    def test_section_student_alert_count(self, create_alerts, coe_advisor, client):
+    def test_section_student_alert_count(self, create_alerts, coe_advisor, client):  # noqa: ARG002
         """Includes alert count of COE student."""
         response = client.get(f'/api/section/{term_id}/{section_id}')
         assert response.json['students'][0].get('alertCount') == 4

--- a/tests/test_api/test_curated_group_controller.py
+++ b/tests/test_api/test_curated_group_controller.py
@@ -61,7 +61,7 @@ class TestCreateCuratedGroup:
         curated_group = _api_get_curated_group(client, curated_group_id)
         assert curated_group['ownerName'] == 'Joni Mitchell'
 
-    def test_unauthorized(self, app, client, fake_auth):
+    def test_unauthorized(self, client, fake_auth):
         fake_auth.login(coe_advisor_uid)
         _api_curated_group_create(
             client=client,
@@ -71,7 +71,7 @@ class TestCreateCuratedGroup:
             sids=['5678901234'],
         )
 
-    def test_authorized_ce3(self, app, client, fake_auth):
+    def test_authorized_ce3(self, client, fake_auth):
         fake_auth.login(ce3_advisor_uid)
         sid = '11667051'
         group = _api_curated_group_create(
@@ -106,7 +106,7 @@ class TestGetCuratedGroup:
         admin_curated_groups = CuratedGroup.get_curated_groups(AuthorizedUser.get_id_per_uid(admin_uid))
         _api_get_curated_group(client, admin_curated_groups[0].id, expected_status_code=403)
 
-    def test_curated_group_includes_alert_count(self, client, fake_auth, create_alerts):
+    def test_curated_group_includes_alert_count(self, client, fake_auth, create_alerts):  # noqa: ARG002
         """Includes alert count per student."""
         fake_auth.login(asc_advisor_uid)
         api_json = _api_get_curated_group(client, self.asc_curated_groups[0]['id'])
@@ -151,7 +151,7 @@ class TestGetCuratedGroup:
             self,
             client,
             fake_auth,
-            create_alerts,
+            create_alerts,  # noqa: ARG002
     ):
         """Includes students in response."""
         fake_auth.login(asc_advisor_uid)
@@ -257,7 +257,7 @@ class TestGetCuratedGroup:
             'None (Jayaprakash)',
         ]
 
-    def test_curated_group_detail_includes_profiles(self, client, fake_auth, create_alerts):
+    def test_curated_group_detail_includes_profiles(self, client, fake_auth, create_alerts):  # noqa: ARG002
         """Returns all students with profile data."""
         fake_auth.login(asc_advisor_uid)
         api_json = _api_get_curated_group(client, self.asc_curated_groups[0]['id'])
@@ -343,7 +343,7 @@ class TestGetCuratedGroupStudentsWithAlerts:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_students_with_alerts(self, client, fake_auth, create_alerts, db_session):
+    def test_students_with_alerts(self, client, fake_auth, create_alerts, db_session):  # noqa: ARG002
         """Students with alerts per group id."""
         fake_auth.login(asc_advisor_uid)
         api_json = self._api_students_with_alerts(client, self.asc_curated_groups[0]['id'])
@@ -358,7 +358,7 @@ class TestGetCuratedGroupStudentsWithAlerts:
         students_with_alerts = client.get(f'/api/curated_group/{curated_group_id}/students_with_alerts').json
         assert students_with_alerts[0]['alertCount'] == 3
 
-    def test_group_includes_student_summary(self, client, fake_auth, create_alerts):
+    def test_group_includes_student_summary(self, client, fake_auth, create_alerts):  # noqa: ARG002
         """Returns summary details but not full term and analytics data."""
         fake_auth.login(asc_advisor_uid)
         api_json = self._api_students_with_alerts(client, self.asc_curated_groups[0]['id'])
@@ -650,9 +650,8 @@ class TestDownloadCuratedGroupCSV:
             content_type='application/json',
         )
         # TODO: Do we want to forbid such downloads?
-        # assert response.status_code == 403
 
-    def test_download_admits_csv(self, app, client, fake_auth):
+    def test_download_admits_csv(self, client, fake_auth):
         """Advisor can download CSV of 'admits' group."""
         fake_auth.login(ce3_advisor_uid)
         curated_group = _api_curated_group_create(
@@ -683,7 +682,7 @@ class TestDownloadCuratedGroupCSV:
         assert 'csv' in response.content_type
         csv = str(response.data)
         for snippet in [
-            'birthdate,citizenship_country,family_dependents_num,highest_parent_education_level,non_immigrant_visa_current,xethnic',  # noqa: E501
+            'birthdate,citizenship_country,family_dependents_num,highest_parent_education_level,non_immigrant_visa_current,xethnic',
             '1985-06-02,Greece,05,5 - College Attended,,NotSpecified',
         ]:
             assert str(snippet) in csv

--- a/tests/test_api/test_degree_progress_category_controller.py
+++ b/tests/test_api/test_degree_progress_category_controller.py
@@ -38,7 +38,7 @@ coe_advisor_read_write_uid = '1133399'
 qcadv_advisor_uid = '53791'
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_template():
     user = AuthorizedUser.find_by_uid(coe_advisor_read_write_uid)
     marker = datetime.now().timestamp()
@@ -102,7 +102,7 @@ class TestCreateDegreeCategory:
         assert api_json['position'] == 1
         assert api_json['templateId'] == mock_template.id
 
-    def test_create_campus_requirements(self, client, fake_auth, mock_template, app):
+    def test_create_campus_requirements(self, client, fake_auth, mock_template):
         """Campus Requirements is created as a category with four children."""
         fake_auth.login(coe_advisor_read_write_uid)
         api_json = _api_create_category(

--- a/tests/test_api/test_degree_progress_controller.py
+++ b/tests/test_api/test_degree_progress_controller.py
@@ -41,7 +41,7 @@ coe_student_sid = '9000000000'
 qcadv_advisor_uid = '53791'
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_degree_check():
     user_id = AuthorizedUser.get_id_per_uid(coe_advisor_read_write_uid)
     parent_template = DegreeProgressTemplate.create(
@@ -63,7 +63,7 @@ def mock_degree_check():
     std_commit(allow_test_environment=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_template():
     return DegreeProgressTemplate.create(
         advisor_dept_codes=['COENG'],
@@ -72,7 +72,7 @@ def mock_template():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_unit_requirement():
     template = DegreeProgressTemplate.create(
         advisor_dept_codes=['COENG'],

--- a/tests/test_api/test_degree_progress_student_controller.py
+++ b/tests/test_api/test_degree_progress_student_controller.py
@@ -43,7 +43,7 @@ coe_student_uid = '300847'
 qcadv_advisor_uid = '53791'
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_degree_check():
     authorized_user_id = AuthorizedUser.get_id_per_uid(coe_advisor_read_write_uid)
     dept_codes = ['COENG']
@@ -61,7 +61,7 @@ def mock_degree_check():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_degree_course():
     marker = datetime.now().timestamp()
     sid = '11667051'
@@ -82,7 +82,7 @@ def mock_degree_course():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_degree_checks():
     user = AuthorizedUser.find_by_uid(coe_advisor_read_write_uid)
     marker = datetime.now().timestamp()
@@ -106,7 +106,7 @@ def mock_degree_checks():
     return degree_checks
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_template():
     user = AuthorizedUser.find_by_uid(coe_advisor_read_write_uid)
     marker = datetime.now().timestamp()
@@ -141,7 +141,7 @@ def mock_template():
     return template
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_note():
     user = AuthorizedUser.find_by_uid(coe_advisor_read_write_uid)
     template = DegreeProgressTemplate.create(
@@ -753,14 +753,13 @@ class TestCopyCourse:
 
         # Set up
         def _create_category(category_type='Category', parent_category_id=None):
-            category = DegreeProgressCategory.create(
+            return DegreeProgressCategory.create(
                 category_type=category_type,
                 name=f'{category_type} for {sid} ({datetime.now().timestamp()})',
                 parent_category_id=parent_category_id,
                 position=1,
                 template_id=degree_check_id,
             )
-            return category
         category_1 = _create_category()
         category_2 = _create_category()
         std_commit(allow_test_environment=True)

--- a/tests/test_api/test_note_templates_controller.py
+++ b/tests/test_api/test_note_templates_controller.py
@@ -45,7 +45,7 @@ class TestGetNoteTemplate:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, app, client, mock_note_template):
+    def test_not_authenticated(self, client, mock_note_template):
         """Returns 401 if not authenticated."""
         self._api_note_template(client=client, note_template_id=mock_note_template.id, expected_status_code=401)
 
@@ -54,12 +54,12 @@ class TestGetNoteTemplate:
         fake_auth.login(coe_advisor_no_advising_data_uid)
         self._api_note_template(client=client, note_template_id=mock_note_template.id, expected_status_code=403)
 
-    def test_unauthorized(self, app, client, fake_auth, mock_note_template):
+    def test_unauthorized(self, client, fake_auth, mock_note_template):
         """Returns 403 if user did not create the requested note template."""
         fake_auth.login(coe_advisor_uid)
         self._api_note_template(client=client, note_template_id=mock_note_template.id, expected_status_code=403)
 
-    def test_get_note_template_by_id(self, app, client, fake_auth, mock_note_template):
+    def test_get_note_template_by_id(self, client, fake_auth, mock_note_template):
         """Returns note template in JSON."""
         fake_auth.login(l_s_major_advisor_uid)
         api_json = self._api_note_template(client=client, note_template_id=mock_note_template.id)
@@ -78,7 +78,7 @@ class TestMyNoteTemplates:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, app, client):
+    def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         self._api_my_note_templates(client=client, expected_status_code=401)
 
@@ -87,12 +87,12 @@ class TestMyNoteTemplates:
         fake_auth.login(coe_advisor_no_advising_data_uid)
         self._api_my_note_templates(client=client, expected_status_code=401)
 
-    def test_get_note_template_by_id(self, app, client, fake_auth):
+    def test_get_note_template_by_id(self, client, fake_auth):
         """Returns note templates created by current user."""
         fake_auth.login(l_s_major_advisor_uid)
         creator_id = AuthorizedUser.get_id_per_uid(l_s_major_advisor_uid)
         names = ['Johnny', 'Tommy', 'Joey', 'Dee Dee']
-        for i in range(0, 4):
+        for i in range(4):
             NoteTemplate.create(creator_id=creator_id, title=f'{names[i]}', subject=f'Subject {i}')
         api_json = self._api_my_note_templates(client=client)
         expected_order = [template['title'] for template in api_json]
@@ -102,7 +102,7 @@ class TestMyNoteTemplates:
 
 class TestCreateNoteTemplate:
 
-    def test_not_authenticated(self, app, client):
+    def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         _api_create_note_template(
             client=client,
@@ -111,7 +111,7 @@ class TestCreateNoteTemplate:
             title='Keep a knockin\'',
         )
 
-    def test_admin_is_unauthorized(self, app, client, fake_auth):
+    def test_admin_is_unauthorized(self, client, fake_auth):
         """Returns 403 if user is an admin."""
         fake_auth.login(admin_uid)
         _api_create_note_template(
@@ -121,7 +121,7 @@ class TestCreateNoteTemplate:
             title='Ain\'t gonna happen',
         )
 
-    def test_user_without_advising_data_access(self, app, client, fake_auth, mock_note_draft):
+    def test_user_without_advising_data_access(self, client, fake_auth, mock_note_draft):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_no_advising_data_uid)
         _api_create_note_template(
@@ -131,7 +131,7 @@ class TestCreateNoteTemplate:
             title='Nope',
         )
 
-    def test_create_note_template(self, app, client, fake_auth, mock_advising_note):
+    def test_create_note_template(self, client, fake_auth, mock_advising_note):
         """Create a note template."""
         fake_auth.login(coe_advisor_uid)
         title = 'I get it, I got it'
@@ -315,7 +315,7 @@ class TestRenameNoteTemplate:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_rename_note_template_not_authenticated(self, app, mock_note_template, client):
+    def test_rename_note_template_not_authenticated(self, mock_note_template, client):
         """Returns 401 if not authenticated."""
         self._api_note_template_rename(
             client,
@@ -334,7 +334,7 @@ class TestRenameNoteTemplate:
             expected_status_code=401,
         )
 
-    def test_rename_note_template_unauthorized(self, app, client, fake_auth, mock_note_template):
+    def test_rename_note_template_unauthorized(self, client, fake_auth, mock_note_template):
         """Deny user's attempt to rename someone else's note template."""
         original_subject = mock_note_template.subject
         fake_auth.login(coe_advisor_uid)
@@ -346,7 +346,7 @@ class TestRenameNoteTemplate:
         )
         assert NoteTemplate.find_by_id(mock_note_template.id).subject == original_subject
 
-    def test_update_note_template_topics(self, app, client, fake_auth, mock_note_template):
+    def test_update_note_template_topics(self, client, fake_auth, mock_note_template):
         """Update note template title."""
         user = AuthorizedUser.find_by_id(mock_note_template.creator_id)
         fake_auth.login(user.uid)
@@ -381,7 +381,7 @@ class TestDeleteNoteTemplate:
         assert response.status_code == 403
         assert NoteTemplate.find_by_id(mock_note_template.id)
 
-    def test_delete_note_template_with_attachments(self, app, client, fake_auth, mock_note_draft):
+    def test_delete_note_template_with_attachments(self, client, fake_auth, mock_note_draft):
         """Delete note template that has an attachment."""
         fake_auth.login(l_s_major_advisor_uid)
         note_template = _api_create_note_template(

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -56,7 +56,7 @@ coe_student = {
 }
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_coe_advising_note():
     return Note.create(
         author_uid=coe_advisor_uid,
@@ -69,7 +69,7 @@ def mock_coe_advising_note():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_asc_advising_note(app, db):
     return Note.create(
         author_uid='1133399',
@@ -86,7 +86,7 @@ def mock_asc_advising_note(app, db):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_private_advising_note(app):
     with mock_advising_note_s3_bucket(app):
         base_dir = app.config['BASE_DIR']
@@ -113,16 +113,16 @@ class TestGetDraftNotes:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, app, client, mock_coe_advising_note):
+    def test_not_authenticated(self, client, mock_coe_advising_note):  # noqa: ARG002
         """Returns 401 if not authenticated."""
         self._api_draft_notes(client=client, expected_status_code=401)
 
-    def test_user_without_advising_data_access(self, client, fake_auth, mock_coe_advising_note):
+    def test_user_without_advising_data_access(self, client, fake_auth, mock_coe_advising_note):  # noqa: ARG002
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_no_advising_data_uid)
         self._api_draft_notes(client=client, expected_status_code=401)
 
-    def test_get_note_by_id(self, app, client, fake_auth):
+    def test_get_note_by_id(self, client, fake_auth):
         """Get advising note by ID returns normalized JSON."""
         uid = coe_advisor_uid
         fake_auth.login(uid)
@@ -154,7 +154,7 @@ class TestGetDraftNotes:
 
 class TestGetNote:
 
-    def test_not_authenticated(self, app, client, mock_coe_advising_note):
+    def test_not_authenticated(self, client, mock_coe_advising_note):
         """Returns 401 if not authenticated."""
         _api_note_by_id(client=client, note_id=mock_coe_advising_note.id, expected_status_code=401)
 
@@ -176,7 +176,7 @@ class TestGetNote:
         assert 'Private Idaho' in api_json['subject']
         assert 'potato' in api_json['body']
 
-    def test_get_note_by_id(self, app, client, fake_auth, mock_coe_advising_note):
+    def test_get_note_by_id(self, client, fake_auth, mock_coe_advising_note):
         """Returns note in JSON compatible with BOA front-end."""
         fake_auth.login(admin_uid)
         note = _api_note_by_id(client=client, note_id=mock_coe_advising_note.id)
@@ -209,7 +209,7 @@ class TestGetNote:
 
 class TestCreateNote:
 
-    def test_not_authenticated(self, app, client):
+    def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         assert _api_update_note(
             client=client,
@@ -219,7 +219,7 @@ class TestCreateNote:
             subject='Authorization is overrated.',
         )
 
-    def test_admin_user_is_not_authorized(self, app, client, fake_auth, mock_note_draft):
+    def test_admin_user_is_not_authorized(self, client, fake_auth, mock_note_draft):
         """Returns 404 if user is an admin."""
         fake_auth.login(admin_uid)
         assert _api_update_note(
@@ -230,7 +230,7 @@ class TestCreateNote:
             subject=mock_note_draft.subject,
         )
 
-    def test_unauthorized_private_note(self, app, client, fake_auth, mock_note_draft):
+    def test_unauthorized_private_note(self, client, fake_auth, mock_note_draft):
         """Non-CE3 advisor cannot create a private note."""
         fake_auth.login(mock_note_draft.author_uid)
         assert 'ZCEEE' not in mock_note_draft.author_dept_codes
@@ -243,7 +243,7 @@ class TestCreateNote:
             subject=mock_note_draft.subject,
         )
 
-    def test_user_without_advising_data_access(self, app, client, fake_auth):
+    def test_user_without_advising_data_access(self, client, fake_auth):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_no_advising_data_uid)
         assert _api_create_draft_note(
@@ -251,7 +251,7 @@ class TestCreateNote:
             expected_status_code=401,
         )
 
-    def test_create_note(self, app, client, fake_auth, mock_note_draft):
+    def test_create_note(self, client, fake_auth, mock_note_draft):
         """Create a note."""
         fake_auth.login(mock_note_draft.author_uid)
         subject = 'Vicar in a Tutu'
@@ -264,7 +264,8 @@ class TestCreateNote:
         )
         note_id = new_note.get('id')
         assert new_note['read'] is True
-        assert isinstance(note_id, int) and note_id > 0
+        assert isinstance(note_id, int)
+        assert note_id > 0
         assert new_note['author']['uid'] == mock_note_draft.author_uid
         assert 'name' in new_note['author']
         assert new_note['author']['role']
@@ -273,9 +274,10 @@ class TestCreateNote:
         # Get notes per SID and compare
         notes = _get_student_notifications(client, coe_student['uid'])['note']
         match = next((n for n in notes if n['id'] == note_id), None)
-        assert match and match['subject'] == subject
+        assert match
+        assert match['subject'] == subject
 
-    def test_create_private_note(self, app, client, fake_auth):
+    def test_create_private_note(self, client, fake_auth):
         """CE3 advisor can create a private note."""
         fake_auth.login(ce3_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
@@ -290,7 +292,7 @@ class TestCreateNote:
         assert note['isPrivate'] is True
         assert 'rock' in note['body']
 
-    def test_create_note_prefers_ldap_dept_affiliation_and_title(self, app, client, fake_auth):
+    def test_create_note_prefers_ldap_dept_affiliation_and_title(self, client, fake_auth):
         fake_auth.login(l_s_major_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
         new_note = _api_update_note(
@@ -303,14 +305,14 @@ class TestCreateNote:
         assert new_note['author']['departments'][0]['deptName'] == 'Department of English'
         assert new_note['author']['role'] == 'Harmless Drudge'
 
-    def test_updated_date_is_none_when_note_create(self, app, client, fake_auth):
+    def test_updated_date_is_none_when_note_create(self, client, fake_auth):
         """Create a note and expect none updated_at."""
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client, sid=coe_student['sid'])
         assert draft_note['createdAt'] is not None
         assert draft_note['updatedAt'] is None
 
-    def test_create_note_with_topics(self, app, client, fake_auth):
+    def test_create_note_with_topics(self, client, fake_auth):
         """Create a note with topics."""
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
@@ -328,7 +330,7 @@ class TestCreateNote:
         assert note['createdAt'] is not None
         assert note['updatedAt'] is None
 
-    def test_create_note_with_raw_url_in_body(self, app, client, fake_auth):
+    def test_create_note_with_raw_url_in_body(self, client, fake_auth):
         """Create a note with topics."""
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
@@ -371,7 +373,7 @@ class TestCreateNote:
         expected_attachment_count = template_attachment_count + 2
         assert len(note.get('attachments')) == expected_attachment_count
 
-    def test_create_note_with_contact_type(self, app, client, fake_auth):
+    def test_create_note_with_contact_type(self, client, fake_auth):
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
         note = _api_update_note(
@@ -383,7 +385,7 @@ class TestCreateNote:
         )
         assert note['contactType'] == 'In-person same day'
 
-    def test_invalid_contact_type(self, app, client, fake_auth):
+    def test_invalid_contact_type(self, client, fake_auth):
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
         _api_update_note(
@@ -395,7 +397,7 @@ class TestCreateNote:
             subject='Career Opportunities',
         )
 
-    def test_create_note_with_set_date(self, app, client, fake_auth):
+    def test_create_note_with_set_date(self, client, fake_auth):
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
         note = _api_update_note(
@@ -408,7 +410,7 @@ class TestCreateNote:
         )
         assert note['setDate'] == '2021-12-25'
 
-    def test_invalid_set_date(self, app, client, fake_auth):
+    def test_invalid_set_date(self, client, fake_auth):
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
         _api_update_note(
@@ -431,7 +433,7 @@ class TestBatchNoteCreation:
         '3456789012', '11667051',
     ]
 
-    def test_user_without_advising_data_access(self, app, client, fake_auth):
+    def test_user_without_advising_data_access(self, client, fake_auth):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_no_advising_data_uid)
         _api_create_draft_note(client=client, expected_status_code=401)
@@ -623,7 +625,7 @@ class TestMarkNoteRead:
         fake_auth.login(coe_advisor_no_advising_data_uid)
         assert client.post('/api/notes/11667051-00001/mark_read').status_code == 401
 
-    def test_mark_note_read(self, app, client, fake_auth):
+    def test_mark_note_read(self, client, fake_auth):
         """Marks a note as read."""
         fake_auth.login(coe_advisor_uid)
         all_notes_unread = _get_student_notifications(client, 61889)['note']
@@ -917,7 +919,7 @@ class TestApplyTemplate:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, app, client):
+    def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         self._api_apply_template(
             client=client,
@@ -926,7 +928,7 @@ class TestApplyTemplate:
             template_id=1,
         )
 
-    def test_unauthorized(self, app, client, fake_auth, mock_coe_advising_note):
+    def test_unauthorized(self, client, fake_auth, mock_coe_advising_note):
         """Deny user's attempt to edit someone else's note."""
         fake_auth.login(asc_advisor_uid)
         assert self._api_apply_template(
@@ -936,7 +938,7 @@ class TestApplyTemplate:
             template_id=1,
         )
 
-    def test_apply_template(self, app, client, fake_auth, mock_note_template):
+    def test_apply_template(self, client, fake_auth, mock_note_template):
         """Update note set date."""
         advisor = AuthorizedUser.find_by_id(mock_note_template.creator_id)
         fake_auth.login(advisor.uid)
@@ -995,7 +997,7 @@ class TestDeleteNote:
         response = client.delete(f'/api/notes/delete/{note_id}')
         assert response.status_code == 200
         assert not Note.find_by_id(note_id)
-        assert 1 == len(notes) - len(Note.get_notes_by_sid(sid=mock_coe_advising_note.sid))
+        assert len(notes) - len(Note.get_notes_by_sid(sid=mock_coe_advising_note.sid)) == 1
         assert not Note.update(
             is_draft=False,
             note_id=note_id,
@@ -1003,7 +1005,7 @@ class TestDeleteNote:
             subject='Deleted note cannot be updated',
         )
 
-    def test_delete_note_with_topics(self, app, client, fake_auth):
+    def test_delete_note_with_topics(self, client, fake_auth):
         """Delete a note with topics."""
         fake_auth.login(coe_advisor_uid)
         draft_note = _api_create_draft_note(client=client)
@@ -1020,8 +1022,6 @@ class TestDeleteNote:
         note_id = note.get('id')
         response = client.delete(f'/api/notes/delete/{note_id}')
         assert response.status_code == 200
-        # TODO: add deleted_at column to NoteTopic and populate it when parent Note is deleted.
-        # assert not NoteTopic.find_by_note_id(note_id)
 
     def test_delete_note_with_attachments(self, app, client, fake_auth):
         """Delete a note with two attachments."""
@@ -1047,7 +1047,8 @@ class TestDeleteNote:
         )
         attachment_ids = [a['id'] for a in note.get('attachments')]
         assert len(attachment_ids) == 2
-        assert NoteAttachment.find_by_id(attachment_ids[0]) and NoteAttachment.find_by_id(attachment_ids[1])
+        assert NoteAttachment.find_by_id(attachment_ids[0])
+        assert NoteAttachment.find_by_id(attachment_ids[1])
 
         # Log in as Admin and delete the note
         fake_auth.login(admin_uid)
@@ -1070,14 +1071,14 @@ class TestStreamNoteAttachments:
             fake_auth.login(coe_advisor_no_advising_data_uid)
             assert client.get('/api/notes/attachment/9000000000_00002_1.pdf').status_code == 401
 
-    def test_unauthorized_request_for_private_note(self, app, client, mock_private_advising_note, fake_auth):
+    def test_unauthorized_request_for_private_note(self, client, mock_private_advising_note, fake_auth):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_uid)
         attachments = mock_private_advising_note.attachments
         assert attachments
         assert client.get(f'/api/notes/attachment/{attachments[0].id}').status_code == 404
 
-    def test_authorized_request_for_private_note(self, app, client, mock_private_advising_note, fake_auth):
+    def test_authorized_request_for_private_note(self, client, mock_private_advising_note, fake_auth):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(ce3_advisor_uid)
         attachments = mock_private_advising_note.attachments

--- a/tests/test_api/test_peer_advising_note_templates_controller.py
+++ b/tests/test_api/test_peer_advising_note_templates_controller.py
@@ -94,12 +94,9 @@ class TestCreatePeerAdvisingNoteTemplate:
             'topics': [t.topic for t in mock_peer_advising_note_template.topics],
         }
         api_json = self._api_create_peer_advising_note_template(client, data)
-        print(api_json)
         note_template_id = api_json.get('id')
-        print(note_template_id)
 
         note_template = NoteTemplate.find_by_id(note_template_id)
-        print(note_template)
 
         assert note_template is not None
         assert note_template.body == mock_peer_advising_note_template.body
@@ -129,13 +126,13 @@ class TestGetPeerAdvisingNoteTemplate:
         """Returns 401 if not authenticated."""
         self._api_get_peer_advising_note_template(client, mock_peer_advising_note_template.id, expected_status_code=401)
 
-    def test_template_not_found(self, client, fake_auth, mock_peer_advising_note_template):
+    def test_template_not_found(self, client, fake_auth, mock_peer_advising_note_template):  # noqa: ARG002
         """Returns 404 if the template is not found."""
         fake_auth.login(peer_advisor_uid)
         self._api_get_peer_advising_note_template(client, note_template_id=999999, expected_status_code=404)
 
     def test_user_not_in_peer_advising_department(self, client, fake_auth, mock_peer_advising_note_template):
-        """Returns 401 if the user is not in the template’s peer advising department."""
+        """Returns 401 if the user is not in the template's peer advising department."""
         fake_auth.login(qcadv_advisor_uid)
         self._api_get_peer_advising_note_template(client, mock_peer_advising_note_template.id, expected_status_code=401)
 
@@ -276,16 +273,19 @@ class TestDeletePeerAdvisingNoteTemplate:
         self._api_delete_peer_advising_note_template(client, mock_peer_advising_note_template.id,
                                                      expected_status_code=401)
 
-    def test_template_not_found(self, client, fake_auth, mock_peer_advising_note_template):
+    def test_template_not_found(self, client, fake_auth, mock_peer_advising_note_template):  # noqa: ARG002
         """Returns 404 if the template does not exist."""
         fake_auth.login(peer_advisor_manager_uid)
         self._api_delete_peer_advising_note_template(client, 999999, expected_status_code=404)
 
     def test_user_not_in_peer_advising_department(self, client, fake_auth, mock_peer_advising_note_template):
-        """Returns 401 if the current user is not a member of the template’s peer advising department."""
+        """Returns 401 if the current user is not a member of the template's peer advising department."""
         fake_auth.login(qcadv_advisor_uid)
-        self._api_delete_peer_advising_note_template(client, mock_peer_advising_note_template.id,
-                                                     expected_status_code=401)
+        self._api_delete_peer_advising_note_template(
+            client,
+            mock_peer_advising_note_template.id,
+            expected_status_code=401,
+        )
 
     def test_delete_peer_advising_note_template_success(self, client, fake_auth, mock_peer_advising_note_template):
         """Deletes a peer advising note template and returns a confirmation message."""

--- a/tests/test_api/test_peer_advising_notes_controller.py
+++ b/tests/test_api/test_peer_advising_notes_controller.py
@@ -55,7 +55,7 @@ class TestCreatePeerAdvisingNote:
         memberships = PeerAdvisingDepartmentMember.find_peer_advising_memberships_by_user_id(user_id)
         cls.ce3_navcal_peer_advising_department_id = memberships[0]['peer_advising_department_id']
 
-    def test_not_authorized(self, app, client, fake_auth):
+    def test_not_authorized(self, client, fake_auth):
         """Returns 401 if not authorized."""
         for uid in (None, ce3_navcal_peer_advisor_manager_uid, qcadv_advisor_uid):
             fake_auth.login(uid)
@@ -165,7 +165,7 @@ class TestGetNotesAuthoredBy:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_unauthorized(self, app, client, fake_auth):
+    def test_unauthorized(self, client, fake_auth):
         """Returns 401 if not authenticated."""
         for uid in [None, coe_advisor_no_advising_data_uid, coe_student['uid']]:
             if uid:
@@ -177,7 +177,7 @@ class TestGetNotesAuthoredBy:
             uid=uid,
         )
 
-    def test_authorized(self, app, client, fake_auth):
+    def test_authorized(self, client, fake_auth):
         """Advisor can view notes created by another Advisor or Peer Advisor user."""
         fake_auth.login(ce3_navcal_peer_advisor_manager_uid)
         peer_advisor = AuthorizedUser.find_by_uid(ce3_navcal_peer_advisor_uid)
@@ -280,7 +280,7 @@ class TestGetPeerAdvisingTopics:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, app, client):
+    def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         self._api_get_peer_advising_topics(client, expected_status_code=401)
 
@@ -404,7 +404,7 @@ class TestUpdateNotes:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_unauthorized_peer_advising_note_update(self, app, client, fake_auth):
+    def test_unauthorized_peer_advising_note_update(self, client, fake_auth):
         """Unauthorized user cannot update Peer Advising note."""
         for uid in [None, coe_advisor_no_advising_data_uid, qcadv_advisor_uid]:
             if uid:
@@ -417,7 +417,7 @@ class TestUpdateNotes:
                 subject='Hack the subject!',
             )
 
-    def test_authorized_peer_advising_note_update(self, app, client, fake_auth):
+    def test_authorized_peer_advising_note_update(self, client, fake_auth):
         """Update Peer Advising note topics."""
         body = """
             Don't pick fights with the bullies or the cads
@@ -443,7 +443,7 @@ class TestUpdateNotes:
         for topic in topics:
             assert topic in api_json['topics']
 
-    def test_remove_note_topics(self, app, client, fake_auth):
+    def test_remove_note_topics(self, client, fake_auth):
         """Delete note topics."""
         note = Note.find_by_id(self.peer_advising_note_id)
         assert len(note.topics) > 0

--- a/tests/test_api/test_peer_advising_users_controller.py
+++ b/tests/test_api/test_peer_advising_users_controller.py
@@ -146,7 +146,7 @@ class TestGetPeerAdvisingDepartment:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, app, client):
+    def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         self._api_get_peer_advising_department(
             client,
@@ -206,7 +206,7 @@ class TestDeleteAndRestore:
         assert response.status_code == expected_status_code
         return response.json
 
-    def test_not_authenticated(self, app, client):
+    def test_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
         self._api_delete_peer_advisor(
             client,

--- a/tests/test_api/test_search_controller.py
+++ b/tests/test_api/test_search_controller.py
@@ -32,31 +32,9 @@ import simplejson as json
 
 admin_uid = '2040'
 asc_advisor_uid = '1081940'
-
-
-@pytest.fixture()
-def admin_login(fake_auth):
-    fake_auth.login(admin_uid)
-
-
-@pytest.fixture()
-def asc_advisor(fake_auth):
-    fake_auth.login(asc_advisor_uid)
-
-
-@pytest.fixture()
-def coe_advisor(fake_auth):
-    fake_auth.login('1133399')
-
-
-@pytest.fixture()
-def coe_advisor_no_advising_data(fake_auth):
-    fake_auth.login('1022796')
-
-
-@pytest.fixture()
-def ce3_advisor(fake_auth):
-    fake_auth.login('2525')
+ce3_advisor_uid = '2525'
+coe_advisor_no_advising_data_uid = '1022796'
+coe_advisor_uid = '1133399'
 
 
 @pytest.fixture(scope='session')
@@ -92,7 +70,7 @@ class TestStudentSearch:
         api_json = _api_search(client, 'barn', students=True)
         students = api_json['students']
         assert len(students) == api_json['totalStudentCount'] == 2
-        assert ['Barney', 'Davies'] == [s['lastName'] for s in students]
+        assert [s['lastName'] for s in students] == ['Barney', 'Davies']
 
     def test_search_by_sid_snippet(self, client, fake_auth, asc_inactive_students):
         """Search by snippet of SID."""
@@ -136,7 +114,7 @@ class TestStudentSearch:
         students = api_json['students']
         assert len(students) == 0
 
-    def test_alerts_in_search_results(self, client, create_alerts, fake_auth):
+    def test_alerts_in_search_results(self, client, create_alerts, fake_auth):  # noqa: ARG002
         """Search results include alert counts."""
         fake_auth.login(admin_uid)
         api_json = _api_search(client, 'davies', students=True)
@@ -159,7 +137,7 @@ class TestStudentSearch:
         api_json = _api_search(client, 'dav', students=True)
         students = api_json['students']
         assert len(students) == api_json['totalStudentCount'] == 3
-        assert ['Crossman', 'Davies', 'Doolittle'] == [s['lastName'] for s in students]
+        assert [s['lastName'] for s in students] == ['Crossman', 'Davies', 'Doolittle']
 
     def test_search_by_full_name_snippet(self, client, fake_auth):
         """Search by snippet of full name."""
@@ -171,8 +149,9 @@ class TestStudentSearch:
             assert len(students) == api_json['totalStudentCount'] == 1
             assert students[0]['lastName'] == 'Crossman'
 
-    def test_search_by_name_coe(self, coe_advisor, client):
+    def test_search_by_name_coe(self, client, fake_auth):
         """A COE name search finds all Pauls, including COE-specific data for COE Pauls."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'Paul', students=True)
         students = api_json['students']
         assert len(students) == 3
@@ -182,8 +161,9 @@ class TestStudentSearch:
         for s in students:
             assert 'inIntensiveCohort' not in s.get('athleticsProfile', {})
 
-    def test_search_by_name_asc(self, asc_advisor, client):
+    def test_search_by_name_asc(self, client, fake_auth):
         """An ASC advisor finds all Pauls, including ASC-specific data for ASC Pauls."""
+        fake_auth.login(asc_advisor_uid)
         api_json = _api_search(client, 'Paul', students=True)
         students = api_json['students']
         assert len(students) == 3
@@ -193,8 +173,9 @@ class TestStudentSearch:
         for s in students:
             assert 'coeProfile' not in s
 
-    def test_search_by_name_admin(self, admin_login, client):
+    def test_search_by_name_admin(self, client, fake_auth):
         """An admin name search finds all Pauls, including both ASC and COE data."""
+        fake_auth.login(admin_uid)
         api_json = _api_search(client, 'Paul', students=True)
         students = api_json['students']
         assert len(students) == 3
@@ -202,8 +183,9 @@ class TestStudentSearch:
         assert next(s for s in students if s['name'] == 'Paul Farestveit' and 'athleticsProfile' in s and 'coeProfile' in s)
         assert next(s for s in students if s['name'] == 'Wolfgang Pauli-O\'Rourke' and s['coeProfile']['isActiveCoe'] is False)
 
-    def test_search_by_name_with_special_characters(self, admin_login, client):
+    def test_search_by_name_with_special_characters(self, client, fake_auth):
         """Search by name where name has special characters: hyphen, etc."""
+        fake_auth.login(admin_uid)
         api_json = _api_search(client, 'Pauli-O\'Rourke', students=True)
         students = api_json['students']
         assert len(students) == 1
@@ -222,7 +204,7 @@ class TestStudentSearch:
         api_json = _api_search(client, 'dav', students=True, order_by='major', offset=1, limit=1)
         assert api_json['totalStudentCount'] == 3
         assert len(api_json['students']) == 1
-        assert 'Crossman' == api_json['students'][0]['lastName']
+        assert api_json['students'][0]['lastName'] == 'Crossman'
 
 
 class TestCourseSearch:
@@ -237,7 +219,8 @@ class TestCourseSearch:
         for course in courses:
             assert course['courseName'] == 'MATH 16A'
 
-    def test_search_by_name_excludes_courses_unless_requested(self, coe_advisor, client):
+    def test_search_by_name_excludes_courses_unless_requested(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'da', students=True)
         assert 'courses' not in api_json
         assert 'totalCourseCount' not in api_json
@@ -247,7 +230,8 @@ class TestCourseSearch:
         fake_auth.login(admin_uid)
         _api_search(client, ' \t  ', courses=True, expected_status_code=400)
 
-    def test_search_by_name_includes_courses_if_requested(self, coe_advisor, client):
+    def test_search_by_name_includes_courses_if_requested(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         """A name search returns matching courses if any."""
         api_json = _api_search(client, 'paul', courses=True, students=True)
         assert api_json['courses'] == []
@@ -269,15 +253,18 @@ class TestCourseSearch:
             'instructors': 'Karen Blixen',
         }
 
-    def test_search_by_name_normalizes_queries(self, coe_advisor, client):
+    def test_search_by_name_normalizes_queries(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         queries = ['MATH 16A', 'Math 16 A', 'math  16a']
         for query in queries:
             self._assert_finds_math_16a(client, query)
 
-    def test_search_by_abbreviated_subject_area_returns_courses(self, coe_advisor, client):
+    def test_search_by_abbreviated_subject_area_returns_courses(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         self._assert_finds_math_16a(client, 'Ma 16A')
 
-    def test_search_by_catalog_id_alone_returns_courses(self, coe_advisor, client):
+    def test_search_by_catalog_id_alone_returns_courses(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, '1A', courses=True, students=True)
         courses = api_json['courses']
         assert len(courses) == 3
@@ -303,17 +290,20 @@ class TestNoteSearch:
         for idx, note_id in enumerate(note_ids):
             assert notes[idx].get('id') == note_id
 
-    def test_search_with_missing_input_no_options(self, coe_advisor, client):
+    def test_search_with_missing_input_no_options(self, client, fake_auth):
         """Notes search is nothing without input when no additional options are set."""
+        fake_auth.login(coe_advisor_uid)
         _api_search(client, ' \t  ', notes=True, expected_status_code=400)
 
-    def test_search_notes(self, coe_advisor, client):
+    def test_search_notes(self, client, fake_auth):
         """Search results include notes ordered by rank."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'life', notes=True)
         self._assert(api_json, note_count=1, note_ids=['11667051-00003'])
 
-    def test_search_respects_date_filters(self, coe_advisor, client):
+    def test_search_respects_date_filters(self, client, fake_auth):
         """Search results include notes updated within provided date range."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'making',
@@ -325,7 +315,8 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-00001'])
 
-    def test_note_search_validates_date_formatting(self, coe_advisor, client):
+    def test_note_search_validates_date_formatting(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Brigitte',
@@ -338,7 +329,8 @@ class TestNoteSearch:
         )
         assert api_json['message'] == 'Invalid dateTo value'
 
-    def test_note_search_validates_date_ranges(self, coe_advisor, client):
+    def test_note_search_validates_date_ranges(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Brigitte',
@@ -351,7 +343,8 @@ class TestNoteSearch:
         )
         assert api_json['message'] == 'dateFrom must be less than dateTo'
 
-    def test_note_search_validates_department_codes_are_present(self, coe_advisor, client):
+    def test_note_search_validates_department_codes_are_present(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Independence',
@@ -363,7 +356,8 @@ class TestNoteSearch:
         )
         assert api_json['message'] == 'Department codes not specified'
 
-    def test_note_search_validates_department_codes_are_valid(self, coe_advisor, client):
+    def test_note_search_validates_department_codes_are_valid(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Independence',
@@ -375,7 +369,8 @@ class TestNoteSearch:
         )
         assert api_json['message'] == 'Invalid department code'
 
-    def test_note_search_matches_correct_department_codes(self, coe_advisor, client, mock_advising_note):
+    def test_note_search_matches_correct_department_codes(self, client, fake_auth, mock_advising_note):  # noqa: ARG002
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Independence',
@@ -387,7 +382,8 @@ class TestNoteSearch:
         assert len(api_json['notes']) == 1
         assert 'Independence' in api_json['notes'][0]['noteSnippet']
 
-    def test_note_search_excludes_incorrect_department_codes(self, coe_advisor, client, mock_advising_note):
+    def test_note_search_excludes_incorrect_department_codes(self, client, fake_auth, mock_advising_note):  # noqa: ARG002
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Independence',
@@ -398,7 +394,8 @@ class TestNoteSearch:
         )
         assert len(api_json['notes']) == 0
 
-    def test_note_data_loch_search_department_code(self, coe_advisor, client, fake_loch):
+    def test_note_data_loch_search_department_code(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'happen around us',
@@ -407,11 +404,11 @@ class TestNoteSearch:
                 'departmentCodes': ['EGCEE'],
             },
         )
-        print(api_json['notes'])
         assert len(api_json['notes']) == 1
 
-    def test_search_with_no_input_and_date(self, coe_advisor, client):
+    def test_search_with_no_input_and_date(self, client, fake_auth):
         """Notes search needs no input when date options are set."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -420,7 +417,7 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=4)
 
-    def test_search_with_midnight_creation(self, coe_advisor, client):
+    def test_search_with_midnight_creation(self, client, fake_auth):
         """Notes search correctly returns legacy notes with midnight creation times."""
         def _single_date_search(date):
             api_json = _api_search(
@@ -430,22 +427,26 @@ class TestNoteSearch:
                 note_options={'dateFrom': date, 'dateTo': date},
             )
             return api_json['notes']
+        fake_auth.login(coe_advisor_uid)
         assert len(_single_date_search('2017-11-01')) == 0
         assert len(_single_date_search('2017-11-02')) == 1
         assert len(_single_date_search('2017-11-03')) == 0
 
-    def test_search_excludes_notes_unless_requested(self, coe_advisor, client):
+    def test_search_excludes_notes_unless_requested(self, client, fake_auth):
         """Excludes notes from search results if notes param is false."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'life', appointments=True, courses=True, students=True)
         assert 'notes' not in api_json
 
-    def test_search_includes_notes_if_requested(self, coe_advisor, client):
+    def test_search_includes_notes_if_requested(self, client, fake_auth):
         """Includes notes in search results if notes param is true."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'Brigitte', notes=True)
         self._assert(api_json, note_count=2, note_ids=['11667051-00002', '11667051-00001'])
 
-    def test_search_note_with_null_body(self, asc_advisor, client):
+    def test_search_note_with_null_body(self, client, fake_auth):
         """Finds newly created BOA note when note body is null."""
+        fake_auth.login(asc_advisor_uid)
         response = client.post(
             '/api/note/create_draft',
             content_type='application/json',
@@ -463,18 +464,21 @@ class TestNoteSearch:
         api_json = _api_search(client, 'a conquering virtue', notes=True)
         self._assert(api_json, note_count=1, note_ids=[note['id']])
 
-    def test_search_asc_notes(self, asc_advisor, client):
+    def test_search_asc_notes(self, client, fake_auth):
         """Includes ASC notes in search results."""
+        fake_auth.login(asc_advisor_uid)
         api_json = _api_search(client, 'ginger', notes=True)
         self._assert(api_json, note_count=3, note_ids=['11667051-139379', '2345678901-139379', '8901234567-139379'])
 
-    def test_search_notes_by_asc_topic(self, asc_advisor, client):
+    def test_search_notes_by_asc_topic(self, client, fake_auth):
         """Includes ASC notes with advisor name match in search results."""
+        fake_auth.login(asc_advisor_uid)
         api_json = _api_search(client, 'academic', notes=True)
         self._assert(api_json, note_count=1, note_ids=['11667051-139362'])
 
-    def test_search_by_topic(self, coe_advisor, client):
+    def test_search_by_topic(self, client, fake_auth):
         """Searches notes by topic if topics option is selected."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'making',
@@ -483,8 +487,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-00001'])
 
-    def test_search_with_no_input_and_topic(self, coe_advisor, client):
+    def test_search_with_no_input_and_topic(self, client, fake_auth):
         """Notes search needs no input when topic set."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -493,8 +498,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-00001'])
 
-    def test_search_by_note_author_sis(self, coe_advisor, client):
+    def test_search_by_note_author_sis(self, client, fake_auth):
         """Searches SIS notes by advisor CSID if posted by option is selected."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Brigitte',
@@ -503,8 +509,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-00001'])
 
-    def test_search_by_note_author_asc(self, coe_advisor, client):
+    def test_search_by_note_author_asc(self, client, fake_auth):
         """Searches ASC notes by advisor CSID if posted by option is selected."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Academic',
@@ -513,8 +520,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-139362'])
 
-    def test_search_by_note_author_data_science(self, coe_advisor, client):
+    def test_search_by_note_author_data_science(self, client, fake_auth):
         """Searches Data Science notes by advisor CSID if posted by option is selected."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Buyer beware',
@@ -523,8 +531,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-20190801112456'])
 
-    def test_search_with_no_input_and_author(self, coe_advisor, client):
+    def test_search_with_no_input_and_author(self, client, fake_auth):
         """Notes search needs no input when author set."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -533,8 +542,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=3)
 
-    def test_search_by_student(self, coe_advisor, client):
+    def test_search_by_student(self, client, fake_auth):
         """Searches notes by student CSID."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'life',
@@ -543,8 +553,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-00003'])
 
-    def test_search_with_no_input_and_student(self, coe_advisor, client):
+    def test_search_with_no_input_and_student(self, client, fake_auth):
         """Notes search needs no input when student set."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -555,8 +566,9 @@ class TestNoteSearch:
         notes = api_json['notes']
         assert len(notes) >= 12
 
-    def test_note_search_limit(self, coe_advisor, client):
+    def test_note_search_limit(self, client, fake_auth):
         """Limits search to the first n notes."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'life',
@@ -565,8 +577,9 @@ class TestNoteSearch:
         )
         self._assert(api_json, note_count=1, note_ids=['11667051-00003'])
 
-    def test_note_search_offset(self, coe_advisor, client):
+    def test_note_search_offset(self, client, fake_auth):
         """Returns results beginning from the offset."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'student',
@@ -589,7 +602,8 @@ class TestNoteSearch:
         notes = api_json['notes']
         assert len(notes) >= 12
 
-    def test_search_notes_includes_inactive_students(self, coe_advisor, client):
+    def test_search_notes_includes_inactive_students(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'vocation', notes=True)
         self._assert(api_json, note_count=1, note_ids=['2718281828-00001'])
 
@@ -613,17 +627,20 @@ class TestAppointmentSearch:
             assert appointment['student']['lastName']
             assert appointment['studentSid']
 
-    def test_search_with_missing_input_no_options(self, coe_advisor, client):
+    def test_search_with_missing_input_no_options(self, client, fake_auth):
         """Appointments search is nothing without input when no additional options are set."""
+        fake_auth.login(coe_advisor_uid)
         _api_search(client, ' \t  ', appointments=True, expected_status_code=400)
 
-    def test_search_appointments(self, coe_advisor, client):
+    def test_search_appointments(self, client, fake_auth):
         """Search results include legacy appointments."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'life', appointments=True)
         self._assert(api_json, appointment_count=1)
 
-    def test_search_respects_date_filters(self, coe_advisor, client):
+    def test_search_respects_date_filters(self, client, fake_auth):
         """Search results include appointments created within provided date range."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'art',
@@ -635,7 +652,8 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=1)
 
-    def test_appointment_search_validates_date_formatting(self, coe_advisor, client):
+    def test_appointment_search_validates_date_formatting(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Brigitte',
@@ -648,7 +666,8 @@ class TestAppointmentSearch:
         )
         assert api_json['message'] == 'Invalid dateTo value'
 
-    def test_appointment_search_validates_date_ranges(self, coe_advisor, client):
+    def test_appointment_search_validates_date_ranges(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'Brigitte',
@@ -661,8 +680,9 @@ class TestAppointmentSearch:
         )
         assert api_json['message'] == 'dateFrom must be less than dateTo'
 
-    def test_appointment_search_with_no_input_and_date(self, coe_advisor, client):
+    def test_appointment_search_with_no_input_and_date(self, client, fake_auth):
         """Appointments search needs no input when date options are set."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -671,13 +691,15 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=3)
 
-    def test_search_excludes_appointments_unless_requested(self, coe_advisor, client):
+    def test_search_excludes_appointments_unless_requested(self, client, fake_auth):
         """Excludes appointments from search results if appointments param is false."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'life', courses=True, students=True, notes=True)
         assert 'appointments' not in api_json
 
-    def test_search_by_appointment_scheduler(self, coe_advisor, client):
+    def test_search_by_appointment_scheduler(self, client, fake_auth):
         """Searches appointments by advisor UID if posted by option is selected."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'union',
@@ -686,8 +708,9 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=1)
 
-    def test_search_appointments_with_no_input_and_author(self, coe_advisor, client):
+    def test_search_appointments_with_no_input_and_author(self, client, fake_auth):
         """Appointments search needs no input when author set."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -696,8 +719,9 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=2)
 
-    def test_search_appointments_by_student(self, coe_advisor, client):
+    def test_search_appointments_by_student(self, client, fake_auth):
         """Searches appointments by student CSID."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'wingspan',
@@ -706,8 +730,9 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=1)
 
-    def test_search_appointments_with_no_input_and_student(self, coe_advisor, client):
+    def test_search_appointments_with_no_input_and_student(self, client, fake_auth):
         """Appointments search needs no input when student set."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -716,8 +741,9 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=3)
 
-    def test_appointments_search_limit(self, coe_advisor, client):
+    def test_appointments_search_limit(self, client, fake_auth):
         """Limits search to the first n appointments."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -726,8 +752,9 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=1)
 
-    def test_appointments_search_offset(self, coe_advisor, client):
+    def test_appointments_search_offset(self, client, fake_auth):
         """Returns appointment results beginning from the offset."""
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             '',
@@ -748,11 +775,13 @@ class TestAppointmentSearch:
         )
         self._assert(api_json, appointment_count=3)
 
-    def test_search_appointments_includes_inactive_students(self, coe_advisor, client):
+    def test_search_appointments_includes_inactive_students(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(client, 'pez', appointments=True)
         self._assert(api_json, appointment_count=1)
 
-    def test_search_appointments_by_dept_code(self, coe_advisor, client):
+    def test_search_appointments_by_dept_code(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         api_json = _api_search(
             client,
             'perfect union',
@@ -798,18 +827,21 @@ class TestAdmittedStudentSearch:
             assert 'applicationFeeWaiverFlag' in admit
             assert 'freshmanOrTransfer' in admit
 
-    def test_search_admits_performed_by_non_ce3_advisor(self, client, coe_advisor):
+    def test_search_admits_performed_by_non_ce3_advisor(self, client, fake_auth):
         """Excludes admit results if user is a non-CE3 advisor."""
+        fake_auth.login(coe_advisor_uid)
         api_json = self._api_search_admits(client, '0000', expected_status_code=401)
         assert 'admits' not in api_json
 
-    def test_search_admits_by_sid(self, client, ce3_advisor):
+    def test_search_admits_by_sid(self, client, fake_auth):
         """Search by SID yields admit results."""
+        fake_auth.login(ce3_advisor_uid)
         api_json = self._api_search_admits(client, '0000')
         self._assert(api_json, admit_count=1)
 
-    def test_search_admits_by_name(self, client, ce3_advisor):
+    def test_search_admits_by_name(self, client, fake_auth):
         """Search by first, last, and/or middle name yields admits."""
+        fake_auth.login(ce3_advisor_uid)
         api_json = self._api_search_admits(client, 'da')
         self._assert(api_json, admit_count=2)
 
@@ -819,7 +851,8 @@ class TestAdmittedStudentSearch:
         api_json = self._api_search_admits(client, 'j ly')
         self._assert(api_json, admit_count=1)
 
-    def test_search_admits_ordering(self, client, ce3_advisor):
+    def test_search_admits_ordering(self, client, fake_auth):
+        fake_auth.login(ce3_advisor_uid)
         api_json = self._api_search_admits(client, 'da', order_by='first_name')
         self._assert(api_json, admit_count=2)
         assert api_json['admits'][0]['firstName'] == 'Daniel'
@@ -860,17 +893,20 @@ class TestSearchHistory:
         """/add_to_search_history returns 401 if not authenticated."""
         self._api_add_to_my_search_history(client, 'I want it all', expected_status_code=401)
 
-    def test_empty_search_history(self, client, coe_advisor):
+    def test_empty_search_history(self, client, fake_auth):
         """Returns empty array if user has no search history."""
+        fake_auth.login(coe_advisor_uid)
         assert self._api_my_search_history(client) == []
 
-    def test_blank_input(self, asc_advisor, client):
+    def test_blank_input(self, client, fake_auth):
         """Blank search phrase is not added to search history."""
+        fake_auth.login(asc_advisor_uid)
         self._api_add_to_my_search_history(client, '    ', expected_status_code=400)
         assert self._api_my_search_history(client=client) == ['Moe', 'Larry', 'Curly']
 
-    def test_search_history(self, asc_advisor, client):
+    def test_search_history(self, client, fake_auth):
         """Returns search history."""
+        fake_auth.login(asc_advisor_uid)
         api_json = self._api_my_search_history(client)
         expected_history = ['Moe', 'Larry', 'Curly']
         assert api_json == expected_history
@@ -878,8 +914,9 @@ class TestSearchHistory:
         self._api_add_to_my_search_history(client, 'Moe')
         assert self._api_my_search_history(client=client) == expected_history
 
-    def test_search_history_truncate(self, client, coe_advisor):
+    def test_search_history_truncate(self, client, fake_auth):
         # The string expected in search history will be shorter than MAX_LENGTH
+        fake_auth.login(coe_advisor_uid)
         expected_length = AuthorizedUser.SEARCH_HISTORY_ITEM_MAX_LENGTH - 20
         expected_search_history_string = 's' * expected_length
         search_string = f'  {expected_search_history_string}  this_suffix_has_no_whitespace_and_will_be_dropped  '
@@ -896,14 +933,16 @@ class TestSearchHistory:
             assert snippet in actual_search_history_string
         assert '  ' not in actual_search_history_string
 
-    def test_search_history_truncate_when_no_whitespace(self, client, coe_advisor):
+    def test_search_history_truncate_when_no_whitespace(self, client, fake_auth):
+        fake_auth.login(coe_advisor_uid)
         expected_search_history_string = 's' * AuthorizedUser.SEARCH_HISTORY_ITEM_MAX_LENGTH
         no_whitespace_in_search_string = f'{expected_search_history_string}truncate_me'
         self._api_add_to_my_search_history(client, f'  {no_whitespace_in_search_string}   ')
         assert self._api_my_search_history(client)[0] == expected_search_history_string
 
-    def test_manage_search_history(self, admin_login, client):
+    def test_manage_search_history(self, client, fake_auth):
         """Properly manages search history."""
+        fake_auth.login(admin_uid)
         assert self._api_my_search_history(client) == []
         polythene_pam = 'Polythene Pam'
         phrases = [
@@ -958,19 +997,22 @@ class TestFindAdvisorsByName:
         """Denies anonymous access."""
         self._api_search_advisors(client, 'Vis', expected_status_code=401)
 
-    def test_user_without_advising_data_access(self, client, coe_advisor_no_advising_data):
+    def test_user_without_advising_data_access(self, client, fake_auth):
         """Denies access to a user who cannot access notes and appointments."""
+        fake_auth.login(coe_advisor_no_advising_data_uid)
         self._api_search_advisors(client, 'Vis', expected_status_code=401)
 
-    def test_find_advisors_by_name(self, client, coe_advisor):
+    def test_find_advisors_by_name(self, client, fake_auth):
         """Finds matches including appointment advisors."""
+        fake_auth.login(coe_advisor_uid)
         response = self._api_search_advisors(client, 'Lor')
         assert len(response) == 1
         labels = [s['label'] for s in response]
         assert 'Loramps Glub' in labels
 
-    def test_find_note_authors_by_name(self, client, coe_advisor, mock_advising_note):
+    def test_find_note_authors_by_name(self, client, fake_auth, mock_advising_note):  # noqa: ARG002
         """Finds matches including authors of legacy and non-legacy notes."""
+        fake_auth.login(coe_advisor_uid)
         Note.refresh_search_index()
         response = self._api_search_advisors(client, 'Jo')
         assert len(response) >= 4

--- a/tests/test_api/test_student_controller.py
+++ b/tests/test_api/test_student_controller.py
@@ -34,17 +34,17 @@ asc_advisor_uid = '1081940'
 coe_advisor_uid = '1133399'
 
 
-@pytest.fixture()
+@pytest.fixture
 def admin_login(fake_auth):
     fake_auth.login(admin_with_cohorts_uid)
 
 
-@pytest.fixture()
+@pytest.fixture
 def asc_advisor_login(fake_auth):
     fake_auth.login(asc_advisor_uid)
 
 
-@pytest.fixture()
+@pytest.fixture
 def coe_advisor_login(fake_auth):
     fake_auth.login(coe_advisor_uid)
 
@@ -93,7 +93,7 @@ class TestStudent:
         self._api_student_by_sid(client=client, sid=self.asc_student['sid'], expected_status_code=401)
         self._api_student_by_uid(client=client, uid=self.asc_student['uid'], expected_status_code=401)
 
-    def test_user_with_no_enrollments_in_current_term(self, asc_advisor_login, client):
+    def test_user_with_no_enrollments_in_current_term(self, asc_advisor_login, client):  # noqa: ARG002
         """Flags student with no enrollments in current term and appends the current term."""
         sid = self.asc_student['sid']
         uid = self.asc_student['uid']
@@ -104,7 +104,7 @@ class TestStudent:
             assert len(enrollment_terms) == 3
             assert [t['termName'] for t in enrollment_terms] == ['Summer 2017', 'Spring 2017', 'Fall 2017']
 
-    def test_user_feed_authenticated(self, client, coe_advisor_login):
+    def test_user_feed_authenticated(self, client, coe_advisor_login):  # noqa: ARG002
         """Returns a well-formed response if authenticated."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -126,7 +126,7 @@ class TestStudent:
                         assert canvas_site['courseCode']
                         assert canvas_site['analytics']
 
-    def test_user_feed_holds(self, asc_advisor_login, client):
+    def test_user_feed_holds(self, asc_advisor_login, client):  # noqa: ARG002
         """Returns holds if any."""
         response = client.get('/api/student/by_uid/9933311')
         assert response.status_code == 200
@@ -137,7 +137,7 @@ class TestStudent:
         assert holds[1]['reason']['description'] == 'Semester Out'
         assert holds[1]['reason']['formalDescription'].startswith('You are not eligible to register')
 
-    def test_user_feed_multiple_terms(self, client, coe_advisor_login):
+    def test_user_feed_multiple_terms(self, client, coe_advisor_login):  # noqa: ARG002
         """Returns all terms with enrollment data in reverse order."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -170,7 +170,7 @@ class TestStudent:
             assert student['enrollmentTerms'][3]['academicStanding']['status'] == 'GST'
             assert len(student['enrollmentTerms'][3]['enrollments']) == 1
 
-    def test_user_feed_academic_standing(self, client, coe_advisor_login):
+    def test_user_feed_academic_standing(self, client, coe_advisor_login):  # noqa: ARG002
         """Includes most recent academic standing, in addition to per-term merges."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -183,7 +183,7 @@ class TestStudent:
                 'termName': 'Spring 2018',
             }
 
-    def test_user_feed_earliest_term_cutoff(self, client, coe_advisor_login):
+    def test_user_feed_earliest_term_cutoff(self, client, coe_advisor_login):  # noqa: ARG002
         """Ignores terms before the configured earliest term."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -193,7 +193,7 @@ class TestStudent:
             for term in student['enrollmentTerms']:
                 assert term['termName'] != 'Spring 2001'
 
-    def test_user_feed_future_term_cutoff(self, client, coe_advisor_login):
+    def test_user_feed_future_term_cutoff(self, client, coe_advisor_login):  # noqa: ARG002
         """Ignores terms after the configured future term."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -203,7 +203,7 @@ class TestStudent:
             for term in student['enrollmentTerms']:
                 assert term['termName'] != 'Summer 2018'
 
-    def test_enrollment_without_course_site(self, client, coe_advisor_login):
+    def test_enrollment_without_course_site(self, client, coe_advisor_login):  # noqa: ARG002
         """Returns enrollments with no associated course sites."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -214,7 +214,7 @@ class TestStudent:
             assert enrollment_without_site['title'] == 'Private Carillon Lessons for Advanced Students'
             assert enrollment_without_site['canvasSites'] == []
 
-    def test_enrollment_with_multiple_course_sites(self, client, coe_advisor_login):
+    def test_enrollment_with_multiple_course_sites(self, client, coe_advisor_login):  # noqa: ARG002
         """Returns multiple course sites associated with an enrollment, sorted by site id."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -227,7 +227,7 @@ class TestStudent:
             assert canvas_sites[0]['courseName'] == 'Radioactive Waste Management'
             assert canvas_sites[1]['courseName'] == 'Optional Friday Night Radioactivity Group'
 
-    def test_multiple_primary_section_enrollments(self, client, coe_advisor_login):
+    def test_multiple_primary_section_enrollments(self, client, coe_advisor_login):  # noqa: ARG002
         """Disambiguates multiple primary sections under a single course display name."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -252,7 +252,7 @@ class TestStudent:
             assert classics_second['gradingBasis'] == 'Letter'
             assert classics_second['grade'] == 'B-'
 
-    def test_enrollments_sorted(self, client, coe_advisor_login):
+    def test_enrollments_sorted(self, client, coe_advisor_login):  # noqa: ARG002
         """Sorts enrollments by course display name."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -264,7 +264,7 @@ class TestStudent:
             assert spring_2017_enrollments[1]['displayName'] == 'CLASSIC 130 LEC 002'
             assert spring_2017_enrollments[2]['displayName'] == 'MUSIC 41C'
 
-    def test_course_site_without_membership(self, client, coe_advisor_login):
+    def test_course_site_without_membership(self, client, coe_advisor_login):  # noqa: ARG002
         """Returns a graceful error if the expected membership is not found in the course site."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -275,7 +275,7 @@ class TestStudent:
             for metric in ['assignmentsSubmitted', 'currentScore', 'lastActivity']:
                 assert course_without_membership['canvasSites'][0]['analytics'][metric]['error']
 
-    def test_course_site_with_enrollment(self, client, coe_advisor_login):
+    def test_course_site_with_enrollment(self, client, coe_advisor_login):  # noqa: ARG002
         """Returns sensible data if the expected enrollment is found in the course site."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -309,7 +309,7 @@ class TestStudent:
             course_with_enrollment = self.get_course_for_code(student, '2178', 'MED ST 205')
             assert course_with_enrollment['canvasSites'] == []
 
-    def test_student_not_found(self, coe_advisor_login, client):
+    def test_student_not_found(self, coe_advisor_login, client):  # noqa: ARG002
         """Returns 404 if no viewable student."""
         sid = self.unrecognized_student['sid']
         uid = self.unrecognized_student['uid']
@@ -318,7 +318,7 @@ class TestStudent:
         for response in [student_by_sid, student_by_uid]:
             assert response['message'] == 'Unknown student'
 
-    def test_sis_enrollment_merge(self, client, coe_advisor_login):
+    def test_sis_enrollment_merge(self, client, coe_advisor_login):  # noqa: ARG002, PLR0915
         """Merges sorted SIS enrollment data."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -389,7 +389,7 @@ class TestStudent:
             assert music['gradingBasis'] == 'Letter'
             assert music['grade'] == 'A-'
 
-    def test_dropped_sections(self, client, coe_advisor_login):
+    def test_dropped_sections(self, client, coe_advisor_login):  # noqa: ARG002
         """Collects dropped sections in a separate feed."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -402,7 +402,7 @@ class TestStudent:
             assert dropped_sections[0]['component'] == 'TUT'
             assert dropped_sections[0]['sectionNumber'] == '002'
 
-    def test_generic_haas_advisor(self, client, coe_advisor_login):
+    def test_generic_haas_advisor(self, client, coe_advisor_login):  # noqa: ARG002
         """Populates UCBUGADHAAS advisor with name and email."""
         sid = self.coe_student['sid']
         uid = self.coe_student['uid']
@@ -434,7 +434,7 @@ class TestStudent:
                 'plan': 'Business Administration BS',
             }
 
-    def test_sis_profile(self, client, coe_advisor_login):
+    def test_sis_profile(self, client, coe_advisor_login):  # noqa: ARG002
         """Provides SIS profile data."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -464,7 +464,7 @@ class TestStudent:
             assert sis_profile['primaryName'] == 'Oski Bear'
             assert sis_profile['termsInAttendance'] is None
 
-    def test_sis_profile_expected_graduation_term(self, client, coe_advisor_login):
+    def test_sis_profile_expected_graduation_term(self, client, coe_advisor_login):  # noqa: ARG002
         """Provides the last of any expected graduation terms listed in SIS profile."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -475,7 +475,7 @@ class TestStudent:
             assert sis_profile['expectedGraduationTerm']['id'] == '2198'
             assert sis_profile['expectedGraduationTerm']['name'] == 'Fall 2019'
 
-    def test_student_profile_inactive_status(self, client, coe_advisor_login):
+    def test_student_profile_inactive_status(self, client, coe_advisor_login):  # noqa: ARG002
         inactive_student_by_sid = self._api_student_by_sid(client=client, sid='3141592653')
         inactive_student_by_uid = self._api_student_by_uid(client=client, uid='314159')
         for student in [inactive_student_by_sid, inactive_student_by_uid]:
@@ -501,7 +501,7 @@ class TestStudent:
             assert student['enrollmentTerms'][1]['enrolledUnits'] == 0
             assert len(student['enrollmentTerms'][1]['enrollments']) == 0
 
-    def test_student_profile_completed_status(self, client, coe_advisor_login):
+    def test_student_profile_completed_status(self, client, coe_advisor_login):  # noqa: ARG002
         inactive_student_by_sid = self._api_student_by_sid(client=client, sid='2718281828')
         inactive_student_by_uid = self._api_student_by_uid(client=client, uid='271828')
         for student in [inactive_student_by_sid, inactive_student_by_uid]:
@@ -522,7 +522,7 @@ class TestStudent:
             assert student['enrollmentTerms'][1]['termName'] == 'Fall 2005'
             assert student['enrollmentTerms'][1]['enrollments'][0]['title'] == 'Chaucer'
 
-    def test_athletics_profile_non_asc(self, client, coe_advisor_login):
+    def test_athletics_profile_non_asc(self, client, coe_advisor_login):  # noqa: ARG002
         """Does not include select athletics profile data for non-ASC users."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -531,7 +531,7 @@ class TestStudent:
         for student in [student_by_sid, student_by_uid]:
             assert 'inIntensiveCohort' not in student['athleticsProfile']
 
-    def test_athletics_profile_asc(self, asc_advisor_login, client):
+    def test_athletics_profile_asc(self, asc_advisor_login, client):  # noqa: ARG002
         """Includes athletics profile for ASC users."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -553,7 +553,7 @@ class TestStudent:
             assert tennis['teamCode'] == 'TNW'
             assert tennis['teamName'] == 'Women\'s Tennis'
 
-    def test_college_of_engineering_profile(self, client, coe_advisor_login):
+    def test_college_of_engineering_profile(self, client, coe_advisor_login):  # noqa: ARG002
         """Includes COE profile (eg, PREP) for COE students."""
         sid = self.coe_student['sid']
         uid = self.coe_student['uid']
@@ -589,7 +589,7 @@ class TestStudent:
             for key, value in expected_coe_profile.items():
                 assert student['coeProfile'].get(key) == value
 
-    def test_athletics_profile_admin(self, admin_login, client):
+    def test_athletics_profile_admin(self, admin_login, client):  # noqa: ARG002
         """Includes athletics profile for admins."""
         sid = self.asc_student_in_coe['sid']
         uid = self.asc_student_in_coe['uid']
@@ -602,13 +602,13 @@ class TestStudent:
             assert athletics_profile['inIntensiveCohort'] is True
             assert len(athletics_profile['athletics']) == 2
 
-    def test_student_with_appointment(self, app, client, asc_advisor_login):
+    def test_student_with_appointment(self, client, asc_advisor_login):  # noqa: ARG002
         """Includes advising appointments."""
         student = self._api_student_by_sid(client=client, sid='11667051')
         appointments = student['notifications']['appointment']
         assert len(appointments) == 3
 
-    def test_appointment_marked_read(self, app, client, asc_advisor_login):
+    def test_appointment_marked_read(self, client, asc_advisor_login):  # noqa: ARG002
         """Includes flag indicating whether user has seen each appointment."""
         student_sid = '11667051'
 
@@ -663,7 +663,7 @@ class TestAlerts:
         assert response.status_code == 200
         return response.json['notifications']['alert']
 
-    def test_current_alerts_for_sid(self, create_alerts, fake_auth, client):
+    def test_current_alerts_for_sid(self, create_alerts, fake_auth, client):  # noqa: ARG002
         """Returns current_user's current alerts for a given sid."""
         fake_auth.login(admin_with_cohorts_uid)
         alerts = self._get_alerts(client, 61889)
@@ -716,7 +716,7 @@ class TestPrefixSearch:
     def test_unauthorized(self, client):
         self._api_find_students(client=client, expected_status_code=401, query='Paul')
 
-    def test_distinct_sid_in_student_search(self, client, coe_advisor_login):
+    def test_distinct_sid_in_student_search(self, client, coe_advisor_login):  # noqa: ARG002
         """Student search results have distinct SIDs."""
         api_json = self._api_find_students(client=client, query='d')
         student_count = len(api_json)
@@ -727,7 +727,7 @@ class TestPrefixSearch:
         assert 'Dave Doolittle (2345678901)' in labels
         assert 'Deborah Davies (11667051)' in labels
 
-    def test_student_prefix_search_by_name(self, client, coe_advisor_login):
+    def test_student_prefix_search_by_name(self, client, coe_advisor_login):  # noqa: ARG002
         """When searching by name, results include current students only."""
         api_json = self._api_find_students(
             client=client,
@@ -736,9 +736,9 @@ class TestPrefixSearch:
         )
         assert len(api_json) == 1
         labels = [student['label'] for student in api_json]
-        assert "Wolfgang Pauli-O'Rourke (9000000000) – wpo@berkeley.edu" in labels
+        assert "Wolfgang Pauli-O'Rourke (9000000000) - wpo@berkeley.edu" in labels
 
-    def test_student_prefix_search_by_sid(self, client, coe_advisor_login):
+    def test_student_prefix_search_by_sid(self, client, coe_advisor_login):  # noqa: ARG002
         """When searching by SID, results include both current and non-current students."""
         api_json = self._api_find_students(client=client, query=9)
         assert len(api_json) == 3
@@ -781,7 +781,7 @@ class TestNotes:
         note = next((n for n in notes if n.get('id') == '11667051-00001'), None)
         assert len(note)
         assert note['legacySource'] == 'SIS'
-        assert 'Brigitte is making athletic and moral progress' == note['message']
+        assert note['message'] == 'Brigitte is making athletic and moral progress'
         author = note['author']
         assert not author['name']
         assert not author['role']
@@ -882,11 +882,11 @@ class TestFindBySids:
         """Requires authentication."""
         self._api_find_by_sids(client, expected_status_code=401)
 
-    def test_missing_param(self, client, coe_advisor_login):
+    def test_missing_param(self, client, coe_advisor_login):  # noqa: ARG002
         """Requires list of SIDs."""
         self._api_find_by_sids(client, expected_status_code=400)
 
-    def test_invalid_param(self, client, coe_advisor_login):
+    def test_invalid_param(self, client, coe_advisor_login):  # noqa: ARG002
         """Requires SIDs to be numeric."""
         self._api_find_by_sids(
             client,
@@ -894,7 +894,7 @@ class TestFindBySids:
             expected_status_code=400,
         )
 
-    def test_(self, client, coe_advisor_login):
+    def test_(self, client, coe_advisor_login):  # noqa: ARG002
         """Returns basic attributes for SIDs found."""
         api_json = self._api_find_by_sids(
             client,
@@ -929,11 +929,11 @@ class TestValidateSids:
         """Requires authentication."""
         self._api_validate_sids(client, expected_status_code=401)
 
-    def test_validate_sids_with_invalid_sid(self, client, coe_advisor_login):
+    def test_validate_sids_with_invalid_sid(self, client, coe_advisor_login):  # noqa: ARG002
         """Complains about non-numeric SID."""
         self._api_validate_sids(client, sids=['7890123456', 'ABC'], expected_status_code=400)
 
-    def test_validate_sids_with_some_invalid(self, client, coe_advisor_login):
+    def test_validate_sids_with_some_invalid(self, client, coe_advisor_login):  # noqa: ARG002
         """SID status is 404 if student is not found."""
         api_json = self._api_validate_sids(
             client,
@@ -948,13 +948,13 @@ class TestValidateSids:
         assert api_json[2]['sid'] == '2345678901'
         assert api_json[2]['status'] == 200
 
-    def test_validate_sids_with_some_inactive(self, client, coe_advisor_login):
+    def test_validate_sids_with_some_inactive(self, client, coe_advisor_login):  # noqa: ARG002
         """Accepts inactive SIDs."""
         api_json = self._api_validate_sids(client, sids=['7890123456', '2718281828', '3141592653'])
         assert len(api_json) == 3
         assert [a['status'] for a in api_json] == [200, 200, 200]
 
-    def test_validate_sids_by_admin(self, client, admin_login):
+    def test_validate_sids_by_admin(self, client, admin_login):  # noqa: ARG002
         """Admin has access to all students."""
         api_json = self._api_validate_sids(
             client,

--- a/tests/test_api/test_topic_controller.py
+++ b/tests/test_api/test_topic_controller.py
@@ -204,7 +204,7 @@ class TestTopicUsageStatistics:
         fake_auth.login(l_s_college_advisor_uid)
         self._api_usage_statistics(client, expected_status_code=401)
 
-    def test_get_topic_usage_statistics(self, client, fake_auth, mock_advising_note):
+    def test_get_topic_usage_statistics(self, client, fake_auth, mock_advising_note):  # noqa: ARG002
         """Admin user can get topic usage report."""
         fake_auth.login(admin_uid)
         api_json = self._api_usage_statistics(client)

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -137,7 +137,7 @@ class TestMyCuratedGroups:
         assert 'totalStudentCount' in group
         assert group['name'] == 'I have two students'
 
-    def test_admitted_students_domain(self, app, client, fake_auth):
+    def test_admitted_students_domain(self, client, fake_auth):
         """Returns 'admitted_students' groups of CE3 advisor."""
         fake_auth.login(ce3_advisor_uid)
         curated_groups = _api_my_profile(client)['myCuratedGroups']
@@ -497,7 +497,7 @@ class TestUserSearch:
         """Deny anonymous user."""
         assert self._api_users_autocomplete(client, 'Jo', expected_status_code=401)
 
-    def test_unauthorized(self, client, fake_auth):
+    def test_unauthorized(self, client):
         """Deny non-admin user."""
         assert self._api_users_autocomplete(client, 'Jo', expected_status_code=401)
 
@@ -561,29 +561,25 @@ class TestDemoMode:
 
     def test_demo_mode_unavailable(self, client, fake_auth):
         """Return 404 when dev_auth is not enabled."""
-        with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
-            # Enable dev_auth to confirm that it is ignored
-            with override_config(app, 'DEMO_MODE_AVAILABLE', False):
-                fake_auth.login(admin_uid)
-                assert client.post('/api/user/demo_mode').status_code == 404
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', True), override_config(app, 'DEMO_MODE_AVAILABLE', False):
+            fake_auth.login(admin_uid)
+            assert client.post('/api/user/demo_mode').status_code == 404
 
     def test_set_demo_mode(self, client, fake_auth):
         """Both admin and advisor can toggle demo mode."""
-        with override_config(app, 'DEVELOPER_AUTH_ENABLED', False):
-            # Disable dev_auth to confirm that it is ignored
-            with override_config(app, 'DEMO_MODE_AVAILABLE', True):
-                for uid in admin_uid, coe_advisor_uid:
-                    fake_auth.login(uid)
-                    for in_demo_mode in [True, False]:
-                        response = client.post(
-                            '/api/user/demo_mode',
-                            data=json.dumps({'demoMode': in_demo_mode}),
-                            content_type='application/json',
-                        )
-                        assert response.status_code == 200
-                        assert response.json['inDemoMode'] is in_demo_mode
-                        user = AuthorizedUser.find_by_uid(uid)
-                        assert user.in_demo_mode is in_demo_mode
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', False), override_config(app, 'DEMO_MODE_AVAILABLE', True):
+            for uid in admin_uid, coe_advisor_uid:
+                fake_auth.login(uid)
+                for in_demo_mode in [True, False]:
+                    response = client.post(
+                        '/api/user/demo_mode',
+                        data=json.dumps({'demoMode': in_demo_mode}),
+                        content_type='application/json',
+                    )
+                    assert response.status_code == 200
+                    assert response.json['inDemoMode'] is in_demo_mode
+                    user = AuthorizedUser.find_by_uid(uid)
+                    assert user.in_demo_mode is in_demo_mode
 
 
 class TestDownloadBoaUsersCSV:

--- a/tests/test_externals/test_data_loch.py
+++ b/tests/test_externals/test_data_loch.py
@@ -35,7 +35,7 @@ import pytest
 @pytest.mark.usefixtures('db_session')
 class TestDataLoch:
 
-    def test_get_advisor_uids_for_affiliations(self, app):
+    def test_get_advisor_uids_for_affiliations(self):
         """Returns one or more rows for each advisor in the program."""
         advisors = data_loch.get_advisor_uids_for_affiliations('UCOE', None)
         assert len(advisors)
@@ -88,14 +88,14 @@ class TestDataLoch:
         assert profile['demographics']['underrepresented'] is False
         assert profile['sisProfile']['academicCareer'] == 'UGRD'
 
-    def test_get_enrolled_primary_sections(self, app):
+    def test_get_enrolled_primary_sections(self):
         sections = data_loch.get_enrolled_primary_sections('2178', 'MATH1')
         assert len(sections) == 6
         for section in sections:
             assert section['term_id'] == '2178'
             assert section['sis_course_name'].startswith('MATH 1')
 
-    def test_get_term_gpas(self, app):
+    def test_get_term_gpas(self):
         term_gpas = data_loch.get_term_gpas(['11667051'])
         assert len(term_gpas) == 4
         assert term_gpas[0]['term_id'] == '2182'
@@ -107,7 +107,7 @@ class TestDataLoch:
         assert term_gpas[3]['gpa'] == Decimal('3.800')
         assert term_gpas[3]['units_taken_for_gpa'] == 15
 
-    def test_get_asc_advising_notes(self, app):
+    def test_get_asc_advising_notes(self):
         notes = data_loch.get_asc_advising_notes('11667051')
         assert len(notes) == 2
         assert notes[0]['id'] == '11667051-139362'
@@ -136,7 +136,7 @@ class TestDataLoch:
         assert notes[1]['note_body']
         assert notes[1]['created_at']
 
-    def test_get_e_i_advising_notes(self, app):
+    def test_get_e_i_advising_notes(self):
         """Excludes notes with author name 'Reception Front Desk'."""
         notes = data_loch.get_e_i_advising_notes('11667051')
         assert len(notes) == 1
@@ -147,17 +147,17 @@ class TestDataLoch:
         assert notes[0]['created_at']
         assert notes[0]['updated_at']
 
-    def test_get_e_i_advising_note_topics(self, app):
+    def test_get_e_i_advising_note_topics(self):
         topics = data_loch.get_e_i_advising_note_topics('11667051')
         assert len(topics) == 2
         assert topics[0]['id'] == '11667051-151620'
         assert topics[0]['topic'] == 'Course Planning'
 
-    def test_get_admitted_student_by_sid(self, app):
+    def test_get_admitted_student_by_sid(self):
         admit = data_loch.get_admitted_student_by_sid('00005852')
         assert admit['sid'] == '00005852'
 
-    def test_get_sis_advising_note_attachment(self, app):
+    def test_get_sis_advising_note_attachment(self):
         attachment = data_loch.get_sis_advising_note_attachment('11667051', '11667051_00001_1.pdf')
         assert len(attachment) == 1
         assert attachment[0]['advising_note_id'] == '11667051-00001'
@@ -165,7 +165,7 @@ class TestDataLoch:
         assert attachment[0]['sis_file_name'] == '11667051_00001_1.pdf'
         assert attachment[0]['user_file_name'] == 'efac7b10-c3f2-11e4-9bbd-ab6a6597d26f.pdf'
 
-    def test_get_sis_advising_appointments(self, app):
+    def test_get_sis_advising_appointments(self):
         appointments = data_loch.get_sis_advising_appointments('11667051')
         assert len(appointments) == 3
         assert appointments[0]['id'] == '11667051-00010'
@@ -235,16 +235,16 @@ class TestDataLoch:
         assert 'LEFT JOIN student.student_enrollment_terms set' in supplemental_query_tables
         assert 'ON set.sid = spi.sid AND set.term_id = \'2202\'' in supplemental_query_tables
 
-    def test_override_fixture(self, app):
+    def test_override_fixture(self):
         mr = MockRows(io.StringIO('sid,first_name,last_name\n20000000,Martin,Van Buren'))
         with register_mock(data_loch.get_sis_section_enrollments, mr):
             data = data_loch.get_sis_section_enrollments(2178, 12345)
         assert len(data) == 1
-        assert {'sid': 20000000, 'first_name': 'Martin', 'last_name': 'Van Buren'} == data[0]
+        assert data[0] == {'sid': 20000000, 'first_name': 'Martin', 'last_name': 'Van Buren'}
 
-    def test_fixture_not_found(self, app):
+    def test_fixture_not_found(self):
         no_db = data_loch.get_sis_section_enrollments(0, 0)
-        # TODO Real data_loch queries will return an empty list if the course is not found.
+        # TODO: Real data_loch queries will return an empty list if the course is not found.
         assert no_db is None
 
     def test_user_permissions_per_affiliations(self):

--- a/tests/test_lib/test_berkeley.py
+++ b/tests/test_lib/test_berkeley.py
@@ -49,7 +49,7 @@ class TestBerkeleySisTermIdForName:
         """Returns None for missing term names."""
         assert berkeley.sis_term_id_for_name(None) is None
 
-    def test_term_ids_range(self, app):
+    def test_term_ids_range(self):
         assert berkeley.term_ids_range('2158', '2208') == [
             '2158', '2162', '2165', '2168', '2172', '2175', '2178', '2182', '2185', '2188', '2192', '2195', '2198', '2202', '2205', '2208',
         ]

--- a/tests/test_lib/test_sis_advising.py
+++ b/tests/test_lib/test_sis_advising.py
@@ -55,7 +55,7 @@ class TestGetLegacyAttachmentStream:
         with mock_sis_note_attachment(app):
             assert get_legacy_attachment_stream('h0ax.lol') is None
 
-    def test_stream_attachment_handles_file_not_in_database(self, app, fake_auth, caplog):
+    def test_stream_attachment_handles_file_not_in_database(self, app, fake_auth):
         with mock_sis_note_attachment(app):
             fake_auth.login(coe_advisor)
             assert get_legacy_attachment_stream('11667051_00002_1.pdf') is None

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -42,7 +42,7 @@ coe_advisor = '1133399'
 class TestMergedAdvisingNote:
     """Advising note data, merged."""
 
-    def test_get_advising_notes(self, app, mock_advising_note, fake_auth):
+    def test_get_advising_notes(self, mock_advising_note, fake_auth):  # noqa: PLR0915
         fake_auth.login(coe_advisor)
         notes = get_advising_notes('11667051')
 
@@ -160,7 +160,7 @@ class TestMergedAdvisingNote:
         assert len(boa_created_note['attachments']) == 1
         assert 'legacySource' not in boa_created_note
 
-    def test_get_advising_notes_ucbconversion_attachment(self, app, fake_auth):
+    def test_get_advising_notes_ucbconversion_attachment(self, fake_auth):
         fake_auth.login(coe_advisor)
         notes = get_advising_notes('11667051')
         assert notes[0]['attachments'] == [
@@ -171,7 +171,7 @@ class TestMergedAdvisingNote:
             },
         ]
 
-    def test_get_advising_notes_cs_attachment(self, app, mock_advising_note, fake_auth):
+    def test_get_advising_notes_cs_attachment(self, mock_advising_note, fake_auth):
         fake_auth.login(coe_advisor)
         notes = get_advising_notes('11667051')
         assert notes[1]['attachments'] == [
@@ -206,7 +206,7 @@ class TestMergedAdvisingNote:
             assert notes[0]['attachments'] is None
             assert notes[0]['body'] is None
 
-    def test_get_advising_notes_timestamp_format(self, app, fake_auth):
+    def test_get_advising_notes_timestamp_format(self, fake_auth):
         fake_auth.login(coe_advisor)
         notes = get_advising_notes('9000000000')
         ucbconversion_note = notes[0]
@@ -216,7 +216,7 @@ class TestMergedAdvisingNote:
         assert parse(cs_note['createdAt']) == parse('2017-11-02T12:00:00+00')
         assert parse(cs_note['updatedAt']) == parse('2017-11-02T13:00:00+00')
 
-    def test_search_advising_notes(self, app, fake_auth):
+    def test_search_advising_notes(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='herostratus')
         notes = results['notes']
@@ -234,7 +234,7 @@ class TestMergedAdvisingNote:
         assert parse(notes[0]['createdAt']) == parse('2017-11-05T12:00:00+00')
         assert notes[0]['updatedAt'] is None
 
-    def test_search_for_private_advising_notes(self, fake_auth, mock_private_advising_note):
+    def test_search_for_private_advising_notes(self, fake_auth, mock_private_advising_note):  # noqa: ARG002
         fake_auth.login(ce3_advisor_uid)
         results = search_advising_notes(search_phrase='neon', author_uid=ce3_advisor_uid)
         notes = results['notes']
@@ -242,7 +242,7 @@ class TestMergedAdvisingNote:
         assert total_note_count == 0
         assert notes == []
 
-    def test_search_advising_notes_by_category(self, app, fake_auth):
+    def test_search_advising_notes_by_category(self, fake_auth):
         """Matches legacy category/subcategory for SIS advising notes only if body is blank."""
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='Quick Question')
@@ -252,7 +252,7 @@ class TestMergedAdvisingNote:
         assert total_note_count == 1
         assert notes[0]['noteSnippet'] == '<strong>Quick</strong> <strong>Question</strong>, Unanswered'
 
-    def test_search_for_asc_advising_notes(self, app, fake_auth):
+    def test_search_for_asc_advising_notes(self, fake_auth):
         fake_auth.login(asc_advisor)
         results = search_advising_notes(search_phrase='kilmister')
         notes = results['notes']
@@ -272,7 +272,7 @@ class TestMergedAdvisingNote:
         assert parse(notes[0]['createdAt']) == parse('2014-01-03T20:30:00+00')
         assert notes[0]['updatedAt'] is None
 
-    def test_search_advising_notes_stemming(self, app, fake_auth):
+    def test_search_advising_notes_stemming(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='spare')
         notes = results['notes']
@@ -285,7 +285,7 @@ class TestMergedAdvisingNote:
         notes = results['notes']
         assert '<strong>felicities</strong>' in notes[0]['noteSnippet']
 
-    def test_search_advising_notes_too_short_to_snippet(self, app, fake_auth):
+    def test_search_advising_notes_too_short_to_snippet(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='campus')
         notes = results['notes']
@@ -294,7 +294,7 @@ class TestMergedAdvisingNote:
         assert total_note_count == 1
         assert notes[0]['noteSnippet'] == 'Is this student even on <strong>campus</strong>?'
 
-    def test_search_advising_notes_ordered_by_relevance(self, app, fake_auth):
+    def test_search_advising_notes_ordered_by_relevance(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='confound')
         notes = results['notes']
@@ -304,7 +304,7 @@ class TestMergedAdvisingNote:
         assert '<strong>confounded</strong> that of himself' in notes[0]['noteSnippet']
         assert notes[1]['noteSnippet'] == 'I am <strong>confounded</strong> by this <strong>confounding</strong> student'
 
-    def test_search_advising_notes_multiple_terms(self, app, fake_auth):
+    def test_search_advising_notes_multiple_terms(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='burnt diana temple')
         notes = results['notes']
@@ -313,7 +313,7 @@ class TestMergedAdvisingNote:
         assert total_note_count == 1
         assert 'Herostratus lives that <strong>burnt</strong> the <strong>Temple</strong> of <strong>Diana</strong>' in notes[0]['noteSnippet']
 
-    def test_search_advising_notes_no_match(self, app, fake_auth):
+    def test_search_advising_notes_no_match(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='pyramid octopus')
         notes = results['notes']
@@ -321,7 +321,7 @@ class TestMergedAdvisingNote:
         assert len(notes) == 0
         assert total_note_count == 0
 
-    def test_search_advising_notes_funny_characters(self, app, fake_auth):
+    def test_search_advising_notes_funny_characters(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='horse & epitaph')
         notes = results['notes']
@@ -330,12 +330,11 @@ class TestMergedAdvisingNote:
         assert total_note_count == 1
         assert 'Time hath spared the <strong>Epitaph</strong> of Adrians <strong>horse</strong>' in notes[0]['noteSnippet']
 
-    def test_search_dates(self, app, fake_auth):
+    def test_search_dates(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='2/1/2019 1:30')
         notes = results['notes']
         total_note_count = results['totalNoteCount']
-        print(notes[0]['noteSnippet'])
         assert len(notes) == 1
         assert total_note_count == 1
         assert (
@@ -348,29 +347,27 @@ class TestMergedAdvisingNote:
         assert total_note_count == 1
         assert 'drop Eng. 123 by <strong>1-24-19</strong>' in notes[0]['noteSnippet']
 
-    def test_search_decimals(self, app, fake_auth):
+    def test_search_decimals(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='2.0')
         notes = results['notes']
-        print(notes[0]['noteSnippet'])
         total_note_count = results['totalNoteCount']
         assert len(notes) == 1
         assert total_note_count == 1
         assert 'Student continued on <strong>2</strong>.<strong>0</strong> prob (COP) until Sp \'19.' in notes[0]['noteSnippet']
 
-    def test_search_email_address(self, app, fake_auth):
+    def test_search_email_address(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='E-mailed test@berkeley.edu')
         notes = results['notes']
         total_note_count = results['totalNoteCount']
-        print(notes[0]['noteSnippet'])
         assert len(notes) == 1
         assert total_note_count == 1
         assert (
                'Student continued on 2.0 prob (COP) until Sp \'19. <strong>E-mailed</strong> '
                '<strong>test</strong>@<strong>berkeley</strong>.<strong>edu</strong>:') in notes[0]['noteSnippet']
 
-    def test_search_advising_notes_timestamp_format(self, app, fake_auth):
+    def test_search_advising_notes_timestamp_format(self, fake_auth):
         fake_auth.login(coe_advisor)
         results = search_advising_notes(search_phrase='confound')
         notes = results['notes']
@@ -381,7 +378,7 @@ class TestMergedAdvisingNote:
         assert cs_note['createdAt']
         assert cs_note['updatedAt'] is None
 
-    def test_search_advising_notes_includes_newly_created(self, app, fake_auth):
+    def test_search_advising_notes_includes_newly_created(self, fake_auth):
         fake_auth.login(coe_advisor)
         _create_coe_advisor_note(
             sid='11667051',
@@ -397,9 +394,9 @@ class TestMergedAdvisingNote:
         assert notes[1]['noteSnippet'].startswith('...pity the founder')
         assert notes[2]['noteSnippet'].startswith('I am <strong>confounded</strong>')
 
-    def test_search_advising_notes_paginates_new_and_old(self, app, fake_auth):
+    def test_search_advising_notes_paginates_new_and_old(self, fake_auth):
         fake_auth.login(coe_advisor)
-        for i in range(0, 5):
+        for i in range(5):
             _create_coe_advisor_note(
                 sid='11667051',
                 subject='Planned redundancy',
@@ -422,7 +419,7 @@ class TestMergedAdvisingNote:
         assert notes[1]['noteSnippet'].startswith('...pity the founder')
         assert notes[2]['noteSnippet'].startswith('I am <strong>confounded</strong>')
 
-    def test_search_advising_notes_narrowed_by_author(self, app, fake_auth):
+    def test_search_advising_notes_narrowed_by_author(self, fake_auth):
         """Narrows results for both new and legacy advising notes by author SID."""
         joni = {
             'name': 'Joni Mitchell',
@@ -456,7 +453,7 @@ class TestMergedAdvisingNote:
         assert new_note['advisorUid'] == joni['uid']
         assert legacy_note['advisorSid'] == joni['sid']
 
-    def test_search_advising_notes_narrowed_by_student(self, app, fake_auth):
+    def test_search_advising_notes_narrowed_by_student(self, fake_auth):
         """Narrows results for both new and legacy advising notes by student SID."""
         for sid in ['9000000000', '9100000000']:
             _create_coe_advisor_note(
@@ -477,7 +474,7 @@ class TestMergedAdvisingNote:
         assert new_note['studentSid'] == '9100000000'
         assert legacy_note['studentSid'] == '9100000000'
 
-    def test_search_advising_notes_restricted_to_students_in_loch(self, app, fake_auth):
+    def test_search_advising_notes_restricted_to_students_in_loch(self, fake_auth):
         fake_auth.login(coe_advisor)
         _create_coe_advisor_note(
             sid='6767676767',
@@ -492,7 +489,7 @@ class TestMergedAdvisingNote:
         )
         assert len(search_advising_notes(search_phrase='loch')['notes']) == 1
 
-    def test_search_advising_notes_narrowed_by_topic(self, app, fake_auth):
+    def test_search_advising_notes_narrowed_by_topic(self, fake_auth):
         for topic in ['Good Show', 'Bad Show']:
             _create_coe_advisor_note(
                 sid='11667051',

--- a/tests/test_merged/test_sis_sections.py
+++ b/tests/test_merged/test_sis_sections.py
@@ -34,7 +34,7 @@ import pytest
 @pytest.mark.usefixtures('db_session')
 class TestGetSisSection:
 
-    def test_get_section(self, app):
+    def test_get_section(self):
         section_id = 90100
         section = get_sis_section('2178', section_id)
         assert section['sectionId'] == section_id
@@ -46,7 +46,7 @@ class TestGetSisSection:
         assert section['meetings'][0]['time'] == '12:00 pm - 12:59 pm'
         assert section['meetings'][0]['location'] == 'Wheeler 999'
 
-    def test_handles_multiple_locations_and_instructors(self, app):
+    def test_handles_multiple_locations_and_instructors(self):
         section = get_sis_section('2178', 90200)
         assert section['meetings'][0]['days'] == 'Tue, Thu'
         assert section['meetings'][0]['time'] == '6:00 pm - 6:59 pm'
@@ -57,7 +57,7 @@ class TestGetSisSection:
         assert section['meetings'][1]['location'] == 'Campbell Hall 501B'
         assert section['meetings'][1]['instructors'] == ['Johan Huizinga', 'Ernst Robert Curtius']
 
-    def test_handles_eap_courses(self, app):
+    def test_handles_eap_courses(self):
         section_id = 98000
         rows = [
             'sis_term_id,sis_section_id,sis_course_title,sis_course_name,is_primary,sis_instruction_format,'
@@ -78,7 +78,7 @@ class TestGetSisSection:
             assert section['meetings'][0]['location'] is None
             assert section['meetings'][0]['instructors'] == []
 
-    def test_handles_online_courses(self, app):
+    def test_handles_online_courses(self):
         section_id = 99000
         rows = [
             'sis_term_id,sis_section_id,sis_course_title,sis_course_name,is_primary,sis_instruction_format,'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -27,20 +27,20 @@ import pytest
 from tests.util import override_config
 
 
-@pytest.fixture()
+@pytest.fixture
 def asc_advisor_session(fake_auth):
     fake_auth.login('1081940')
 
 
 class TestFrontEndRoute:
 
-    def test_front_end_route(self, app, client, asc_advisor_session):
+    def test_front_end_route(self, app, client, asc_advisor_session):  # noqa: ARG002
         """No server-side redirect if Vue code is bundled in deployment (AWS environment)."""
         with override_config(app, 'VUE_LOCALHOST_BASE_URL', None):
             response = client.get('/student/123?r=1')
             assert response.status_code == 200
 
-    def test_front_end_route_redirect(self, app, client, asc_advisor_session):
+    def test_front_end_route_redirect(self, app, client, asc_advisor_session):  # noqa: ARG002
         """Server-side redirect to Vue.js (separate port) on developer workstation."""
         vue_path = '/student/12345?r=1'
         vue_base_url = 'http://localhost:8080'

--- a/tox.ini
+++ b/tox.ini
@@ -28,50 +28,7 @@ setenv =
 commands = pytest --durations=10 {posargs: -p no:warnings tests}
 
 [testenv:lint-bea]
-commands = flake8 --ignore=C901,D101,D102,D103,D104,D105,D107,E731,Q003,W503,W605 {posargs:bea}
-deps =
-    flake8==7.2.0
-    flake8-builtins>=2.5.0
-    flake8-colors>=0.1.9
-    flake8-commas>=4.0.0
-    flake8-docstrings>=1.7.0
-    flake8-import-order>=0.18.2
-    flake8-pytest>=1.4
-    flake8-quotes>=3.4.0
-    flake8-tidy-imports>=4.11.0
-    pep8-naming>=0.14.1
-    pydocstyle>=6.3.0
+commands = ruff check {posargs:bea}
 
 [testenv:lint-py]
-# Bottom of file has Flake8 settings
-commands = flake8 {posargs:application.py boac config consoler.py scripts tests}
-deps =
-    flake8==7.2.0
-    flake8-builtins>=2.5.0
-    flake8-colors>=0.1.9
-    flake8-commas>=4.0.0
-    flake8-docstrings>=1.7.0
-    flake8-import-order>=0.18.2
-    flake8-pytest>=1.4
-    flake8-quotes>=3.4.0
-    flake8-tidy-imports>=4.11.0
-    pep8-naming>=0.14.1
-    pydocstyle>=6.3.0
-
-[flake8]
-exclude =
-    *.pyc
-    .cache
-    .git
-    .tox
-    __pycache__
-    build
-    config/*-local.py
-    dist
-    node_modules
-ignore = A005,D101,D102,D103,D104,D105,D107,E731,Q003,W503,W605
-import-order-style = google
-max-complexity = 13
-max-line-length = 150
-show-source = True
-statistics = True
+commands = ruff check {posargs:application.py boac config consoler.py scripts tests}


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6150

* `ruff.toml` is the Ruff config. All Flake-iness removed from `tox.ini`
* Some code-style violations were fixed, mostly in `tests` dir.  No risky changes made.
* A lot of `noqa: ...` (ie, ignore linter failure) in the more messy pytest code
* Rules we aspire to enable are listed in a `ruff.toml` comment
* BEA has a limited set of linter rules
* Unused method params no longer tolerated