### PR TITLE
BOAC-6230, remove 'Download CSV' option from AcademicTimeline eForms tab

### DIFF
--- a/bea/pages/student_page_e_form.py
+++ b/bea/pages/student_page_e_form.py
@@ -22,14 +22,10 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
 """
-import csv
-from io import TextIOWrapper
 import re
-import zipfile
 
 from bea.pages.create_note_modal import CreateNoteModal
 from bea.pages.student_page_timeline import StudentPageTimeline
-from bea.test_utils import utils
 from flask import current_app as app
 from selenium.webdriver.common.by import By
 
@@ -41,7 +37,6 @@ class StudentPageEForm(StudentPageTimeline, CreateNoteModal):
     E_FORMS_BUTTON = (By.ID, 'timeline-tab-eForm')
     SHOW_HIDE_E_FORMS_BUTTON = (By.ID, 'toggle-expand-all-eForms')
     E_FORM_MSG_ROW = By.XPATH, '//tr[contains(@id, "permalink-eForm-")]'
-    E_FORMS_DOWNLOAD_LINK = (By.ID, 'download-notes-link')
 
     def show_e_forms(self):
         app.logger.info('Checking eForms tab')
@@ -100,53 +95,3 @@ class StudentPageEForm(StudentPageTimeline, CreateNoteModal):
 
     def expanded_e_form_term(self, e_form):
         return self.el_text_if_exists(self.e_form_data_loc(e_form, 'Term'))
-
-    # Downloads
-
-    def e_forms_export_zip_file_name(self, student):
-        return self.export_zip_file_name(student, 'eForms')
-
-    def e_forms_export_csv_file_name(self, student):
-        return self.export_csv_file_name(student, 'eForms')
-
-    def download_e_forms(self, student):
-        app.logger.info(f'Downloading eForms for UID {student.uid}')
-        self.download_file(self.E_FORMS_DOWNLOAD_LINK, self.e_forms_export_zip_file_name(student))
-
-    def e_form_export_file_names(self, student):
-        return self.downloaded_zip_file_name_list(self.e_forms_export_zip_file_name(student))
-
-    def expected_e_form_export_file_names(self, student):
-        return [self.e_forms_export_csv_file_name(student)]
-
-    def verify_e_form_in_export_csv(self, student, e_form):
-        file_path = f'{utils.default_download_dir()}/{self.e_forms_export_zip_file_name(student)}'
-        with zipfile.ZipFile(file_path, 'r') as zip_file:
-            with zip_file.open(self.e_forms_export_csv_file_name(student)) as csv_file:
-                csv_reader = csv.DictReader(TextIOWrapper(csv_file))
-                rows = list(csv_reader)
-                for row in rows:
-                    try:
-                        assert row['created_date'] == e_form.created_date.strftime('%Y-%m-%d')
-                        assert row['student_sid'] == int(student.sid)
-                        assert row['student_name'] == student.full_name
-                        assert row['eform_id'] == e_form.form_id
-                        if e_form.action:
-                            assert row['late_change_request_action'] == e_form.action
-                        if e_form.grading_basis:
-                            assert row['grading_basis'] == e_form.grading_basis
-                        if e_form.requested_grading_basis:
-                            assert row['requested_grading_basis'] == e_form.requested_grading_basis
-                        if e_form.units_taken:
-                            assert row['units_taken'] == e_form.units_taken
-                        if e_form.requested_units_taken:
-                            assert row['requested_units_taken'] == e_form.requested_units_taken
-                        if e_form.status:
-                            assert row['late_change_request_status'] == e_form.status
-                        if e_form.term:
-                            assert row['late_change_request_term'] == e_form.term
-                        assert row['late_change_request_course'] == e_form.course
-                        return True
-                    except AssertionError:
-                        if row == rows[-1]:
-                            return False

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -32,7 +32,7 @@ from os import path
 import re
 
 from boac.externals import data_loch, s3
-from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME, is_peer_advisor_manager, term_name_for_sis_id
+from boac.lib.berkeley import BERKELEY_DEPT_CODE_TO_NAME, is_peer_advisor_manager
 from boac.lib.sis_advising import (
     get_legacy_attachment_stream,
     get_sis_advising_attachments,
@@ -462,7 +462,6 @@ def get_zip_stream(
         student,
 ):
     app_timezone = pytz.timezone(app.config['TIMEZONE'])
-    is_eforms_download = download_type == 'eForm'
     notes = _filter_notes(download_type, notes)
 
     def iter_csv():
@@ -472,38 +471,19 @@ def get_zip_stream(
             return csv_output.getvalue().encode('utf-8')
             csv_output.close()
 
-        if is_eforms_download:
-            csv_headers = [
-                'student_sid',
-                'student_name',
-                'eform_id',
-                'eform_type',
-                'requested_action',
-                'grading_basis',
-                'requested_grading_basis',
-                'units_taken',
-                'requested_units_taken',
-                'late_change_request_action',
-                'late_change_request_status',
-                'late_change_request_term',
-                'late_change_request_course',
-                'date_created',
-                'updated_at',
-            ]
-        else:
-            csv_headers = [
-                'date_created',
-                'student_sid',
-                'student_name',
-                'author_uid',
-                'author_csid',
-                'author_name',
-                'subject',
-                'body',
-                'topics',
-                'attachments',
-                'is_private',
-            ]
+        csv_headers = [
+            'date_created',
+            'student_sid',
+            'student_name',
+            'author_uid',
+            'author_csid',
+            'author_name',
+            'subject',
+            'body',
+            'topics',
+            'attachments',
+            'is_private',
+        ]
 
         yield csv_line(csv_headers)
 
@@ -513,49 +493,27 @@ def get_zip_stream(
             datetime_created = pytz.utc.localize(datetime.strptime(timestamp_created, '%Y-%m-%dT%H:%M:%S'))
             localized_created_at = datetime_created.astimezone(app_timezone).strftime('%Y-%m-%d')
 
-            if is_eforms_download:
-                e_form = note.get('eForm')
-                section_id = e_form.get('sectionId')
-                course = f"{e_form['sectionId']} {e_form['courseName']} - {e_form['courseTitle']} {e_form['section']}" if section_id else None
-                column_data = [
-                    student['sid'],
-                    join_if_present(' ', [student.get('first_name', ''), student.get('last_name', '')]),
-                    e_form.get('id'),
-                    e_form.get('type'),
-                    e_form.get('requestedAction'),
-                    e_form.get('gradingBasis'),
-                    e_form.get('requestedGradingBasis'),
-                    e_form.get('unitsTaken'),
-                    e_form.get('requestedUnitsTaken'),
-                    e_form.get('action'),
-                    e_form.get('status'),
-                    term_name_for_sis_id(e_form.get('term')),
-                    course,
-                    localized_created_at,
-                    e_form.get('updatedAt'),
-                ]
-            else:
-                author_sids = [n['author']['sid'] for n in notes if n['author']['sid'] and not n['author']['name']]
-                author_sids = list(set(author_sids))
-                supplemental_calnet_advisor_feeds = get_calnet_users_for_csids(app, author_sids)
-                author = supplemental_calnet_advisor_feeds.get(note['author']['sid']) or {}
-                author_name = author.get('name') or join_if_present(' ', [author.get('firstName'), author.get('lastName')])
-                author_uid = author.get('uid')
+            author_sids = [n['author']['sid'] for n in notes if n['author']['sid'] and not n['author']['name']]
+            author_sids = list(set(author_sids))
+            supplemental_calnet_advisor_feeds = get_calnet_users_for_csids(app, author_sids)
+            author = supplemental_calnet_advisor_feeds.get(note['author']['sid']) or {}
+            author_name = author.get('name') or join_if_present(' ', [author.get('firstName'), author.get('lastName')])
+            author_uid = author.get('uid')
 
-                omit_note_body = note.get('isPrivate') and not current_user.can_access_private_notes
-                column_data = [
-                    localized_created_at,
-                    student['sid'],
-                    join_if_present(' ', [student.get('first_name', ''), student.get('last_name', '')]),
-                    (note['author']['uid'] or author_uid),
-                    note['author']['sid'],
-                    (note['author']['name'] or author_name),
-                    note['subject'],
-                    '' if omit_note_body else note['body'],
-                    '; '.join([t for t in note['topics'] or []]),
-                    '' if omit_note_body else '; '.join([a['displayName'] for a in note['attachments'] or []]),
-                    note.get('isPrivate'),
-                ]
+            omit_note_body = note.get('isPrivate') and not current_user.can_access_private_notes
+            column_data = [
+                localized_created_at,
+                student['sid'],
+                join_if_present(' ', [student.get('first_name', ''), student.get('last_name', '')]),
+                (note['author']['uid'] or author_uid),
+                note['author']['sid'],
+                (note['author']['name'] or author_name),
+                note['subject'],
+                '' if omit_note_body else note['body'],
+                '; '.join([t for t in note['topics'] or []]),
+                '' if omit_note_body else '; '.join([a['displayName'] for a in note['attachments'] or []]),
+                note.get('isPrivate'),
+            ]
             yield csv_line(column_data)
 
     z = zipstream.ZipFile(mode='w', compression=zipstream.ZIP_DEFLATED)

--- a/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
@@ -550,7 +550,7 @@ const showDownloadNotesLink = computed(() => {
     const notes = messagesPerType('note')
     return find(notes, n => !n.isDraft)
   }
-  return ['eForm', 'note'].includes(props.selectedFilter)
+  return props.selectedFilter === 'note'
     && (currentUser.isAdmin || isDirector(currentUser))
     && hasNonDrafts()
 })
@@ -934,7 +934,7 @@ table {
 .column-pill {
   vertical-align: top;
   white-space: nowrap;
-  width: 7.5rem;
+  width: 8.0rem;
 }
 .expanded-timeline-container {
   position: absolute;

--- a/tests/test_merged/test_advising_note.py
+++ b/tests/test_merged/test_advising_note.py
@@ -565,50 +565,39 @@ class TestMergedAdvisingNote:
 
     def test_stream_zipped_bundle(self, app):
         with mock_sis_note_attachment(app):
-            for download_type in ('eForm', 'note'):
-                sid = '9000000000'
-                filename = 'advising_notes'
-                stream = get_zip_stream(
-                    download_type=download_type,
-                    filename=filename,
-                    notes=get_advising_notes(sid),
-                    student={
-                        'first_name': 'Wolfgang',
-                        'last_name': 'Pauli-O\'Rourke',
-                        'sid': sid,
-                    },
-                )
-                body = b''
-                for chunk in stream:
-                    body += chunk
-                zipfile = ZipFile(io.BytesIO(body), 'r')
-                contents = {}
-                for name in zipfile.namelist():
-                    contents[name] = zipfile.read(name)
+            sid = '9000000000'
+            filename = 'advising_notes'
+            stream = get_zip_stream(
+                download_type='note',
+                filename=filename,
+                notes=get_advising_notes(sid),
+                student={
+                    'first_name': 'Wolfgang',
+                    'last_name': 'Pauli-O\'Rourke',
+                    'sid': sid,
+                },
+            )
+            body = b''
+            for chunk in stream:
+                body += chunk
+            zipfile = ZipFile(io.BytesIO(body), 'r')
+            contents = {}
+            for name in zipfile.namelist():
+                contents[name] = zipfile.read(name)
 
-                csv_rows = contents[f'{filename}.csv'].decode('utf-8').strip().split('\r\n')
-                if download_type == 'note':
-                    assert len(contents) == 2
-                    assert len(csv_rows) == 3
-                    assert contents['dog_eaten_homework.pdf'] == b'When in the course of human events, it becomes necessarf arf woof woof woof'
-                    assert csv_rows[0] == """
-                        date_created,student_sid,student_name,author_uid,author_csid,author_name,subject,body,topics,attachments,is_private
-                    """.strip()
-                    assert csv_rows[1] == """
-                        2017-11-02,9000000000,Wolfgang Pauli-O'Rourke,,700600500,,,I am confounded by this confounding student,,dog_eaten_homework.pdf,False
-                    """.strip()  # noqa: E501
-                    assert csv_rows[2] == """
-                        2017-11-02,9000000000,Wolfgang Pauli-O'Rourke,,600500400,,,Is this student even on campus?,Ne Scéaw,,False
-                    """.strip()
-                else:
-                    assert len(contents) == 1
-                    assert len(csv_rows) == 2
-                    assert csv_rows[0] == """
-                        student_sid,student_name,eform_id,eform_type,requested_action,grading_basis,requested_grading_basis,units_taken,requested_units_taken,late_change_request_action,late_change_request_status,late_change_request_term,late_change_request_course,date_created,updated_at
-                    """.strip()
-                    assert csv_rows[1] == """
-                        9000000000,Wolfgang Pauli-O'Rourke,469118,SRLATEDROP,Late Grading Basis Change,Elective Pass/No Pass,Graded,3,0.00,Late Grading Basis Change,In Error,Fall 2020,24460 PSYCH 110 - INTROD BIOL PSYCH 001,2020-12-05,2020-12-04
-                    """.strip()  # noqa: E501
+            csv_rows = contents[f'{filename}.csv'].decode('utf-8').strip().split('\r\n')
+            assert len(contents) == 2
+            assert len(csv_rows) == 3
+            assert contents['dog_eaten_homework.pdf'] == b'When in the course of human events, it becomes necessarf arf woof woof woof'
+            assert csv_rows[0] == """
+                date_created,student_sid,student_name,author_uid,author_csid,author_name,subject,body,topics,attachments,is_private
+            """.strip()
+            assert csv_rows[1] == """
+                2017-11-02,9000000000,Wolfgang Pauli-O'Rourke,,700600500,,,I am confounded by this confounding student,,dog_eaten_homework.pdf,False
+            """.strip()
+            assert csv_rows[2] == """
+                2017-11-02,9000000000,Wolfgang Pauli-O'Rourke,,600500400,,,Is this student even on campus?,Ne Scéaw,,False
+            """.strip()
 
 
 def _create_coe_advisor_note(


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6230

Notes:
* Flint's decision on eForms CSV: https://jira-secure.berkeley.edu/browse/BOAC-6232
* Review with `?w-1` for simpler diff.
* @pfarestveit - I removed BEA code related to eForms CSV download.