### PR TITLE
BOAC-6213, notes-related: std_commit after exec INSERT statement

### DIFF
--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -781,7 +781,9 @@ def _create_notes(
         ]
 
         results_of_chunk_query = {}
-        for row in db.session.execute(text(sql), {'json_dumps': json.dumps(data)}).mappings():
+        results = db.session.execute(text(sql), {'json_dumps': json.dumps(data)})
+        std_commit()
+        for row in results.mappings():
             sid = row['sid']
             results_of_chunk_query[sid] = row['id']
         # Yes, the note author has read the note.
@@ -798,6 +800,7 @@ def _create_notes(
             } for note_id in results_of_chunk_query.values()
         ]
         db.session.execute(text(sql), {'json_dumps': json.dumps(notes_read_data)})
+        std_commit()
         ids_by_sid.update(results_of_chunk_query)
     return ids_by_sid
 
@@ -820,6 +823,7 @@ def _add_topics_to_notes(author_uid, note_ids, topics):
                 } for note_id in note_ids_subset
             ]
             db.session.execute(text(sql), {'json_dumps': json.dumps(data)})
+            std_commit()
 
 
 def _add_attachments_and_template_attachments(attachments, author_uid, note_ids, template_attachment_ids):
@@ -863,6 +867,7 @@ def _add_attachments(author_uid, note_ids, s3_path, now=None):
             } for note_id in note_ids_subset
         ]
         db.session.execute(text(sql), {'json_dumps': json.dumps(data)})
+        std_commit()
 
 
 def _get_total_count_peer_advising_notes(peer_advising_department_id):

--- a/boac/models/note_read.py
+++ b/boac/models/note_read.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from datetime import datetime
 
-from boac import db
+from boac import db, std_commit
 from sqlalchemy import text
 
 
@@ -57,6 +57,7 @@ class NoteRead(db.Model):
             'note_id': note_id,
             'viewer_id': viewer_id,
         })
+        std_commit()
         return cls.query.filter(cls.viewer_id == viewer_id, cls.note_id == note_id).first()
 
     @classmethod


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6213

With SQLAlchemy, we must `commit` after `execute`.