### PR TITLE
BOAC-6284, /peer_advisor/home page: Allow PA to edit their own notes

### DIFF
--- a/boac/api/peer_advising_notes_controller.py
+++ b/boac/api/peer_advising_notes_controller.py
@@ -249,7 +249,7 @@ def update_peer_advising_note():
     subject = (params.get('subject', None) or '').strip()
     topics = get_note_topics_from_http_post()
     note_template_id = params.get('noteTemplateId', None)
-    if not subject or (not body and not len(topics)):
+    if not (subject or body or len(topics)):
         raise BadRequestError('Request has missing or invalid request parameters')
     # Fetch existing note
     note = Note.find_by_id(note_id=note_id) if note_id else None

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -474,21 +474,23 @@ def get_boa_attachment_stream(attachment):
 
 
 def get_note_author_summary(note):
+    def _get(key, fallback_key):
+        return note.get(key) or note.get(fallback_key)
     departments = []
-    dept_codes = note.get('dept_code') if 'dept_code' in note else note.get('author_dept_codes') or []
+    dept_codes = _get('dept_code', 'deptCode') or _get('author_dept_codes', 'authorDeptCodes') or []
     for dept_code in dept_codes:
         departments.append({
             'deptCode': dept_code,
             'deptName': BERKELEY_DEPT_CODE_TO_NAME.get(dept_code, dept_code),
         })
     return {
-        'id': note.get('author_id'),
-        'uid': note.get('author_uid'),
-        'sid': note.get('advisor_sid'),
-        'name': note.get('author_name'),
-        'role': note.get('author_role'),
+        'id': _get('author_id', 'authorId'),
+        'uid': _get('author_uid', 'authorUid'),
+        'sid': _get('advisor_sid', 'advisorSid'),
+        'name': _get('author_name', 'authorName'),
+        'role': _get('author_role', 'authorRole'),
         'departments': departments,
-        'email': note.get('advisor_email'),
+        'email': _get('advisor_email', 'advisorEmail'),
     }
 
 

--- a/src/components/note/EditAdvisingNote.vue
+++ b/src/components/note/EditAdvisingNote.vue
@@ -5,7 +5,7 @@
     :class="wrapperClass"
     @submit.prevent="save"
   >
-    <div v-if="noteStore.model.isDraft" class="font-size-18 text-error pa-2">
+    <div v-if="model.isDraft" class="font-size-18 text-error pa-2">
       <v-icon :icon="mdiAlert" />
       <span class="edit-draft-text">
         You are editing a draft note.
@@ -22,7 +22,7 @@
         </span>
       </transition>
     </div>
-    <div v-if="!isPeerAdvisor(currentUser) && !noteStore.model.peerAdvisingDepartmentId" class="mt-1">
+    <div v-if="!isPeerAdvisor(currentUser) && !model.peerAdvisingDepartmentId" class="mt-1">
       <label id="edit-note-subject-label" class="font-weight-bold" for="edit-note-subject">Subject</label>
       <v-text-field
         id="edit-note-subject"
@@ -30,12 +30,12 @@
         bg-color="white"
         class="mt-1"
         density="comfortable"
-        :disabled="isSaving || boaSessionExpired || (noteStore.model.peerAdvisingDepartmentId && !noteStore.model.subject)"
+        :disabled="isSaving || boaSessionExpired || (model.peerAdvisingDepartmentId && !model.subject)"
         hide-details
         maxlength="255"
-        :model-value="noteStore.model.subject"
+        :model-value="model.subject"
         required
-        :rules="[value => (!!trim(value) || noteStore.model.isDraft) || !!noteStore.model.peerAdvisingDepartmentId || 'Subject is required']"
+        :rules="[value => (!!trim(value) || model.isDraft) || !!model.peerAdvisingDepartmentId || 'Subject is required']"
         size="255"
         validate-on="submit"
         @input="onInput"
@@ -45,7 +45,7 @@
     <div id="edit-note-details" class="bg-transparent mt-3">
       <RichTextEditor
         :disabled="isSaving || boaSessionExpired"
-        :initial-value="noteStore.model.body || ''"
+        :initial-value="model.body || ''"
         label="Note Details"
         :on-value-update="noteStore.setBody"
         :show-advising-note-best-practices="true"
@@ -56,28 +56,28 @@
       :topics="topics"
     />
     <PrivacyPermissions
-      v-if="currentUser.canAccessPrivateNotes && !noteStore.model.peerAdvisingDepartmentId"
+      v-if="currentUser.canAccessPrivateNotes && !model.peerAdvisingDepartmentId"
       class="mt-2"
       :disabled="isSaving || boaSessionExpired"
     />
     <ContactMethod
       class="mt-3"
       :disabled="isSaving || boaSessionExpired"
-      :is-peer-advising="!!noteStore.model.peerAdvisingDepartmentId"
+      :is-peer-advising="!!model.peerAdvisingDepartmentId"
     />
     <ManuallySetDate
-      v-if="!noteStore.model.peerAdvisingDepartmentId"
+      v-if="!model.peerAdvisingDepartmentId"
       class="mt-3"
       :container-id="`note-${noteId}-edit-form`"
     />
     <AdvisingNoteAttachments
-      v-if="size(noteStore.model.attachments) && !noteStore.model.peerAdvisingDepartmentId"
-      :attachments="noteStore.model.attachments"
+      v-if="size(model.attachments)"
+      :attachments="model.attachments"
       class="mt-3"
       :disabled="isSaving || boaSessionExpired"
       id-prefix="edit-note"
       :is-read-only="true"
-      :note="noteStore.model"
+      :note="model"
     />
     <div>
       <div
@@ -93,13 +93,13 @@
         <ProgressButton
           id="save-note-button"
           :action="() => save(false)"
-          :aria-label="noteStore.model.isDraft ? 'Publish Note' : 'Save Note'"
-          :disabled="!noteStore.recipients.sids.length || isSaving || boaSessionExpired || (noteStore.model.peerAdvisingDepartmentId ? !stripHtmlAndTrim(noteStore.model.body) : !trim(noteStore.model.subject))"
+          :aria-label="model.isDraft ? 'Publish Note' : 'Save Note'"
+          :disabled="!noteStore.recipients.sids.length || isSaving || boaSessionExpired || (model.peerAdvisingDepartmentId ? (!stripHtmlAndTrim(model.body) && !model.topics.length) : !trim(model.subject))"
           :in-progress="isPublishingNote"
-          :text="noteStore.model.isDraft ? 'Publish Note' : 'Save'"
+          :text="model.isDraft ? 'Publish Note' : 'Save'"
         />
         <ProgressButton
-          v-if="noteStore.model.isDraft"
+          v-if="model.isDraft"
           id="update-draft-note-button"
           :action="() => save(true)"
           class="ml-2"
@@ -110,7 +110,7 @@
         />
         <v-btn
           id="cancel-edit-note-button"
-          :aria-label="`Cancel Edit ${noteStore.model.isDraft ? 'Draft' : ' Note'}`"
+          :aria-label="`Cancel Edit ${model.isDraft ? 'Draft' : ' Note'}`"
           class="ml-2"
           color="primary"
           :disabled="isSaving || boaSessionExpired"
@@ -194,7 +194,7 @@ const isSavingDraft = ref(false)
 const showAreYouSureModal = ref(false)
 const suppressAutoSaveDraftNoteAlert = ref(false)
 const topics = ref([])
-const {boaSessionExpired, isSaving, mode} = storeToRefs(noteStore)
+const {boaSessionExpired, isSaving, mode, model} = storeToRefs(noteStore)
 
 watch(() => noteStore.isAutoSavingDraftNote, value => value && setTimeout(() => suppressAutoSaveDraftNoteAlert.value = !suppressAutoSaveDraftNoteAlert.value, 5000))
 
@@ -230,8 +230,8 @@ onBeforeMount(() => {
 
 const cancelRequested = () => {
   getNote(props.noteId).then(note => {
-    const isPristine = trim(noteStore.model.subject) === note.subject
-      && stripHtmlAndTrim(noteStore.model.body) === stripHtmlAndTrim(note.body)
+    const isPristine = trim(model.value.subject) === note.subject
+      && stripHtmlAndTrim(model.value.body) === stripHtmlAndTrim(note.body)
     if (isPristine) {
       cancelConfirmed()
     } else {
@@ -269,20 +269,20 @@ const save = isDraft => {
     }
     validate().then(({valid}) => {
       if (valid) {
-        const trimmedSubject = trim(noteStore.model.subject)
+        const trimmedSubject = trim(model.value.subject)
         updateNote(
-          noteStore.model.id,
-          trim(noteStore.model.body),
+          model.value.id,
+          trim(model.value.body),
           [],
-          noteStore.model.contactType,
+          model.value.contactType,
           [],
           isDraft,
-          noteStore.model.isPrivate,
-          noteStore.model.setDate,
+          model.value.isPrivate,
+          model.value.setDate,
           noteStore.recipients.sids,
           trimmedSubject,
           [],
-          noteStore.model.topics
+          model.value.topics
         ).then(updatedNote => {
           props.afterSaved(updatedNote)
           isSavingDraft.value = false

--- a/src/components/peer/note/PeerAdvisingNotesTable.vue
+++ b/src/components/peer/note/PeerAdvisingNotesTable.vue
@@ -61,7 +61,7 @@
                 </span>
               </button>
             </div>
-            <div v-if="isExpanded(note)" :class="{'d-contents': !smAndDown}">
+            <div v-if="isExpanded(note)" :class="{'d-contents': !smAndDown && editingNoteId !== note.id}">
               <div class="grid-cell">
                 <v-btn
                   v-if="editingNoteId !== note.id"
@@ -89,7 +89,7 @@
                     :note="note"
                     :note-description="`Note ${getNotePosition(index)}`"
                   />
-                  <div v-if="note.id === editingNoteId" class="edit-advising-note-container">
+                  <div v-if="note.id === editingNoteId" :class="{'edit-advising-note-container': !smAndDown}">
                     <EditAdvisingNote
                       :after-cancel="afterNoteEditCancel"
                       :after-saved="afterEditAdvisingNote"
@@ -110,10 +110,8 @@
             }"
             class="td-created-date"
           >
-            <div class="grid-cell">
+            <div class="grid-cell pr-8">
               <div v-if="isExpanded(note) && editingNoteId !== note.id && canUserEditNote(note, currentUser)" class="pl-2">
-                <!--
-                TODO: Give Peer Advisors the power to edit their own notes.
                 <v-btn
                   :id="`edit-note-${note.id}-button`"
                   :aria-label="`Edit ${getNoteLabel(note, index)}`"
@@ -126,7 +124,6 @@
                   variant="text"
                   @click="() => editNote(note.id)"
                 />
-                -->
                 <v-btn
                   v-if="isPeerAdvisorManager(currentUser)"
                   :id="`delete-note-button-${note.id}`"
@@ -282,11 +279,10 @@ const deleteConfirmed = () => {
   }
 }
 
-// TODO: Give Peer Advisors the power to edit their own notes.
-// const editNote = (noteId: number) => {
-//   editingNoteId.value = noteId
-//   putFocusNextTick('edit-note-subject')
-// }
+const editNote = (noteId: number) => {
+  editingNoteId.value = noteId
+  putFocusNextTick('edit-note-subject')
+}
 
 const getNoteLabel = (note: Note, index: number) => {
   const attachments = note.attachments.length ? `, ${note.attachments.length} attachments` : ''
@@ -321,7 +317,7 @@ const toggleShowHide = (note: Note) => {
 <style scoped>
 @media (max-width: 959px) {
   .grid-cell {
-    padding-bottom: 0px !important;
+    padding-bottom: 0 !important;
   }
   .peer-advising-table-wrapper {
     min-width: 300px;
@@ -361,7 +357,8 @@ const toggleShowHide = (note: Note) => {
   display: contents;
 }
 .edit-advising-note-container {
-  margin-top: -25px;
+  margin-left: -34%;
+  margin-top: -50px;
   padding-right: 25px;
 }
 .has-attachment-icon {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6284
https://jira-secure.berkeley.edu/browse/BOAC-6283

The use of CSS 'display: contents' (for accessibility reasons) was making the edit-note form unreachable w/ click actions ([more info](https://medium.com/design-bootcamp/display-contents-broke-my-layout-then-fixed-my-thinking-73f438e732ea)). So, that style is disabled on the specific table cell during edit, and we use negative margin-left to have the edit form align w/ the existing page layout.