### PR TITLE
[QA Revert] BOAC-6221, revert the tweak to SQLAlchemy usage in note search

### DIFF
--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -550,12 +550,10 @@ class Note(Base):
                     ORDER BY notes.updated_at DESC, fts.rank DESC
                     OFFSET {offset} LIMIT {limit}
                 """
-            return db.session.execute(text(sql), params)
-
-        search_results = _fetch_result()
+            return db.session.execute(text(sql), params).mappings()
         return {
-            'results': [dict(zip(search_results.keys(), row)) for row in search_results.fetchall()],
-            'total_matching_count': _fetch_result(True).mappings().first()['count'],
+            'results': [row for row in _fetch_result().all()],
+            'total_matching_count': _fetch_result(True).first()['count'],
         }
 
     @classmethod


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6221

Reverts PR #5098
