### PR TITLE
BOAC-6254, Calendly: do not show rescheduled appts

### DIFF
--- a/boac/externals/data_loch.py
+++ b/boac/externals/data_loch.py
@@ -561,6 +561,7 @@ def get_asc_advising_note_topics(sid):
 
 
 def get_calendly_advising_appointments(sid):
+    # NOTE: We are excluding 'rescheduled' appointments per BOAC-6254. Essentially, they are canceled meetings.
     sql = f"""
         SELECT
             id, 'Calendly' AS appointment_type,
@@ -570,7 +571,7 @@ def get_calendly_advising_appointments(sid):
             meeting_notes_plain, questions_and_answers, start_time AS starts_at, student_sid, student_uid, title,
             updated_at
         FROM {advising_appointments_schema()}.calendly_advising_appointments
-        WHERE student_sid=%(sid)s
+        WHERE student_sid=%(sid)s AND is_rescheduled IS FALSE
         ORDER BY start_time DESC
         """
     return safe_execute_rds(sql, sid=sid)

--- a/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
@@ -873,6 +873,15 @@ const refreshSearchIndex = () => {
         e.term
       ])
     }
+    if (m.type === 'appointment') {
+      idx = idx.concat([
+        m.cancelReason,
+        m.status
+      ])
+    }
+    if (m.createdBy === 'Calendly') {
+      idx = idx.concat([m.appointmentTitle])
+    }
     searchIndex.value.push({idx: normalizeForSearchIndex(idx.join()), message: m})
   })
 }


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6254

And, add some appointment specific properties to front-end search index (Academic Timeline).