### PR TITLE
BOAC-6311, front-end user session init is better with Promise.resolve

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -3,11 +3,15 @@ import utils from '@/api/api-utils'
 import {initGoogleAnalytics} from '@/lib/ga'
 import {useContextStore} from '@/stores/context'
 
-export function devAuthLogIn(uid: string, password: string) {
-  const url: string = `${utils.apiBaseUrl()}/api/auth/dev_auth_login`
-  return axios.post(url, {uid, password}).then(response => {
-    useContextStore().setCurrentUser(response.data)
-    initGoogleAnalytics()
+export function devAuthLogIn(uid: string, password: string): Promise<void> {
+  return new Promise(resolve => {
+    const url: string = `${utils.apiBaseUrl()}/api/auth/dev_auth_login`
+    axios.post(url, {uid, password}).then(response => {
+      useContextStore().setCurrentUser(response.data).then(() => {
+        initGoogleAnalytics()
+        resolve()
+      })
+    })
   })
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,23 +46,24 @@ axios.get(`${apiBaseUrl}/api/config`).then(response => {
   const contextStore = useContextStore()
   contextStore.setConfig({...response.data, apiBaseUrl, isVueAppDebugMode})
   axios.get(`${apiBaseUrl}/api/profile/my`).then(response => {
-    contextStore.setCurrentUser(response.data)
-    initGoogleAnalytics()
-    // Async API calls, whenever possible.
-    getServiceAnnouncement().then(data => {
-      contextStore.setServiceAnnouncement(data)
-      const pingFrequency: number = contextStore.config.pingFrequency
-      if (pingFrequency) {
-        // Keep session-cookie alive during user inactivity.
-        setInterval(() => {
-          axios.get(`${apiBaseUrl}/api/user/session_keep_alive`).then(response => {
-            if (!response.data.isAuthenticated) {
-              contextStore.broadcast('user-session-expired')
-            }
-          })
-        }, pingFrequency)
-      }
-      app.use(router).mount('#app')
+    contextStore.setCurrentUser(response.data).then(() => {
+      initGoogleAnalytics()
+      // Async API calls, whenever possible.
+      getServiceAnnouncement().then(data => {
+        contextStore.setServiceAnnouncement(data)
+        const pingFrequency: number = contextStore.config.pingFrequency
+        if (pingFrequency) {
+          // Keep session-cookie alive during user inactivity.
+          setInterval(() => {
+            axios.get(`${apiBaseUrl}/api/user/session_keep_alive`).then(response => {
+              if (!response.data.isAuthenticated) {
+                contextStore.broadcast('user-session-expired')
+              }
+            })
+          }, pingFrequency)
+        }
+        app.use(router).mount('#app')
+      })
     })
   })
 })

--- a/src/stores/context.ts
+++ b/src/stores/context.ts
@@ -8,7 +8,6 @@ import {ANONYMOUS_USER, alertScreenReader} from '@/lib/utils'
 import type {
   BoaConfig,
   BoaUser,
-  Cohort,
   CuratedGroup,
   Department,
   NoteContactType,
@@ -16,6 +15,7 @@ import type {
   ScreenReaderAlert,
   ServiceAnnouncement,
 } from '@/lib/types'
+import type {Cohort} from '@/lib/types-cohorts'
 import {getDepartments} from '@/api/user'
 
 const $_getDefaultApplicationState = () => ({
@@ -23,8 +23,6 @@ const $_getDefaultApplicationState = () => ({
   stacktrace: undefined as string | undefined | null,
   status: 200
 })
-
-let HAS_LAZY_LOADED = false
 
 export const useContextStore = defineStore('context', {
   state: () => ({
@@ -124,26 +122,29 @@ export const useContextStore = defineStore('context', {
     setConfig(data: BoaConfig) {
       this.config = data
     },
-    setCurrentUser(currentUser: BoaUser) {
-      this.currentUser = currentUser
-      // Lazy-load departmental data (and more?) when user is first authenticated.
-      if (this.currentUser.isAuthenticated && !HAS_LAZY_LOADED) {
-        HAS_LAZY_LOADED = true
-        getDepartments().then(data => {
-          this.allBerkeleyDepartments = data
-          this.allPeerAdvisingDepartments = []
-          each(this.allBerkeleyDepartments, (d: Department) => {
-            each(d.peerAdvisingDepartments, (p: PeerAdvisingDepartment) => {
-              this.allPeerAdvisingDepartments.push({
-                ...p,
-                deptCode: d.deptCode,
-                deptName: d.deptName
+    setCurrentUser(currentUser: BoaUser): Promise<void> {
+      return new Promise<void>(resolve => {
+        this.currentUser = currentUser
+        if (this.currentUser.isAuthenticated) {
+          getDepartments().then(data => {
+            this.allBerkeleyDepartments = data
+            this.allPeerAdvisingDepartments = []
+            each(this.allBerkeleyDepartments, (d: Department) => {
+              each(d.peerAdvisingDepartments, (p: PeerAdvisingDepartment) => {
+                this.allPeerAdvisingDepartments.push({
+                  ...p,
+                  deptCode: d.deptCode,
+                  deptName: d.deptName
+                })
               })
             })
+            this.allPeerAdvisingDepartments = sortBy(this.allPeerAdvisingDepartments, 'name')
+            resolve()
           })
-          this.allPeerAdvisingDepartments = sortBy(this.allPeerAdvisingDepartments, 'name')
-        })
-      }
+        } else {
+          resolve()
+        }
+      })
     },
     setDemoMode(inDemoMode: boolean): void {
       this.currentUser.inDemoMode = inDemoMode

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -55,16 +55,12 @@ const cohorts = reactive(_filter(currentUser.myCohorts, ['domain', 'default']))
 const curatedGroups = reactive(_filter(currentUser.myCuratedGroups, ['domain', 'default']))
 
 onMounted(() => {
-  if (contextStore.currentUser.isStale) {
-    contextStore.loadingStart()
-    getUserProfile().then(data => {
-      contextStore.setCurrentUser(data)
-      contextStore.currentUser.isStale = true
-      contextStore.loadingComplete()
-    })
-  } else {
-    contextStore.currentUser.isStale = true
+  // The BOA homepage presents a summary of the user's cohorts and curated groups and must always be fresh.
+  // If, for example, a cohort was deleted in a separate browser tab then we want this browser tab to reflect
+  // that change. Therefore, we always refresh the user session object when user visits /home.
+  getUserProfile().then(data => {
+    contextStore.setCurrentUser(data).then()
     contextStore.loadingComplete()
-  }
+  })
 })
 </script>

--- a/src/views/PeerAdvisorSearch.vue
+++ b/src/views/PeerAdvisorSearch.vue
@@ -17,6 +17,7 @@
     </div>
     <div class="align-center d-flex justify-space-between">
       <ShowMyPeerAdvisingNotesToggle
+        v-if="showMyNotesOnly || notes.length"
         v-model="showMyNotesOnly"
         :is-fetching-notes="isFetchingNotes"
       />


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6311

When user first authenticates, we load all department metadata and that takes time. Without a `promise`, the UI is rendered before user session init is complete. Thus, a `promise` is made. 