### PR TITLE
BOAC-6594, Enable Enhanced CloudWatch Metrics

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -1,6 +1,106 @@
-#
-# AWS configuration for BOA
-#
+files:
+  "/tmp/amazon-cloudwatch-agent.json":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      {
+        "agent": {
+          "metrics_collection_interval": 60,
+          "run_as_user": "root"
+        },
+        "metrics": {
+          "namespace": "CWAgent",
+          "append_dimensions": {
+            "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+          },
+          "aggregation_dimensions": [
+            ["AutoScalingGroupName"],
+            ["InstanceId"],
+            []
+          ],
+          "metrics_collected": {
+            "cpu": {
+              "measurement": [
+                "cpu_usage_idle",
+                "cpu_usage_system",
+                "cpu_usage_user",
+                "cpu_usage_iowait"
+              ],
+              "totalcpu": true,
+              "resources": [
+                "*"
+              ],
+              "metrics_collection_interval": 60
+            },
+            "mem": {
+              "measurement": [
+                "mem_used_percent",
+                "mem_available"
+              ],
+              "metrics_collection_interval": 300
+            },
+            "disk": {
+              "measurement": [
+                "disk_used_percent"
+              ],
+              "resources": [
+                "/"
+              ],
+              "drop_device": true,
+              "metrics_collection_interval": 300
+            },
+            "diskio": {
+              "measurement": [
+                "write_bytes",
+                "read_bytes",
+                "writes",
+                "reads"
+              ],
+              "resources": [
+                "*"
+              ],
+              "metrics_collection_interval": 300
+            },
+            "net": {
+              "measurement": [
+                "bytes_sent",
+                "bytes_recv"
+              ],
+              "resources": [
+                "eth0",
+                "ens*"
+              ],
+              "metrics_collection_interval": 300
+            }
+          }
+        },
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/app/current/boa.log*",
+                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/app/current/boa.log\"]]}`",
+                  "log_stream_name": "{instance_id}"
+                },
+                {
+                  "file_path": "/var/log/messages",
+                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/log/messages\"]]}`",
+                  "log_stream_name": "{instance_id}-messages",
+                  "timestamp_format": "%b %d %H:%M:%S"
+                },
+                {
+                  "file_path": "/var/log/secure",
+                  "log_group_name": "`{\"Fn::Join\":[\"/\", [\"/aws/elasticbeanstalk\", { \"Ref\":\"AWSEBEnvironmentName\" }, \"var/log/secure\"]]}`",
+                  "log_stream_name": "{instance_id}-secure",
+                  "timestamp_format": "%b %d %H:%M:%S"
+                }
+              ]
+            }
+          }
+        }
+      }
 
 packages:
   yum:
@@ -22,48 +122,21 @@ option_settings:
     /favicon.ico: dist/static/favicon.ico
   aws:elasticbeanstalk:environment:process:default:
     HealthCheckPath: /api/ping
-    Port: '443'
+    Port: "443"
     Protocol: HTTPS
-
-  # Default listener (port 80) is enabled, but will redirect to 443 per Apache config.
   aws:elbv2:listener:default:
-    ListenerEnabled: 'true'
-
-  # Custom load balancer listener (port 443)
+    ListenerEnabled: "true"
   aws:elbv2:listener:443:
-    ListenerEnabled: 'true'
+    ListenerEnabled: "true"
     Protocol: HTTPS
     SSLPolicy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
     SSLCertificateArns: arn:aws:acm:us-west-2:641415506485:certificate/05ef0fa3-936f-4938-9f92-3db1fd033501
-
-
-files:
-  /opt/aws/amazon-cloudwatch-agent/bin/config.json:
-    mode: '000644'
-    owner: root
-    group: root
-    content: |
-      {
-        "logs": {
-          "logs_collected": {
-            "files": {
-              "collect_list": [
-                {
-                  "file_path": "/var/app/current/boa.log*",
-                  "log_group_name": "`{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/boa.log"]]}`",
-                  "log_stream_name": "{instance_id}"
-                }
-              ]
-            }
-          }
-        }
-      }
 
 Resources:
   sslSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
+      GroupId: { "Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"] }
       IpProtocol: tcp
       ToPort: 443
       FromPort: 443

--- a/.platform/hooks/postdeploy/02_start_awslogsd.sh
+++ b/.platform/hooks/postdeploy/02_start_awslogsd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/tmp/amazon-cloudwatch-agent.json -s


### PR DESCRIPTION
Enable sending enhanced metrics to cloudwatch. Update the post-deploy hook to reference the new cloudwatch agent location.