### PR TITLE
BOAC-6328, no console error when confirm delete of peer-advising note attachment

### DIFF
--- a/src/components/peer/note/PeerAdvisingNoteDetails.vue
+++ b/src/components/peer/note/PeerAdvisingNoteDetails.vue
@@ -35,7 +35,7 @@
         :function-confirm="confirmedRemoveAttachment"
         modal-header="Delete Attachment"
       >
-        Are you sure you want to delete the <strong>'{{ note.attachments[deleteAttachmentIndex].displayName }}'</strong> attachment?
+        Are you sure you want to delete the <strong>'{{ get(note, `attachments[${deleteAttachmentIndex}].displayName`) }}'</strong> attachment?
       </AreYouSureModal>
     </div>
   </div>
@@ -44,7 +44,7 @@
 <script setup lang="ts">
 import type {PropType} from 'vue'
 import {ref} from 'vue'
-import {size} from 'lodash'
+import {get, size} from 'lodash'
 import type {Note, NoteAttachment} from '@/lib/types'
 import AdvisingNoteAttachments from '@/components/note/AdvisingNoteAttachments.vue'
 import AdvisingNoteTopics from '@/components/note/AdvisingNoteTopics.vue'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6328