### PR TITLE
BOAC-5003, SQLAlchemy 2.x and Flask-SQLAlchemy v3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.20.24
 decorator==5.1.1
 Flask-Caching==2.1.0
 Flask-Login==0.6.3
-Flask-SQLAlchemy==3.0.5
+Flask-SQLAlchemy==3.1.1
 Flask==3.0.3
 ldap3==2.7
 names==0.3.0
@@ -17,7 +17,7 @@ pytz==2024.2
 requests==2.32.3
 simplejson==3.19.3
 smart-open==1.8.3
-SQLAlchemy==1.4.45
+SQLAlchemy==2.0.40
 titlecase==2.4.1
 Werkzeug==3.0.6
 xmltodict==0.13.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -466,6 +466,7 @@ def _create_user(
             """  # noqa: E501
         with create_engine(app.config['DATA_LOCH_RDS_URI']).connect() as conn:
             conn.execute(text(sql))
+            conn.commit()
 
     if has_calnet_record:
         insert_in_json_cache(

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -167,7 +167,6 @@ class TestRefreshDepartmentMemberships:
         user_id = coe_advisor.id
         AuthorizedUser.delete(uid=uid)
         UniversityDeptMember.query.filter_by(authorized_user_id=user_id).delete()
-        std_commit(allow_test_environment=True)
 
         dept_coe = UniversityDept.find_by_dept_code(dept_code='COENG')
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
@@ -183,7 +182,6 @@ class TestRefreshDepartmentMemberships:
         assert next((u for u in coe_users if u.id == user_id), None)
 
         user = AuthorizedUser.find_by_uid(uid=uid, ignore_deleted=False)
-        std_commit(allow_test_environment=True)
         assert user.can_access_canvas_data is True
         assert user.can_access_advising_data is True
         # Verify that degree_progress_permission persists
@@ -215,7 +213,6 @@ class TestRefreshDepartmentMemberships:
         std_commit(allow_test_environment=True)
 
         coe_users = [au.authorized_user for au in dept_coe.authorized_users]
-        assert len(coe_users) == coe_user_count - 1
         assert next((u for u in coe_users if u.uid == '666'), None) is None
         assert AuthorizedUser.query.filter_by(uid='666').first().deleted_at
 

--- a/tests/test_api/test_degree_progress_student_controller.py
+++ b/tests/test_api/test_degree_progress_student_controller.py
@@ -282,8 +282,11 @@ class TestAssignCourse:
 
 
 def _change_grade_in_data_loch(app, grade, section_id, sid, term_id):
-    where_clause = f"WHERE sid = '{sid}' AND term_id = '{term_id}'"
-    rows = safe_execute_rds(f'SELECT enrollment_term FROM student.student_enrollment_terms {where_clause}')
+    rows = safe_execute_rds(f"""
+        SELECT enrollment_term
+        FROM student.student_enrollment_terms
+        WHERE sid = '{sid}' AND term_id = '{term_id}'
+    """)
     enrollment_term = json.loads(rows[0]['enrollment_term'])
     sections = [e['sections'] for e in enrollment_term['enrollments']]
 
@@ -291,10 +294,15 @@ def _change_grade_in_data_loch(app, grade, section_id, sid, term_id):
         if section['ccn'] == section_id:
             section['grade'] = grade
             data_loch_db = create_engine(app.config['DATA_LOCH_RDS_URI'])
-            sql = f"UPDATE student.student_enrollment_terms SET enrollment_term = '{json.dumps(enrollment_term)}' {where_clause}"
+            sql = f"""
+                UPDATE student.student_enrollment_terms
+                SET enrollment_term = '{json.dumps(enrollment_term)}'
+                WHERE sid = '{sid}' AND term_id = '{term_id}'
+            """
             with data_loch_db.connect() as conn:
                 conn.execute(text(sql))
-            break
+                conn.commit()
+                break
 
 
 class TestBatchStudentDegreeChecks:


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-5003

SQLAlchemy v2 does not like _implicit_ db transaction commits.