### PR TITLE
BOAC-6518: prevents modal's Esc listener overriding ckeditor's

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,6 +22,7 @@ const contextStore = useContextStore()
 <style>
 @import 'v-calendar/style.css';
 @import "@/assets/styles/vcalendar-custom.css";
+@import "@/assets/styles/ckeditor-custom.css";
 @import "@/assets/styles/global.css";
 @import "@/assets/styles/focus.scss";
 </style>

--- a/src/assets/styles/ckeditor-custom.css
+++ b/src/assets/styles/ckeditor-custom.css
@@ -1,3 +1,6 @@
+.ck.ck-button.ck-on, a.ck.ck-button.ck-on {
+  border: 1px solid var(--ck-color-button-on-color);
+}
 .ck-editor__editable.ck-read-only {
   opacity: var(--v-disabled-opacity);
 }
@@ -7,13 +10,13 @@
 }
 :root {
   /* Overrides the border radius setting in the theme. */
-  --ck-border-radius: 4px;
+  --ck-border-radius: 4px !important;
   /* Overrides the default font size in the theme. */
-  --ck-font-size-base: 13px;
+  --ck-font-size-base: 14px !important;
   /* Helper variables to avoid duplication in the colors. */
-  --ck-custom-background: hsl(270, 1%, 29%);
-  --ck-custom-foreground: hsl(255, 3%, 18%);
-  --ck-custom-white: hsl(0, 0%, 100%);
+  --ck-custom-background: hsl(270, 1%, 29%) !important;
+  --ck-custom-foreground: hsl(255, 3%, 18%) !important;
+  --ck-custom-white: hsl(0, 0%, 100%) !important;
   /* -- BOAC custom colors. ------------------------------------------------------------- */
   --boac-white: hsl(270, 1%, 29%);
   --boac-color-button-default-background: hsl(0, 0%, 95%);
@@ -39,6 +42,7 @@
   --ck-color-button-default-active-shadow: var(--boac-color-button-default-active-shadow);
   --ck-color-button-default-disabled-background: var(--boac-color-button-on-disabled-background);
   /* ---------------------------------------- */
+  --ck-color-button-on-color: rgb(var(--v-theme-primary)) !important;
   --ck-color-button-on-background: var(--boac-color-button-on-background);
   --ck-color-button-on-hover-background: var(--boac-color-button-on-hover-background);
   --ck-color-button-on-active-background: var(--boac-color-button-on-active-background);
@@ -52,8 +56,8 @@
   --ck-color-button-action-disabled-background: var(--boac-color-button-on-disabled-background);
   --ck-color-button-action-text: var(--ck-custom-white);
   /* ---------------------------------------- */
-  --ck-color-button-save: hwb(120 0% 28%);
-  --ck-color-button-cancel: hsl(15, 100%, 56%);
+  --ck-color-button-save: rgb(var(--v-theme-success)) !important;
+  --ck-color-button-cancel: rgb(var(--v-theme-error)) !important;
   /* -- Overrides the default .ck-dropdown class colors. -------------------------------------- */
   --ck-color-dropdown-panel-background: var(--boac-color-button-default-background);
   --ck-color-dropdown-panel-border: var(--ck-custom-foreground);
@@ -64,8 +68,8 @@
   --ck-color-list-button-on-background-focus: var(--ck-color-base-active-focus);
   --ck-color-list-button-on-text: var(--ck-color-base-background);
   /* -- Overrides the default .ck-toolbar class colors. --------------------------------------- */
-  --ck-color-toolbar-background: var(--ck-custom-white);
-  --ck-color-toolbar-border: var(--ck-custom-white);
+  /* --ck-color-toolbar-background: var(--ck-custom-white) !important;
+  --ck-color-toolbar-border: var(--ck-custom-white) !important; */
   /* -- Overrides the default .ck-tooltip class colors. --------------------------------------- */
   --ck-color-tooltip-background: hsl(252, 7%, 14%);
   --ck-color-tooltip-text: hsl(0, 0%, 93%);
@@ -77,7 +81,7 @@
   --ck-color-widget-hover-border: hsl(43, 100%, 68%);
   --ck-color-widget-editable-focus-background: var(--ck-custom-white);
   /* -- Overrides the default colors used by the ckeditor5-link package. ---------------------- */
-  --ck-color-link-default: rgb(var(--v-theme-anchor));
+  --ck-color-link-default: rgb(var(--v-theme-anchor)) !important;
   /* -- Configure the z-index of the editor UI so it doesn't appear behind modals. ------------ */
   --ck-z-default: 2400 !important;
   --ck-z-panel: calc( var(--ck-z-default) + 999 ) !important;

--- a/src/components/note/EditBatchNoteModal.vue
+++ b/src/components/note/EditBatchNoteModal.vue
@@ -2,10 +2,12 @@
   <div>
     <v-dialog
       v-if="mode"
+      id="edit-batch-note-modal"
       v-model="dialogModel"
       aria-labelledby="dialog-header-note"
       persistent
       scrollable
+      @after-enter="afterModalShown"
     >
       <v-card
         id="new-note-modal-container"
@@ -53,6 +55,7 @@
                 label="Note Details"
                 :on-value-update="noteStore.setBody"
                 :show-advising-note-best-practices="true"
+                :on-toggle-popover="toggleFocusLock"
               />
             </div>
             <div class="py-3">
@@ -198,24 +201,23 @@ const alert = ref(undefined)
 // eslint-disable-next-line vue/require-prop-types
 const dialogModel = defineModel()
 const dismissAlertSeconds = ref(undefined)
+const isSecondModalOpen = ref(false)
 const showCreateTemplateModal = ref(false)
 const showDiscardNoteModal = ref(false)
 const showDiscardTemplateModal = ref(false)
 const topics = ref([])
 
 const selectEscape = event => {
-  if (event.key === 'Escape' && !noteStore.isSaving && !showCreateTemplateModal.value && dialogModel.value) {
+  if (event.key === 'Escape' && !isSecondModalOpen.value && !noteStore.isSaving && !showCreateTemplateModal.value && dialogModel.value) {
     discardRequested()
   }
+  return false
 }
 
 watch(dialogModel, () => {
   if (dialogModel.value) {
     // remove scrollbar for content behind the modal
     document.documentElement.classList.add('modal-open')
-    document.removeEventListener('keydown', selectEscape)
-    document.addEventListener('keydown', selectEscape, {capture: true})
-    enableFocusLock()
     getMyNoteTemplates().then(noteStore.setNoteTemplates)
     noteStore.resetModel()
     init().then(note => {
@@ -237,9 +239,8 @@ watch(dialogModel, () => {
   } else {
     noteStore.setMode(null)
     noteStore.clearAutoSaveJob()
-    disableFocusLock()
     document.documentElement.classList.remove('modal-open')
-    document.removeEventListener('keydown', selectEscape)
+    disableFocusLock()
     contextStore.removeEventHandler('user-session-expired', noteStore.onBoaSessionExpires)
   }
 })
@@ -264,6 +265,13 @@ const addNoteAttachments = attachments => {
       resolve()
     }
   })
+}
+
+const afterModalShown = () => {
+  const modal = document.getElementById('edit-batch-note-modal')
+  modal.removeEventListener('keydown', selectEscape)
+  modal.addEventListener('keydown', selectEscape, {capture: true})
+  enableFocusLock()
 }
 
 const cancelCreateTemplate = () => {
@@ -420,11 +428,14 @@ const showAlert = (value, seconds=3) => {
   dismissAlertSeconds.value = seconds
 }
 
-const toggleFocusLock = isSecondModalOpen => {
+const toggleFocusLock = isOpen => {
+  isSecondModalOpen.value = isOpen
   if (dialogModel.value) {
-    if (isSecondModalOpen) {
+    if (isSecondModalOpen.value) {
       disableFocusLock()
-    } else enableFocusLock()
+    } else {
+      enableFocusLock()
+    }
   }
 }
 

--- a/src/components/util/RichTextEditor.vue
+++ b/src/components/util/RichTextEditor.vue
@@ -70,6 +70,11 @@ const props = defineProps({
     required: true,
     type: String
   },
+  onTogglePopover: {
+    default: () => {},
+    required: false,
+    type: Function
+  },
   onValueUpdate: {
     required: true,
     type: Function
@@ -114,6 +119,7 @@ const abandonAttempt = () => {
   domFixAttemptCount.value++
   return false
 }
+
 const correctTheDOM = () => {
   if (domFixAttemptCount.value >= 10) {
     // Abort after N tries.
@@ -131,11 +137,12 @@ const correctTheDOM = () => {
   each(linksInText, link => {
     link.addEventListener(
       'click',
-      () => makePopupAccessible(popupsContainer, toolbar),
+      () => makePopupAccessible(popupsContainer, toolbar, 'Edit link'),
       {signal: editorLinkEventController.signal}
     )
   })
   if (isInModal.value) {
+    registerPopupListener(editor)
     // When embedded in a modal, the CKEditor toolbar popups are unreachable because they are attached to
     // the end of the DOM and outside the modal. We must move these "ck" elements. The user should not notice.
     toolbar.insertAdjacentElement('afterend', popupsContainer)
@@ -148,7 +155,7 @@ const correctTheDOM = () => {
       if ('Link' === button.textContent) {
         button.addEventListener(
           'click',
-          () => makePopupAccessible(popupsContainer, toolbar),
+          () => makePopupAccessible(popupsContainer, toolbar, 'Create link'),
           {signal: toolbarLinkButtonEventController.signal}
         )
       }
@@ -169,7 +176,7 @@ const correctTheDOM = () => {
       if ('Link' === button.textContent) {
         button.addEventListener(
           'click',
-          () => makePopupAccessible(popupsContainer, toolbar),
+          () => makePopupAccessible(popupsContainer, toolbar, 'Create link'),
           {signal: toolbarLinkButtonEventController.signal}
         )
       }
@@ -180,7 +187,7 @@ const correctTheDOM = () => {
 
 const correctPopupPosition = (popup, popupsContainer, toolbar) => {
   const offset = parseInt(popup.style.top, 10) - (toolbar.clientHeight + popup.clientHeight)
-  const popupButtons = popup.querySelectorAll('button')
+  const popupButtons = popup.querySelectorAll(':where(button, a)')
   popup.style.transform = `translateY(-${offset}px)`
   each(popupButtons, b => {
     b.addEventListener('mouseenter', () => {
@@ -211,7 +218,7 @@ const initDomFixer = () => {
   domFixer.value = setInterval(correctTheDOM, 500)
 }
 
-const makePopupAccessible = (popupsContainer, toolbar) => {
+const makePopupAccessible = (popupsContainer, toolbar, ariaLabel) => {
   let attemptCount = 0
   popupFixer.value = setInterval(() => {
     if (attemptCount >= 10) {
@@ -220,7 +227,7 @@ const makePopupAccessible = (popupsContainer, toolbar) => {
     const popup = popupsContainer.querySelector('.ck.ck-balloon-panel.ck-balloon-panel_with-arrow:not(.ck-tooltip)')
     attemptCount++
     if (popup) {
-      popup.setAttribute('aria-label', 'Create or edit link')
+      popup.setAttribute('aria-label', ariaLabel)
       popup.setAttribute('role', 'dialog')
       popup.setAttribute('aria-modal', 'true')
       if (isInModal.value) {
@@ -231,8 +238,23 @@ const makePopupAccessible = (popupsContainer, toolbar) => {
   }, 500)
 }
 
+const onChangePopoverVisible = (e, propertyName, newValue) => {
+  props.onTogglePopover(newValue)
+}
+
 const onUpdate = event => {
   props.onValueUpdate(isString(event) ? event : event.target.value)
+}
+
+const registerPopupListener = editor => {
+  const editable = editor.querySelector('.ck-editor__editable_inline')
+  if (editable) {
+    const editorInstance = editable.ckeditorInstance
+    const balloonInstance = editorInstance.plugins.get('ContextualBalloon')
+    const balloonPanelView = balloonInstance.view
+    balloonPanelView.off('change:isVisible', onChangePopoverVisible)
+    balloonPanelView.on('change:isVisible', onChangePopoverVisible)
+  }
 }
 </script>
 
@@ -240,6 +262,12 @@ const onUpdate = event => {
 .ck.ck-balloon-panel.ck-balloon-panel_with-arrow:not(.ck-tooltip) {
   /* make sure the Link popup doesn't cover its own tooltips */
   z-index: 9998 !important;
+}
+.ck.ck-balloon-panel .ck-link-actions__preview {
+  font-size: 1rem;
+}
+.ck.ck-balloon-panel.ck-powered-by-balloon {
+  display: none !important;
 }
 .ck-content ul {
   padding-left: 25px !important;
@@ -250,8 +278,4 @@ const onUpdate = event => {
 .ck.ck-sticky-panel .ck-sticky-panel__content_sticky {
   position: static !important;
 }
-</style>
-
-<style>
-@import "@/assets/styles/ckeditor-custom.css";
 </style>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6518

When one of CKEditor's popups is open inside a modal, the Escape key will close the popup but not the modal.