### PR TITLE
BOAC-6276, /degree_progress: sort courses and courseReqts by name

### DIFF
--- a/boac/models/degree_progress_category.py
+++ b/boac/models/degree_progress_category.py
@@ -217,10 +217,17 @@ class DegreeProgressCategory(Base):
             else:
                 hierarchy.append(category)
 
-        # Order by ux_position_y, descending.
-        hierarchy = sorted(hierarchy, key=lambda c: c['uxPositionY'], reverse=True)
+        def _sort(_categories):
+            # Order by ux_position_y, descending.
+            _categories = sorted(_categories, key=lambda c: c['uxPositionY'], reverse=True)
+            for _category in _categories:
+                # Order courses and course_requirements by name, ascending.
+                _category['courses'] = sorted(_category['courses'], key=lambda c: (c['name'], c['createdAt']))
+                _category['courseRequirements'] = sorted(_category['courseRequirements'], key=lambda c: (c['name'], c['createdAt']))
+            return _categories
+        hierarchy = _sort(hierarchy)
         for category in hierarchy:
-            category['subcategories'] = sorted(category['subcategories'], key=lambda s: s['uxPositionY'], reverse=True)
+            category['subcategories'] = _sort(category['subcategories'])
         return hierarchy
 
     @classmethod

--- a/tests/test_api/test_degree_progress_category_controller.py
+++ b/tests/test_api/test_degree_progress_category_controller.py
@@ -701,19 +701,36 @@ class TestSatisfyCampusRequirement:
         api_json = _api_get_template(client=client, template_id=mock_template.id)
         category = api_json['categories'][0]
         assert category['id'] == parent_category['id']
-        assert category['courseRequirements'][0]['id'] == requirement_id
-        assert category['courseRequirements'][0]['categoryType'] == 'Campus Requirement, Satisfied'
+        matching_course_requirement = next((r for r in category['courseRequirements'] if r['id'] == requirement_id), None)
+        assert matching_course_requirement
+        assert matching_course_requirement['categoryType'] == 'Campus Requirement, Satisfied'
 
         self._api_toggle_satisfied(
             category_id=requirements[0].id,
             client=client,
             is_satisfied=False,
         )
+        # Next, fetch updated degree-template.
         api_json = _api_get_template(client=client, template_id=mock_template.id)
         category = api_json['categories'][0]
         assert category['id'] == parent_category['id']
-        assert category['courseRequirements'][0]['id'] == requirement_id
-        assert category['courseRequirements'][0]['categoryType'] == 'Campus Requirement, Unsatisfied'
+        # Verify that value was toggled.
+        matching_course_requirement = next((r for r in category['courseRequirements'] if r['id'] == requirement_id), None)
+        assert matching_course_requirement
+        assert matching_course_requirement['categoryType'] == 'Campus Requirement, Unsatisfied'
+
+        def _verify_sorted_by_name(_courses):
+            previous_name = None
+            for _course in _courses:
+                if previous_name:
+                    assert _course['name'] > previous_name
+                previous_name = _course['name']
+        for _category in api_json['categories']:
+            _verify_sorted_by_name(_category['courses'])
+            _verify_sorted_by_name(_category['courseRequirements'])
+            for _subcategory in _category['subcategories']:
+                _verify_sorted_by_name(_subcategory['courses'])
+                _verify_sorted_by_name(_subcategory['courseRequirements'])
 
 
 def _api_create_category(


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6276

Both categories and subcategories come with `courses` and `courseRequirements`. We want `courses` and `courseRequirements` to be sorted by name in the UI.