### PR TITLE
BOAC-6262, /student: PAM can only delete PA notes (edit-note will be v6.5)

### DIFF
--- a/src/components/note/AdvisingNote.vue
+++ b/src/components/note/AdvisingNote.vue
@@ -168,7 +168,7 @@ const currentUser = contextStore.currentUser
 const deleteAttachmentIndex = ref(undefined)
 const isAuthorDetailsLoaded = ref(false)
 const isUpdatingAttachments = ref(false)
-const peerAdvisingDepartment = computed(() =>props.note.peerAdvisingDepartmentId ? findPeerAdvisingDepartment(props.note.peerAdvisingDepartmentId) : undefined)
+const peerAdvisingDepartment = computed(() => props.note.peerAdvisingDepartmentId ? findPeerAdvisingDepartment(props.note.peerAdvisingDepartmentId) : undefined)
 const showConfirmDeleteAttachment = ref(false)
 
 watch(() => props.isOpen, () => {

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -1,16 +1,13 @@
-import {each, filter, get, isEmpty, map, size, trim} from 'lodash'
+import {each, filter, get, isEmpty, size, trim} from 'lodash'
 import type {
   AcademicTimelineMessage,
   Attachment,
   BoaConfig,
   BoaUser,
-  DepartmentMembership,
   EForm,
   Note,
   NoteTemplate,
 } from '@/lib/types'
-import {getPeerAdvisorDepartmentMemberships} from '@/lib/berkeley-department'
-import {isPeerAdvisorManager} from '@/lib/boa-user'
 import {oxfordJoin, stripHtmlAndTrim} from '@/lib/utils'
 import {useContextStore} from '@/stores/context'
 import {useNoteStore} from '@/stores/note-edit-session'
@@ -33,10 +30,11 @@ export function canUserEditNote(note: Note, user: BoaUser): boolean {
   let canEdit: boolean = false
   if (user.uid === note.author.uid && (!note.isPrivate || user.canAccessPrivateNotes)) {
     canEdit = true
-  } else if (isPeerAdvisorManager(user) && note.peerAdvisingDepartmentId) {
-    // Peer Advisor Managers can edit notes created by Peer Advisors within same Peer Advising department.
-    const memberships: DepartmentMembership[] = getPeerAdvisorDepartmentMemberships(user, 'peer_advisor_manager')
-    canEdit = map(memberships, 'peerAdvisingDepartmentId').includes(note.peerAdvisingDepartmentId)
+  // TODO: Give Peer Advisor Managers the power to edit their own notes.
+  // } else if (isPeerAdvisorManager(user) && note.peerAdvisingDepartmentId) {
+  //   // Peer Advisor Managers can edit notes created by Peer Advisors within same Peer Advising department.
+  //   const memberships: DepartmentMembership[] = getPeerAdvisorDepartmentMemberships(user, 'peer_advisor_manager')
+  //   canEdit = map(memberships, 'peerAdvisingDepartmentId').includes(note.peerAdvisingDepartmentId)
   }
   return canEdit
 }


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6262

Let's role out the "PAMs can edit PA notes" feature when it's road tested and working on both `/student` page and PAM dashboard.