### PR TITLE
BOAC-6481: makes acad timeline tabs more accessible, responsive

### DIFF
--- a/src/components/note/AdvisingNoteAttachments.vue
+++ b/src/components/note/AdvisingNoteAttachments.vue
@@ -37,16 +37,15 @@
         </v-btn>
       </label>
       <v-file-input
-        v-if="!attachmentLimitReached"
         :id="inputId"
         ref="attachmentFileInput"
         :aria-busy="isAdding"
-        :aria-describedby="isAdding ? progressBarId : null"
+        :aria-describedby="isAdding ? progressBarId : `${idPrefix}-attachment-details`"
         :aria-label="`Select file for attachment; ${pluralize('file', attachments.length)} attached.`"
         class="border-sm choose-file-for-note-attachment rounded"
         :class="{'border-success': disabled, 'border-md border-error': !!attachmentError}"
         :clearable="false"
-        :disabled="isAdding || disabled"
+        :disabled="isAdding || disabled || attachmentLimitReached"
         flat
         hide-details
         :loading="isAdding ? 'primary' : false"
@@ -63,28 +62,31 @@
         </template>
       </v-file-input>
     </div>
-    <v-alert
-      v-if="attachmentError"
-      :id="`${idPrefix}-attachment-error`"
-      aria-live="polite"
-      class="font-size-14 w-100 mb-1 mt-2"
-      density="compact"
-      :icon="mdiAlert"
-      :text="attachmentError"
-      type="error"
-      variant="tonal"
-    />
-    <v-alert
-      v-if="attachmentLimitReached"
-      :id="`${idPrefix}-attachment-limit`"
-      aria-live="polite"
-      class="w-100 mt-2"
-      density="compact"
-      type="warning"
-      variant="tonal"
-    >
-      <v-alert-title class="font-size-16">A note can have no more than {{ contextStore.config.maxAttachmentsPerNote }} attachments.</v-alert-title>
-    </v-alert>
+    <div :id="`${idPrefix}-attachment-details`">
+      <v-alert
+        v-if="attachmentError"
+        :id="`${idPrefix}-attachment-error`"
+        aria-live="polite"
+        class="font-size-14 w-100 mb-1 mt-2"
+        density="compact"
+        :icon="mdiAlert"
+        role="none"
+        :text="attachmentError"
+        type="error"
+        variant="tonal"
+      />
+      <v-alert
+        v-if="attachmentLimitReached"
+        :id="`${idPrefix}-attachment-limit`"
+        class="w-100 mt-2"
+        density="compact"
+        role="none"
+        type="warning"
+        variant="tonal"
+      >
+        <v-alert-title class="font-size-16">A note can have no more than {{ contextStore.config.maxAttachmentsPerNote }} attachments.</v-alert-title>
+      </v-alert>
+    </div>
     <ul
       :id="`${idPrefix}-attachments-list`"
       :aria-labelledby="`${idPrefix}-attachments-list-label`"

--- a/src/components/student/profile/academic-timeline/AcademicTimeline.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimeline.vue
@@ -60,7 +60,7 @@ onMounted(() => {
   filterTypes.value = {
     alert: {name: 'Alert', tab: 'Alerts', tabWidth: 65},
     hold: {name: 'Hold', tab: 'Holds', tabWidth: 62},
-    requirement: {name: 'Requirement', tab: 'Reqs', tabWidth: 58}
+    requirement: {ariaLabel: 'requirements', name: 'Requirement', tab: 'Reqs', tabWidth: 58}
   }
   if (currentUser.canAccessAdvisingData) {
     filterTypes.value.eForm = {name: 'eForm', tab: 'eForms', tabWidth: 76}

--- a/src/components/student/profile/academic-timeline/AcademicTimelineHeader.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimelineHeader.vue
@@ -23,16 +23,45 @@
         />
       </div>
     </div>
+    <div v-if="$vuetify.display.width < mobileBreakpoint && !isAcademicTimelineEmpty" class="d-flex align-baseline">
+      <label for="timeline-tab-select" class="mr-2">Showing:</label>
+      <select
+        id="timeline-tab-select"
+        ref="timelineTabSelect"
+        autocomplete="off"
+        class="d-block mb-2 select-menu"
+        :model-value="selectedTab"
+        @change="onSelectTab"
+      >
+        <option
+          id="timeline-tab-all"
+          key="all"
+          :aria-label="`All ${pluralize('message', countsPerType['all'])}`"
+          value="all"
+        >
+          All ({{ countsPerType['all'] }})
+        </option>
+        <option
+          v-for="(tab) in tabs"
+          :id="`timeline-tab-${tab}`"
+          :key="tab"
+          :aria-label="`${filterTypes[tab].ariaLabel || filterTypes[tab].tab}, ${pluralize('message', countsPerType[tab])}`"
+          :selected="selectedTab === tab"
+          :value="tab"
+        >
+          {{ filterTypes[tab].tab }} ({{ countsPerType[tab] }})
+        </option>
+      </select>
+    </div>
     <v-tabs
-      v-if="!isAcademicTimelineEmpty"
+      v-if="$vuetify.display.width >= mobileBreakpoint && !isAcademicTimelineEmpty"
       v-model="selectedTab"
       class="timeline-tabs"
       aria-label="Academic Timeline"
-      :aria-orientation="$vuetify.display.mdAndUp ? 'horizontal' : 'vertical'"
-      :class="{'horizontal-tabs': $vuetify.display.mdAndUp}"
+      aria-orientation="horizontal"
       color="primary"
       density="compact"
-      :direction="$vuetify.display.mdAndUp ? 'horizontal' : 'vertical'"
+      direction="horizontal"
       selected-class="bg-sky-blue font-weight-bold"
       @update:model-value="onUpdateTabsModel"
     >
@@ -40,6 +69,7 @@
         v-if="tabs.length > 1"
         id="timeline-tab-all"
         aria-controls="timeline-messages"
+        :aria-label="`All ${pluralize('message', countsPerType['all'])}`"
         :class="{
           'bg-white border-b-0': selectedTab === 'all',
           'bg-grey-lighten-4 border-b-md': selectedTab !== 'all'
@@ -48,12 +78,13 @@
         value="all"
         variant="text"
       >
-        <span class="sr-only">Show </span>All <span class="letter-spacing-compact ml-1">({{ countsPerType['all'] }})</span>
+        All <span class="letter-spacing-compact ml-1">({{ countsPerType['all'] }})</span>
       </v-tab>
       <!-- eslint-disable-next-line vue/no-v-for-template-key -->
       <template v-for="(tab, index) in tabs" :key="tab">
         <v-tab
           :id="`timeline-tab-${tab}`"
+          :aria-label="`${filterTypes[tab].ariaLabel || filterTypes[tab].tab}, ${pluralize('message', countsPerType[tab])}`"
           class="border-s-sm border-e-sm border-t-sm pb-1 rounded-t-lg"
           :class="{
             'bg-white border-b-0': selectedTab === tab,
@@ -63,7 +94,7 @@
           :value="tab"
           variant="text"
         >
-          <span class="sr-only">Show </span>{{ filterTypes[tab].tab }} <span class="letter-spacing-compact ml-1">({{ countsPerType[tab] }})</span>
+          {{ filterTypes[tab].tab }} <span class="letter-spacing-compact ml-1">({{ countsPerType[tab] }})</span>
         </v-tab>
       </template>
     </v-tabs>
@@ -71,10 +102,10 @@
 </template>
 
 <script setup>
-import {filter as _filter, includes, keys} from 'lodash'
+import {filter as _filter, includes, keys, size} from 'lodash'
 import {mdiFileDocument} from '@mdi/js'
 import {computed, ref} from 'vue'
-import {putFocusNextTick} from '@/lib/utils'
+import {pluralize, putFocusNextTick} from '@/lib/utils'
 import EditBatchNoteModal from '@/components/note/EditBatchNoteModal'
 import {useContextStore} from '@/stores/context'
 import {useNoteStore} from '@/stores/note-edit-session'
@@ -109,22 +140,29 @@ const noteStore = useNoteStore()
 const currentUser = contextStore.currentUser
 const isAcademicTimelineEmpty = !props.countsPerType['all']
 const isEditingNote = ref(false)
+// set breakpoint based on the number of tabs, providing 90px width for each tab and subtracting 60px to account for the sidebar.
+const mobileBreakpoint = computed(() => (size(tabs) * 90) - 60)
 const selectedTab = ref(undefined)
 const tabs = computed(() => _filter(keys(props.filterTypes), key => !!props.countsPerType[key]))
+const timelineTabSelect = ref()
 
 const onModalClose = note => {
   isEditingNote.value = false
   putFocusNextTick(note && includes(['all', 'note'], selectedTab) ? `timeline-tab-${selectedTab.value}-message-0` : 'new-note-button')
 }
 
-const onUpdateTabsModel = value => props.setFilter(value === 'all' ? null : value)
+const onSelectTab = () => {
+  selectedTab.value = timelineTabSelect.value.value
+  onUpdateTabsModel(selectedTab.value)
+}
+
+const onUpdateTabsModel = value => {
+  props.setFilter(value === 'all' ? null : value)
+}
 </script>
 
 <style scoped>
-.horizontal-tabs {
-  min-width: 680px;
-}
 .timeline-tabs :deep(.v-slide-group__content) {
-  gap: 8px;
+  gap: 2px;
 }
 </style>

--- a/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
@@ -39,10 +39,10 @@
           <v-text-field
             :id="`timeline-${selectedFilter}s-query-input`"
             v-model="timelineQuery"
+            autocomplete="on"
             bg-color="pale-blue"
             class="academic-timeline-search-input"
             color="primary"
-            autocomplete="on"
             :disabled="!messagesVisible.length && !timelineQuery"
             flat
             hide-details


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6481

- tabs will be replaced by a <select> in narrow viewports
- also prevents screen reader from announcing the maximum number of attachments warning every time the Notes tab is hidden then shown.