### PR TITLE
BOAC-6157: fixes add-to-curated-group bindings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,7 @@ export default [
     languageOptions: {
       globals: {
         ...globals.node,
+        ...globals.browser
       },
       parser: parser,
       parserOptions: {
@@ -133,7 +134,7 @@ export default [
       'vue/no-v-html': 0,
       'vue/no-v-for-template-key': 1,
       'vue/no-v-for-template-key-on-child': 2,
-      'vue/no-v-model-argument': 1,
+      'vue/no-v-model-argument': 2,
       'vue/no-v-text-v-html-on-component': 0,
       'vue/order-in-components': 2,
       'vue/require-default-prop': 2,

--- a/src/components/admin/passenger-manifest/BoaUsers.vue
+++ b/src/components/admin/passenger-manifest/BoaUsers.vue
@@ -7,8 +7,6 @@
       Showing {{ pluralize('user', totalUserCount) }}
     </div>
     <v-data-table-virtual
-      v-model:expanded="expanded"
-      v-model:items-per-page="itemsPerPage"
       :cell-props="data => {
         const padding = ['becomeUser', 'data-table-expand'].includes(data.column.key) ? 'px-0' : ''
         return {
@@ -19,6 +17,7 @@
       class="responsive-data-table v-table-hidden-row-override"
       disable-pagination
       :disable-sort="totalUserCount < 2"
+      :expanded="expanded"
       :headers="[
         {key: 'data-table-expand', sortable: false, title: '', width: 40},
         {align: 'start', key: 'uid', title: 'UID'},
@@ -222,7 +221,6 @@ const dialogs = ref([])
 const editUserModel = ref(undefined)
 const expanded = ref([])
 const isBecomingUid = ref(false)
-const itemsPerPage = 10
 
 watch(() => props.refresh, value => {
   if (value) {

--- a/src/components/curated/dropdown/CuratedGroupSelector.vue
+++ b/src/components/curated/dropdown/CuratedGroupSelector.vue
@@ -48,12 +48,11 @@
           </button>
         </template>
         <v-list
-          v-model:selected="selectedCuratedGroups"
           :aria-label="`Select one or more ${domainLabel(true)}s`"
           class="pb-1"
           density="compact"
           max-height="400"
-          select-strategy="leaf"
+          :model-value="selectedCuratedGroups"
           variant="flat"
         >
           <v-list-item v-if="!size(myCuratedGroups)" disabled>
@@ -63,11 +62,13 @@
             v-for="group in myCuratedGroups"
             :id="`${idFragment}-${group.id}`"
             :key="group.id"
-            :aria-checked="!!find(selectedCuratedGroups, {'id': group.id})"
+            :aria-checked="!!find(selectedCuratedGroups, g => g.id === group.id)"
+            :aria-selected="undefined"
             class="v-list-item-override py-0"
             density="compact"
             role="checkbox"
             :value="group"
+            @click.stop="() => onClickListItem(group)"
             @focus="scrollToItem(`${idFragment}-${group.id}`)"
           >
             <template #prepend="{isSelected}">
@@ -131,7 +132,7 @@
 
 <script setup>
 import {computed, onMounted, onUnmounted, reactive, ref} from 'vue'
-import {filter as _filter, each, find, inRange, map, remove, size} from 'lodash'
+import {filter as _filter, each, find, findIndex, inRange, map, remove, size} from 'lodash'
 import {mdiCheckBold, mdiMenuDown, mdiPlus} from '@mdi/js'
 import CreateCuratedGroupModal from '@/components/curated/CreateCuratedGroupModal'
 import {addStudentsToCuratedGroups, createCuratedGroup} from '@/api/curated'
@@ -238,6 +239,15 @@ const onCheckboxUnchecked = args => {
   if (props.domain === args.domain) {
     sids.value = remove(sids.value, s => s !== args.sid)
     refresh()
+  }
+}
+
+const onClickListItem = group => {
+  const index = findIndex(selectedCuratedGroups.value, g => g.id === group.id)
+  if (index >= 0) {
+    selectedCuratedGroups.value.splice(index, 1)
+  } else {
+    selectedCuratedGroups.value.push(group)
   }
 }
 

--- a/src/components/curated/dropdown/ManageStudent.vue
+++ b/src/components/curated/dropdown/ManageStudent.vue
@@ -51,12 +51,12 @@
         </button>
       </template>
       <v-list
-        v-model:selected="selectedGroupIds"
         :aria-label="`${props.student.name}\'s ${domainLabel(true)} memberships`"
         class="pb-1"
         density="compact"
         max-height="400"
-        select-strategy="leaf"
+        :model-value="selectedGroupIds"
+        selectable
         variant="flat"
       >
         <v-list-item v-if="!size(filteredCuratedGroups)" disabled>
@@ -67,17 +67,19 @@
           :id="`${idFragment}-${group.id}`"
           :key="group.id"
           :aria-checked="!!includes(selectedGroupIds, group.id)"
-          density="compact"
+          :aria-selected="undefined"
           class="v-list-item-override py-0"
+          density="compact"
           role="checkbox"
           :value="group.id"
+          @click.stop="() => onClickListItem(group.id)"
           @focus="scrollToItem(`${idFragment}-${group.id}`)"
         >
-          <template #prepend="{isSelected}">
+          <template #prepend>
             <v-list-item-action start>
               <v-checkbox-btn
                 :id="`${idFragment}-${group.id}-checkbox`"
-                :model-value="isSelected"
+                :model-value="!!includes(selectedGroupIds, group.id)"
                 class="mr-7 w-100"
                 color="primary"
                 density="compact"
@@ -132,8 +134,8 @@
 </template>
 
 <script setup>
-import {computed, onMounted, onUnmounted, ref} from 'vue'
 import {filter as _filter, clone, difference, includes, map, noop, size, xor} from 'lodash'
+import {computed, onMounted, onUnmounted, ref} from 'vue'
 import {mdiCheckBold, mdiCloseThick, mdiMenuDown, mdiPlus} from '@mdi/js'
 import CreateCuratedGroupModal from '@/components/curated/CreateCuratedGroupModal'
 import {
@@ -178,7 +180,7 @@ const props = defineProps({
 
 const contextStore = useContextStore()
 
-const selectedGroupIds = ref(undefined)
+const selectedGroupIds = ref([])
 const confirmationTimeout = ref(1500)
 const currentUser = contextStore.currentUser
 const eventName = 'my-curated-groups-updated'
@@ -212,6 +214,15 @@ onUnmounted(() => {
 
 const domainLabel = capitalize => {
   return describeCuratedGroupDomain(props.domain, capitalize)
+}
+
+const onClickListItem = groupId => {
+  const index = selectedGroupIds.value.indexOf(groupId)
+  if (index >= 0) {
+    selectedGroupIds.value.splice(index, 1)
+  } else {
+    selectedGroupIds.value.push(groupId)
+  }
 }
 
 const onCreateCuratedGroup = name => {

--- a/src/components/reports/UserReport.vue
+++ b/src/components/reports/UserReport.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="pr-3">
     <v-data-table-server
-      v-model:expanded="expanded"
       class="responsive-data-table"
       density="compact"
       disable-pagination
       disable-sort
+      :expanded="expanded"
       :header-props="{class: 'font-size-14 font-weight-bold py-3 text-no-wrap'}"
       :headers="[
         {key: 'data-table-expand'},


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6157

v-model with argument (e.g. `v-model:selected`) is apparently a no-no. I think something in the recent package upgrades caused it to break in CuratedGroupSelector.vue and ManageStudent.vue.

It didn't seem to impact BoaUsers.vue and UserReport.vue, but I got rid of it there anyway so the linter won't complain. 