### PR TITLE
BOAC-6597: manages focus after loading more search results

### DIFF
--- a/src/components/search/SearchResultsHeader.vue
+++ b/src/components/search/SearchResultsHeader.vue
@@ -4,7 +4,7 @@
       <span v-if="countTotal <= countInView">
         Showing {{ pluralize(resultsType, countTotal, {1: 'one'}) }}.
         <span v-if="searchPhrase">
-          matching <strong class="font-weight-500">{{ searchPhrase }}</strong>
+          matching <strong class="font-weight-600">{{ searchPhrase }}</strong>.
         </span>.
       </span>
       <span v-if="countTotal > countInView" class="font-size-18">
@@ -13,14 +13,14 @@
         <span class="sr-only"> 1 to {{ countInView }}</span>
         of {{ toInt(countTotal, 0).toLocaleString() }}
         <span v-if="searchPhrase">
-          matching <strong class="font-weight-500">{{ searchPhrase }}</strong>
+          matching <strong class="font-weight-600">{{ searchPhrase }}</strong>.
         </span>
       </span>
     </span>
     <span v-if="!countTotal">
       Showing {{ countInView }} {{ resultsType }}s
       <span v-if="searchPhrase">
-        matching <strong class="font-weight-500">{{ searchPhrase }}</strong>
+        matching <strong class="font-weight-600">{{ searchPhrase }}</strong>.
       </span>
     </span>
     <span v-if="!countTotal || countTotal > countInView">

--- a/src/views/SearchResults.vue
+++ b/src/views/SearchResults.vue
@@ -410,8 +410,9 @@ const fetchMoreAppointments = () => {
     .then(data => {
       results.appointments = concat(results.appointments, data.appointments)
       const nowShowing = size(results.appointments)
-      const total = results.totalAppointmentCount === null ? null : toInt(results.totalAppointmentCount, 0)
+      const total = results.totalAppointmentCount === null ? null : formatCount(results.totalAppointmentCount)
       alertScreenReader(total ? `Now showing ${nowShowing} of ${total} advising appointments.` : `Now showing ${nowShowing} advising appointments.`)
+      putFocusNextTick('fetch-more-appointments')
     }).finally(() => {
       loadingAdditionalAppointments.value = false
     })
@@ -433,8 +434,9 @@ const fetchMoreNotes = () => {
     .then(data => {
       results.notes = concat(results.notes, data.notes)
       const nowShowing = size(results.notes)
-      const total = results.totalNoteCount === null ? null : toInt(results.totalNoteCount, 0)
+      const total = results.totalNoteCount === null ? null : formatCount(results.totalNoteCount)
       alertScreenReader(total ? `Now showing ${nowShowing} of ${total} advising notes.` : `Now showing ${nowShowing} advising notes.`)
+      putFocusNextTick('fetch-more-notes')
     }).finally(() => {
       loadingAdditionalNotes.value = false
     })


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6597

Also
- formats numbers in screen reader alert (so they are read as "seven thousand" instead of "seven zero zero zero"
- The class `font-weight-500` doesn't have an effect - maybe the font we're using doesn't have a 500-weight variant. 