### PR TITLE
BOAC-6447: removes aria-label from highcharts container

### DIFF
--- a/src/components/student/StudentAvatar.vue
+++ b/src/components/student/StudentAvatar.vue
@@ -13,11 +13,11 @@
     <PillCount
       v-if="alertCount"
       :id="`student-avatar-${student.uid}-alert-count`"
-      :aria-label="pluralize('alert', alertCount)"
       class="student-avatar-alert-count"
       color="warning"
     >
-      {{ alertCount }}
+      <span aria-hidden="true">{{ alertCount }}</span>
+      <span class="sr-only">{{ pluralize('alert', alertCount) }}</span>
       <v-tooltip
         :id="`student-avatar-${student.uid}-tooltip`"
         activator="parent"

--- a/src/components/util/PillCount.vue
+++ b/src/components/util/PillCount.vue
@@ -1,7 +1,6 @@
 <template>
   <v-chip
     :id="id"
-    :aria-label="ariaLabel"
     class="border-sm pill-count"
     :class="{'pill-color-override': outlined}"
     :color="color"
@@ -14,11 +13,6 @@
 
 <script setup>
 defineProps({
-  ariaLabel: {
-    default: undefined,
-    required: false,
-    type: String
-  },
   color: {
     default: 'surface-variant',
     required: false,

--- a/src/plugins/highcharts.ts
+++ b/src/plugins/highcharts.ts
@@ -27,6 +27,7 @@ export default ((el: Element) => {
 
     // prevent screen reader text from being announced as 'clickable' due to the attached mousedown handler
     el.setAttribute('role', 'presentation')
+    el.removeAttribute('aria-label')
 
     if (container) {
       // make keyboard navigation work with JAWS


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6447

Also removes `aria-label` from the alert count on the student avatar because it's invalid on non-interactive elements.