### PR TITLE
BOAC-6207, /student: show Appt quick-links, even if only one appt

### DIFF
--- a/src/components/student/profile/academic-timeline/AcademicTimeline.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimeline.vue
@@ -14,7 +14,7 @@
     <div
       :class="{
         'border-sm': !!messages.length,
-        'pt-3': ['appointment', 'eForm', 'note'].includes(selectedFilter) && countsPerType[selectedFilter] > 1
+        'pt-3': ['appointment', 'eForm', 'note'].includes(selectedFilter) && countsPerType[selectedFilter]
       }"
     >
       <AcademicTimelineTable

--- a/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-expand-transition v-if="countPerActiveTab > 1">
+    <v-expand-transition>
       <div v-if="isExpandAllAvailable" class="align-center d-flex flex-wrap font-size-14">
         <h3 class="sr-only">Quick Links</h3>
         <div class="pb-2 pl-2 toggle-expand-all-container">


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6207

On the appts tab, I was deliberately hiding quick-links and search when appointment count == 1.  Makes sense, I suppose, but consistency is more important.  Now we show when count > 0.