### PR TITLE
BOAC-5777, /cohort page: we can now control the order of option-groups

### DIFF
--- a/boac/lib/cohort_utils.py
+++ b/boac/lib/cohort_utils.py
@@ -92,19 +92,22 @@ def academic_division_options():
 
 
 @stow('cohort_filter_options_academic_standing')
-def academic_standing_options(min_term_id=0):
-    option_groups = {}
+def academic_standing_options(min_term_id):
+    option_groups = []
     for term_id, rows in groupby(data_loch.get_academic_standing_terms(min_term_id), lambda r: r['term_id']):
-        group = term_name_for_sis_id(term_id)
-        option_groups[group] = []
+        options = []
         for row in rows:
             value = row['status']
             standing = ACADEMIC_STANDING_DESCRIPTIONS.get(value)
             if standing:
-                option_groups[group].append({
+                options.append({
                     'name': standing,
                     'value': f'{term_id}:{value}',
                 })
+        option_groups.append({
+            'label': term_name_for_sis_id(term_id),
+            'options': options,
+        })
     return option_groups
 
 
@@ -147,17 +150,18 @@ def ethnicities():
 @stow('cohort_filter_options_grad_terms')
 def grad_terms():
     current_term_id_ = current_term_id()
-    option_groups = {
-        'Future': [],
-        'Past': [],
-    }
+    options_future = []
+    options_past = []
     for term_id in [r['expected_grad_term'] for r in data_loch.get_expected_graduation_terms()]:
-        key = 'Past' if term_id < current_term_id_ else 'Future'
-        option_groups[key].append({
+        options = options_past if term_id < current_term_id_ else options_future
+        options.append({
             'name': ' '.join(term_name_for_sis_id(term_id).split()[::-1]),
             'value': term_id,
         })
-    return option_groups
+    return [
+        {'label': 'Future', 'options': options_future},
+        {'label': 'Past', 'options': options_past},
+    ]
 
 
 @stow('cohort_filter_options_grading_terms')

--- a/scripts/db/migrate/2025/20250507-BOAC-5777/remove_json_cache_entries.sql
+++ b/scripts/db/migrate/2025/20250507-BOAC-5777/remove_json_cache_entries.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DELETE FROM json_cache WHERE
+  key IN ('all_team_groups')
+  OR
+  key LIKE 'cohort_filter_options_%';
+
+COMMIT;

--- a/src/components/cohort/FilterRow.vue
+++ b/src/components/cohort/FilterRow.vue
@@ -38,7 +38,7 @@
         <div v-if="isUX('dropdown')">
           <span :id="`filter-secondary-${position}-label`" class="sr-only">{{ filter.name }} options</span>
           <FilterSelect
-            v-if="filter.options instanceof Array"
+            v-if="!isOptGroup(filter.options)"
             v-model="selectedOption"
             :disabled="isUpdatingExistingFilter"
             :filter-row-index="position"
@@ -46,7 +46,7 @@
             :options="filter.options"
           />
           <FilterSelectOptionGroups
-            v-if="!(filter.options instanceof Array)"
+            v-if="isOptGroup(filter.options)"
             v-model="selectedOption"
             :disabled="isUpdatingExistingFilter"
             :filter-row-index="position"
@@ -223,11 +223,10 @@ import {
   cloneDeep,
   each,
   find,
-  flatten,
   get,
   isNaN,
   isNil,
-  isUndefined, map,
+  isUndefined,
   noop,
   toLower,
   trim
@@ -394,8 +393,6 @@ onMounted(() => {
   reset()
 })
 
-const flattenOptions = filterCategories => flatten(map(filterCategories, 'options'))
-
 const formatGPA = value => {
   // Prepend zero in case input is, for example, '.2'. No harm done if input has a leading zero.
   const gpa = trim(value)
@@ -403,22 +400,21 @@ const formatGPA = value => {
 }
 
 const getDropdownSelectedLabel = () => {
-  const allOptions = flattenOptions(cohortStore.filterCategories)
-  const option = find(allOptions, ['key', filter.value.key])
   let label = ''
-  const isOptGroup = !Array.isArray(option.options)
-  if (isOptGroup) {
-    each(option.options, (optGroupOptions, optGroupLabel) => {
-      const option = find(optGroupOptions, ['value', filter.value.value])
-      label = option ? `${get(option, 'name')} (${optGroupLabel})` : null
+  if (isOptGroup(filter.value.options)) {
+    each(filter.value.options, option => {
+      const dropdownOption = find(option.options, ['value', filter.value.value])
+      label = dropdownOption ? `${get(dropdownOption, 'name')} (${option.label})` : null
       return !label
     })
   } else {
-    const option = find(option.options, ['value', filter.value.value])
-    label = get(option, 'name')
+    const dropdownOption = find(filter.value.options, ['value', filter.value.value])
+    label = get(dropdownOption, 'name')
   }
   return label
 }
+
+const isOptGroup = dropdownOptions => !!dropdownOptions[0].options
 
 const isUX = type => {
   return get(filter.value, 'type.ux') === type
@@ -460,16 +456,20 @@ const onClickCancelEdit = () => {
 
 const onClickEditButton = () => {
   disableUpdateButton.value = false
+  const selection = filter.value.value
   if (isUX('dropdown')) {
-    // Populate select options, with selected option based on current filter.value.
-    const findOption = (options, value) => find(options, ['value', value])
-    const options = find(flattenOptions(cohortStore.filterCategories), ['key', filter.value.key]).options
-    filter.value.options = options
-    selectedOption.value = Array.isArray(options) ? findOption(options, filter.value.value) : find(flattenOptions(options), filter.value.value)
+    if (isOptGroup(filter.value.options)) {
+      each(filter.value.options, option => {
+        selectedOption.value = find(option.options, ['value', filter.value.value])
+        return !selectedOption.value
+      })
+    } else {
+      selectedOption.value = find(filter.value.options, ['value', selection])
+    }
     putFocusNextTick(`filter-select-secondary-${props.position}`)
   } else if (isUX('range')) {
-    rangeMin.value = filter.value.value.min
-    rangeMax.value = filter.value.value.max
+    rangeMin.value = selection.min
+    rangeMax.value = selection.max
     putFocusNextTick(`filter-range-min-${props.position}`)
   }
   isModifyingFilter.value = true

--- a/src/components/cohort/FilterSelectOptionGroups.vue
+++ b/src/components/cohort/FilterSelectOptionGroups.vue
@@ -11,15 +11,15 @@
         Select...
       </option>
       <optgroup
-        v-for="(options, label) in optionGroups"
-        :id="normalizeId(`secondary-option-group-${label}`)"
-        :key="label"
-        :label="label"
+        v-for="optionGroup in optionGroups"
+        :id="normalizeId(`secondary-option-group-${optionGroup.label}`)"
+        :key="optionGroup.label"
+        :label="optionGroup.label"
       >
         <option
-          v-for="option in options"
+          v-for="option in optionGroup.options"
           :id="normalizeId(`secondary-option-${normalizeId(option.value)}`)"
-          :key="option.key"
+          :key="option.value"
           :aria-disabled="option.disabled"
           :disabled="option.disabled"
           :value="option"

--- a/tests/test_api/test_cohort_filter_options_controller.py
+++ b/tests/test_api/test_cohort_filter_options_controller.py
@@ -34,7 +34,7 @@ ce3_advisor_uid = '2525'
 coe_advisor_uid = '1133399'
 
 
-class TestCohortFilterOptions:
+class TestCohortFilterCategories:
 
     @classmethod
     def _api_cohort_filter_categories(cls, client, data, expected_status_code=200):
@@ -204,8 +204,12 @@ class TestCohortFilterOptions:
         academic_filter_category = next((category for category in api_json if category['label'] == 'Academic'), None)
         entering_terms_dropdown = next((option for option in academic_filter_category['options'] if option['key'] == 'expectedGradTerms'), None)
         options = entering_terms_dropdown['options']
-        assert len(options['Past']) == 1
-        assert options['Past'][0]['name'] == '1997 Fall'
+        assert len(options) == 2
+        assert options[0]['label'] == 'Future'
+        assert options[1]['label'] == 'Past'
+        options_past = options[1]['options']
+        assert len(options_past) == 1
+        assert options_past[0]['name'] == '1997 Fall'
 
     def test_range_of_majors(self, user_factory, client, fake_auth):
         """Cohort filter: Range of major terms."""


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5777

* This fixes issue with both 'Expected Grad Term' and 'Academic Standing' filters
* Includes db-migrate script which flushes cohort-filter related cache entries.