### PR TITLE
BOAC-6519: custom ckeditor buttons for better focus management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,11 @@
     "": {
       "name": "BOA",
       "dependencies": {
-        "@ckeditor/ckeditor5-build-classic": "43.3.1",
         "@ckeditor/ckeditor5-vue": "5.1.0",
         "@mdi/js": "7.4.47",
         "@popperjs/core": "2.11.8",
         "axios": "1.13.2",
+        "ckeditor5": "43.3.1",
         "core-js": "3.48.0",
         "highcharts": "12.5.0",
         "js-file-download": "0.4.12",
@@ -197,35 +197,6 @@
         "@ckeditor/ckeditor5-ui": "43.3.1",
         "@ckeditor/ckeditor5-utils": "43.3.1",
         "ckeditor5": "43.3.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-build-classic": {
-      "version": "43.3.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-43.3.1.tgz",
-      "integrity": "sha512-ilc1YyOyIhknNd1NSAiHmXZewazGuIHYl5rHPeCiBShNGTjnh9DrA5hXSk7JBc1BpAxpxd4ojKR1nJ0dvkaR7g==",
-      "deprecated": "The predefined builds are no longer maintained. Check the https://ckeditor.com/docs/ckeditor5/latest/updating/nim-migration/predefined-builds.html page for the details.",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "43.3.1",
-        "@ckeditor/ckeditor5-autoformat": "43.3.1",
-        "@ckeditor/ckeditor5-basic-styles": "43.3.1",
-        "@ckeditor/ckeditor5-block-quote": "43.3.1",
-        "@ckeditor/ckeditor5-ckbox": "43.3.1",
-        "@ckeditor/ckeditor5-ckfinder": "43.3.1",
-        "@ckeditor/ckeditor5-cloud-services": "43.3.1",
-        "@ckeditor/ckeditor5-easy-image": "43.3.1",
-        "@ckeditor/ckeditor5-editor-classic": "43.3.1",
-        "@ckeditor/ckeditor5-essentials": "43.3.1",
-        "@ckeditor/ckeditor5-heading": "43.3.1",
-        "@ckeditor/ckeditor5-image": "43.3.1",
-        "@ckeditor/ckeditor5-indent": "43.3.1",
-        "@ckeditor/ckeditor5-link": "43.3.1",
-        "@ckeditor/ckeditor5-list": "43.3.1",
-        "@ckeditor/ckeditor5-media-embed": "43.3.1",
-        "@ckeditor/ckeditor5-paragraph": "43.3.1",
-        "@ckeditor/ckeditor5-paste-from-office": "43.3.1",
-        "@ckeditor/ckeditor5-table": "43.3.1",
-        "@ckeditor/ckeditor5-typing": "43.3.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
@@ -8573,33 +8544,6 @@
         "@ckeditor/ckeditor5-ui": "43.3.1",
         "@ckeditor/ckeditor5-utils": "43.3.1",
         "ckeditor5": "43.3.1"
-      }
-    },
-    "@ckeditor/ckeditor5-build-classic": {
-      "version": "43.3.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-43.3.1.tgz",
-      "integrity": "sha512-ilc1YyOyIhknNd1NSAiHmXZewazGuIHYl5rHPeCiBShNGTjnh9DrA5hXSk7JBc1BpAxpxd4ojKR1nJ0dvkaR7g==",
-      "requires": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "43.3.1",
-        "@ckeditor/ckeditor5-autoformat": "43.3.1",
-        "@ckeditor/ckeditor5-basic-styles": "43.3.1",
-        "@ckeditor/ckeditor5-block-quote": "43.3.1",
-        "@ckeditor/ckeditor5-ckbox": "43.3.1",
-        "@ckeditor/ckeditor5-ckfinder": "43.3.1",
-        "@ckeditor/ckeditor5-cloud-services": "43.3.1",
-        "@ckeditor/ckeditor5-easy-image": "43.3.1",
-        "@ckeditor/ckeditor5-editor-classic": "43.3.1",
-        "@ckeditor/ckeditor5-essentials": "43.3.1",
-        "@ckeditor/ckeditor5-heading": "43.3.1",
-        "@ckeditor/ckeditor5-image": "43.3.1",
-        "@ckeditor/ckeditor5-indent": "43.3.1",
-        "@ckeditor/ckeditor5-link": "43.3.1",
-        "@ckeditor/ckeditor5-list": "43.3.1",
-        "@ckeditor/ckeditor5-media-embed": "43.3.1",
-        "@ckeditor/ckeditor5-paragraph": "43.3.1",
-        "@ckeditor/ckeditor5-paste-from-office": "43.3.1",
-        "@ckeditor/ckeditor5-table": "43.3.1",
-        "@ckeditor/ckeditor5-typing": "43.3.1"
       }
     },
     "@ckeditor/ckeditor5-ckbox": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve-vue": "vite --host --strictPort"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-build-classic": "43.3.1",
+    "ckeditor5": "43.3.1",
     "@ckeditor/ckeditor5-vue": "5.1.0",
     "@mdi/js": "7.4.47",
     "@popperjs/core": "2.11.8",

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,6 +22,7 @@ const contextStore = useContextStore()
 <style>
 @import 'v-calendar/style.css';
 @import "@/assets/styles/vcalendar-custom.css";
+@import 'ckeditor5/ckeditor5.css';
 @import "@/assets/styles/ckeditor-custom.css";
 @import "@/assets/styles/global.css";
 @import "@/assets/styles/focus.scss";

--- a/src/assets/styles/ckeditor-custom.css
+++ b/src/assets/styles/ckeditor-custom.css
@@ -19,17 +19,18 @@
   --ck-custom-white: hsl(0, 0%, 100%) !important;
   /* -- BOAC custom colors. ------------------------------------------------------------- */
   --boac-white: hsl(270, 1%, 29%);
-  --boac-color-button-default-background: hsl(0, 0%, 95%);
+  --boac-color-button-default-background: transparent;
   --boac-color-button-default-hover-background: hsl(0, 0%, 85%);
-  --boac-color-button-default-active-background: hsl(0, 0%, 90%);
+  --boac-color-button-default-active-background: hsl(0, 0%, 95%);
   --boac-color-button-default-active-shadow: hsl(0, 0%, 75%);
 
-  --boac-color-button-on-background: hsl(0, 0%, 85%);
+  --boac-color-button-on-background: hsl(0, 0%, 90%);
   --boac-color-button-on-hover-background: hsl(0, 0%, 75%);
   --boac-color-button-on-active-background: hsl(0, 0%, 80%);
   --boac-color-button-on-active-shadow: hsl(0, 0%, 50%);
   --boac-color-button-on-disabled-background: hsl(0, 0%, 85%);
   /* -- Overrides generic colors. ------------------------------------------------------------- */
+  --ck-color-base-border: hsla(0, 0%, 0%, 0.38) !important;
   --ck-color-base-foreground: var(--ck-custom-background);
   --ck-color-focus-border: hsl(202, 47% 44%);
   --ck-color-text: var(--boac-white);

--- a/src/assets/styles/focus.scss
+++ b/src/assets/styles/focus.scss
@@ -21,6 +21,8 @@
   }
   .bg-primary:focus::after,
   .button-menu.bg-primary:focus,
+  .ck.ck-input:focus,
+  .ck.ck-toolbar .ck.ck-button:focus,
   .text-primary:focus::after,
   button.clear-button:focus {
     outline-color: rgba(var(--v-theme-primary)) !important;
@@ -38,6 +40,8 @@
   .text-tertiary:focus::after {
     outline-color: rgba(var(--v-theme-tertiary)) !important;
   }
+  .ck.ck-button:focus,
+  .ck.ck-input:focus,
   .checkbox-container:focus-within,
   .select-menu:focus,
   .vc-focus:focus,
@@ -58,6 +62,10 @@
     outline-offset: 0.125rem;
     outline-style: solid;
     outline-width: 0.125rem;
+  }
+  .ck.ck-button:focus {
+    box-shadow: inset 0 0 0.1rem 0.1rem white !important;
+    outline-offset: 0 !important;
   }
   .select-menu:focus,
   .v-chip:focus,
@@ -155,6 +163,8 @@
   }
   .bg-primary:focus-visible::after,
   .button-menu.bg-primary:focus-visible,
+  .ck.ck-input:focus-visible,
+  .ck.ck-toolbar .ck.ck-button:focus-visible,
   .text-primary:focus-visible::after,
   button.clear-button:focus-visible {
     outline-color: rgba(var(--v-theme-primary)) !important;
@@ -172,6 +182,8 @@
   .text-tertiary:focus-visible::after {
     outline-color: rgba(var(--v-theme-tertiary)) !important;
   }
+  .ck.ck-button:focus-visible,
+  .ck.ck-input:focus-visible,
   .checkbox-container:focus-within,
   .select-menu:focus-visible,
   .vc-focus:focus-visible,
@@ -192,6 +204,10 @@
     outline-offset: 0.125rem;
     outline-style: solid;
     outline-width: 0.125rem;
+  }
+  .ck.ck-button:focus-visible {
+    box-shadow: inset 0 0 0.125rem 0.125rem white !important;
+    outline-offset: 0 !important;
   }
   .select-menu:focus-visible,
   .v-chip:focus-visible,
@@ -265,6 +281,12 @@
   input[type="checkbox"]:focus-visible {
     outline: none;
   }
+}
+.ck.ck-editor:not(:has(.ck.ck-toolbar:focus-within)) .ck.ck-editor__editable.ck-focused:not(.ck-editor__nested-editable) {
+  outline-color: rgba(var(--v-theme-primary)) !important;
+  outline-offset: -.125rem;
+  outline-style: solid;
+  outline-width: 0.125rem;
 }
 .v-input--focused.basic-search .v-field--focused {
   --v-theme-overlay-multiplier: 3;

--- a/src/components/util/AccessibleDateInput.vue
+++ b/src/components/util/AccessibleDateInput.vue
@@ -18,7 +18,7 @@
       <template #default="{ inputValue, inputEvents }">
         <div
           class="custom-text-field w-100"
-          :class="{ 'error--text': !isValid(inputValue), disabled: disabled }"
+          :class="{ 'border-error': !isValid(inputValue), disabled: disabled }"
           :aria-invalid="!isValid(inputValue)"
         >
           <input
@@ -374,9 +374,6 @@ const onUpdateFocus = (hasFocus, inputEvents) => {
 }
 .custom-text-field input::placeholder {
   color: rgba(var(--v-theme-on-surface), var(--v-medium-emphasis-opacity));
-}
-.custom-text-field.error--text {
-  border-color: rgb(var(--v-theme-error));
 }
 </style>
 

--- a/src/components/util/RichTextEditor.vue
+++ b/src/components/util/RichTextEditor.vue
@@ -23,44 +23,28 @@
       class="mt-2"
     >
       <ckeditor
-        :model-value="initialValue"
+        v-model="model"
         :disabled="disabled"
         :editor="ClassicEditor"
-        :config="editorConfig"
-        @input="onUpdate"
+        :config="config"
+        @input="onEditorInput"
+        @ready="onEditorReady"
       />
     </div>
   </div>
 </template>
 
 <script setup>
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic'
+import {AutoLink, Bold, ClassicEditor, ContextualBalloon, Essentials, Italic, Link, List, Paragraph, StandardEditingMode, TextTransformation, Typing} from 'ckeditor5'
 import {each, isString} from 'lodash'
 import {mdiOpenInNew} from '@mdi/js'
 import {nextTick, onBeforeUnmount, onMounted, ref} from 'vue'
+import {BoldCustom, ItalicCustom, ListBulletedCustom, ListNumberedCustom} from '@/plugins/ckeditor'
 
 const props = defineProps({
   disabled: {
     required: false,
     type: Boolean
-  },
-  editorConfig: {
-    required: false,
-    default: () => ({
-      link: {
-        addTargetToExternalLinks: true
-      },
-      toolbar: {
-        items: ['bold', 'italic', 'bulletedList', 'numberedList', 'link'],
-        shouldNotGroupWhenFull: true
-      },
-      typing: {
-        transformations: {
-          remove: ['oneForth', 'oneHalf', 'oneThird', 'threeQuarters', 'twoThirds']
-        }
-      }
-    }),
-    type: Object
   },
   initialValue: {
     required: true,
@@ -86,10 +70,27 @@ const props = defineProps({
 })
 
 const ckElementId = ref('rich-text-editor')
+const config = {
+  link: {
+    addTargetToExternalLinks: true
+  },
+  plugins: [AutoLink, Bold, BoldCustom, ContextualBalloon, Essentials, Italic, ItalicCustom, Link, List, ListBulletedCustom, ListNumberedCustom, Paragraph, StandardEditingMode, TextTransformation, Typing],
+  toolbar: {
+    items: ['boldCustom', 'italicCustom', 'listBulletedCustom', 'listNumberedCustom', 'link'],
+    shouldNotGroupWhenFull: true
+  },
+  typing: {
+    transformations: {
+      remove: ['oneForth', 'oneHalf', 'oneThird', 'threeQuarters', 'twoThirds']
+    }
+  }
+}
 const domFixAttemptCount = ref(0)
 const domFixer = ref(undefined)
+const editor = ref()
 const editorLinkEventController = new AbortController()
 const isInModal = ref(false)
+const model = ref(props.initialValue)
 const popupButtonEventController = new AbortController()
 const popupFixer = ref(undefined)
 const toolbarButtonEventController = new AbortController()
@@ -111,7 +112,6 @@ onMounted(() => {
   nextTick(() => {
     // Is this instance inside a modal dialog?
     isInModal.value = !!document.querySelector(`.v-overlay-container #${ckElementId.value}`)
-    initDomFixer()
   })
 })
 
@@ -120,32 +120,31 @@ const abandonAttempt = () => {
   return false
 }
 
-const correctAttributes = (editor, toolbar) => {
-  const textbox = editor.querySelector('[role="textbox"]')
+const correctAttributes = (toolbar) => {
+  const textbox = editor.value.ui.view.editable.element
   if (textbox) {
     textbox.setAttribute('aria-multiline', true)
     textbox.setAttribute('id', `${ckElementId.value}-textbox`)
   }
   toolbar.setAttribute('aria-label', `${props.label} editor`)
   toolbar.setAttribute('aria-controls', `${ckElementId.value}-textbox`)
+  toolbar.setAttribute('tabindex', 0)
 }
 
 const correctTheDOM = () => {
-  if (domFixAttemptCount.value >= 10) {
+  if (domFixAttemptCount.value >= 5) {
     // Abort after N tries.
     clearInterval(domFixer.value)
     return false
   }
-  const editor = document.getElementById(ckElementId.value)
-  if (!editor) return abandonAttempt()
-  const toolbar = editor.querySelector('[role="toolbar"]')
+  const toolbar = editor.value.ui.view.element.querySelector('[role="toolbar"]')
   if (!toolbar) return abandonAttempt()
-  correctAttributes(editor, toolbar)
+  correctAttributes(toolbar)
 
   const popupsContainer = document.body.querySelector('.ck.ck-reset_all.ck-body.ck-rounded-corners')
   if (!popupsContainer) return abandonAttempt()
   const toolbarButtons = toolbar.querySelectorAll('button')
-  const linksInText = editor.querySelectorAll('[role="textbox"] a')
+  const linksInText = editor.value.ui.view.editable.element.querySelectorAll('a')
   each(linksInText, link => {
     link.addEventListener(
       'click',
@@ -154,23 +153,28 @@ const correctTheDOM = () => {
     )
   })
   if (isInModal.value) {
-    registerPopupListener(editor)
     // When embedded in a modal, the CKEditor toolbar popups are unreachable because they are attached to
     // the end of the DOM and outside the modal. We must move these "ck" elements. The user should not notice.
     toolbar.insertAdjacentElement('afterend', popupsContainer)
-    each(toolbarButtons, button => {
-      const buttonImage = button.querySelector('.ck-icon')
-      if (buttonImage) {
-        buttonImage.setAttribute('aria-hidden', 'true')
-      }
-      button.setAttribute('tabindex', 0)
-      if ('Link' === button.textContent) {
-        button.addEventListener(
-          'click',
-          () => makePopupAccessible(popupsContainer, toolbar, 'Create link'),
-          {signal: toolbarLinkButtonEventController.signal}
-        )
-      }
+  }
+  each(toolbarButtons, button => {
+    const buttonImage = button.querySelector('.ck-icon')
+    if (buttonImage) {
+      buttonImage.setAttribute('aria-hidden', true)
+    }
+    if ('Link' === button.textContent) {
+      button.addEventListener(
+        'click',
+        () => makePopupAccessible(popupsContainer, toolbar, 'Create link'),
+        {signal: toolbarLinkButtonEventController.signal}
+      )
+    } else {
+      button.addEventListener(
+        'click',
+        onButtonClick,
+      )
+    }
+    if (isInModal.value) {
       button.addEventListener(
         'mouseenter',
         () => {
@@ -179,21 +183,16 @@ const correctTheDOM = () => {
         },
         {signal: toolbarButtonEventController.signal}
       )
-    })
-    clearInterval(domFixer.value)
-  } else {
-    // We're not in a modal.
-    each(toolbarButtons, button => {
-      button.setAttribute('tabindex', 0)
-      if ('Link' === button.textContent) {
-        button.addEventListener(
-          'click',
-          () => makePopupAccessible(popupsContainer, toolbar, 'Create link'),
-          {signal: toolbarLinkButtonEventController.signal}
-        )
-      }
-    })
-    clearInterval(domFixer.value)
+    }
+  })
+  clearInterval(domFixer.value)
+}
+
+const onButtonClick = e => {
+  // If the button was pressed using a mouse or equivalent pointing device, move focus back to the textbox.
+  // Otherwise, the button was pressed using the keyboard and focus will stay on the button.
+  if (e.pointerType) {
+    editor.value.editing.view.focus()
   }
 }
 
@@ -250,23 +249,59 @@ const makePopupAccessible = (popupsContainer, toolbar, ariaLabel) => {
   }, 500)
 }
 
+const manageToolbarFocus = () => {
+  let lastFocusedButton
+
+  // When focus leaves the editor UI entirely, reset so Bold is the first focused button
+  editor.value.ui.focusTracker.on('change:isFocused', (e, data, isFocused) => {
+    if (!isFocused) {
+      lastFocusedButton = null
+    }
+  })
+  editor.value.ui.view.toolbar.focusTracker.on('change:focusedElement', e => {
+    const focusedElement = editor.value.ui.view.toolbar.focusTracker.focusedElement
+    if (focusedElement && 'button' === focusedElement.type && focusedElement !== lastFocusedButton) {
+      // Focus is landing on a toolbar button from another toolbar button or from the toolbar itself
+      lastFocusedButton = focusedElement
+      lastFocusedButton.focus()
+      editor.value.ui.view.toolbar.element.setAttribute('tabindex', '-1')
+    } else if (focusedElement) {
+      // Focus is landing on the toolbar itself from outside of the toolbar. When focus lands on the toolbar,
+      // we move it either to the previously focused button or the first button.
+      editor.value.ui.view.toolbar.element.setAttribute('tabindex', '-1')
+      if (!lastFocusedButton) {
+        lastFocusedButton = editor.value.ui.view.toolbar.focusTracker.elements[1]
+      }
+      lastFocusedButton.focus()
+    } else {
+      // Focus is leaving the toolbar
+      editor.value.ui.view.toolbar.element.setAttribute('tabindex', '0')
+    }
+    e.stop()
+    return false
+  })
+}
+
 const onChangePopoverVisible = (e, propertyName, newValue) => {
   props.onTogglePopover(newValue)
 }
 
-const onUpdate = event => {
+const onEditorInput = event => {
   props.onValueUpdate(isString(event) ? event : event.target.value)
 }
 
-const registerPopupListener = editor => {
-  const editable = editor.querySelector('.ck-editor__editable_inline')
-  if (editable) {
-    const editorInstance = editable.ckeditorInstance
-    const balloonInstance = editorInstance.plugins.get('ContextualBalloon')
-    const balloonPanelView = balloonInstance.view
-    balloonPanelView.off('change:isVisible', onChangePopoverVisible)
-    balloonPanelView.on('change:isVisible', onChangePopoverVisible)
-  }
+const onEditorReady = editorInstance => {
+  editor.value = editorInstance
+  initDomFixer()
+  registerPopupListener()
+  manageToolbarFocus()
+}
+
+const registerPopupListener = () => {
+  const balloonInstance = editor.value.plugins.get('ContextualBalloon')
+  const balloonPanelView = balloonInstance.view
+  balloonPanelView.off('change:isVisible', onChangePopoverVisible)
+  balloonPanelView.on('change:isVisible', onChangePopoverVisible)
 }
 </script>
 
@@ -281,6 +316,11 @@ const registerPopupListener = editor => {
 .ck.ck-balloon-panel.ck-powered-by-balloon {
   display: none !important;
 }
+.ck.ck-content.ck-editor__editable.ck-focused:not(.ck-editor__nested-editable) {
+  border-style: solid !important;
+  border-width: 1px !important;
+  box-shadow: none !important;
+}
 .ck-content ul {
   padding-left: 25px !important;
 }
@@ -289,5 +329,18 @@ const registerPopupListener = editor => {
 }
 .ck.ck-sticky-panel .ck-sticky-panel__content_sticky {
   position: static !important;
+}
+.ck.ck-sticky-panel__content:focus-within,
+.ck.ck-editor:hover {
+  --ck-color-base-border: hsla(0, 0%, 0%, 1) !important;
+  transition: border-color 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.ck.ck-content.ck-editor__editable {
+  border-radius: 4px;
+  border-style: solid !important;
+  border-width: 1 !important;
+  &.text-error input {
+    color: rgb(var(--v-theme-error))
+  }
 }
 </style>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -226,7 +226,7 @@ export function toBoolean(value: string) {
 }
 
 export function toggleModalBackgroundDisabled(isModalOpen: boolean) {
-  const inactiveModals = document.querySelectorAll('.v-overlay:not(.v-overlay-active')
+  const inactiveModals = document.querySelectorAll('.v-overlay:not(.v-overlay--active')
   useContextStore().setIsModalOpen(isModalOpen)
   if (isModalOpen) {
     inactiveModals.forEach(modal => modal.setAttribute('inert', 'true'))

--- a/src/plugins/ckeditor/bold.ts
+++ b/src/plugins/ckeditor/bold.ts
@@ -1,0 +1,26 @@
+import {Plugin, icons} from 'ckeditor5'
+import {createButton} from '@/plugins/ckeditor/utils'
+
+export default class BoldCustom extends Plugin {
+  static get pluginName() {
+    return 'BoldCustom'
+  }
+
+  static get isOfficialPlugin() {
+    return true
+  }
+
+  init(): void {
+    const editor = this.editor
+    const t = editor.locale.t
+    const button = createButton({
+      editor,
+      commandName: 'bold',
+      plugin: this,
+      icon: icons.bold,
+      label: t( 'Bold' ),
+      keystroke: 'CTRL+B'
+    })
+    editor.ui.componentFactory.add('boldCustom', () => button)
+  }
+}

--- a/src/plugins/ckeditor/bulleted-list.ts
+++ b/src/plugins/ckeditor/bulleted-list.ts
@@ -1,0 +1,25 @@
+import {Plugin, icons} from 'ckeditor5'
+import {createButton} from '@/plugins/ckeditor/utils'
+
+export default class ListBulletedCustom extends Plugin {
+  static get pluginName() {
+    return 'ListBulletedCustom'
+  }
+
+  static get isOfficialPlugin() {
+    return true
+  }
+
+  init(): void {
+    const editor = this.editor
+    const t = editor.locale.t
+    const button = createButton({
+      editor,
+      commandName: 'bulletedList',
+      plugin: this,
+      icon: icons.bulletedList,
+      label: t('Bulleted List')
+    })
+    editor.ui.componentFactory.add('listBulletedCustom', () => button)
+  }
+}

--- a/src/plugins/ckeditor/index.ts
+++ b/src/plugins/ckeditor/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @module ckeditor
+ */
+export {default as BoldCustom} from './bold'
+export {default as ItalicCustom} from './italic'
+export {default as ListBulletedCustom} from './bulleted-list'
+export {default as ListNumberedCustom} from './numbered-list'

--- a/src/plugins/ckeditor/italic.ts
+++ b/src/plugins/ckeditor/italic.ts
@@ -1,0 +1,29 @@
+import {Plugin} from 'ckeditor5'
+import {createButton} from '@/plugins/ckeditor/utils'
+
+const italicIcon = '<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="m9.586 14.633.021.004c-.036.335.095.655.393.962.082.083.173.15.274.201h1.474a.6.6 0 1 1 0 1.2H5.304a.6.6 0 0 1 0-1.2h1.15c.474-.07.809-.182 1.005-.334.157-.122.291-.32.404-.597l2.416-9.55a1.053 1.053 0 0 0-.281-.823 1.12 1.12 0 0 0-.442-.296H8.15a.6.6 0 0 1 0-1.2h6.443a.6.6 0 1 1 0 1.2h-1.195c-.376.056-.65.155-.823.296-.215.175-.423.439-.623.79l-2.366 9.347z"/></svg>'
+
+
+export default class ItalicCustom extends Plugin {
+  static get pluginName() {
+    return 'ItalicCustom'
+  }
+
+  static get isOfficialPlugin() {
+    return true
+  }
+
+  init(): void {
+    const editor = this.editor
+    const t = editor.locale.t
+    const button = createButton({
+      editor,
+      commandName: 'italic',
+      plugin: this,
+      icon: italicIcon,
+      label: t('Italic'),
+      keystroke: 'CTRL+I'
+    })
+    editor.ui.componentFactory.add('italicCustom', () => button)
+  }
+}

--- a/src/plugins/ckeditor/numbered-list.ts
+++ b/src/plugins/ckeditor/numbered-list.ts
@@ -1,0 +1,25 @@
+import {Plugin, icons} from 'ckeditor5'
+import {createButton} from '@/plugins/ckeditor/utils'
+
+export default class ListNumberedCustom extends Plugin {
+  static get pluginName() {
+    return 'ListNumberedCustom'
+  }
+
+  static get isOfficialPlugin() {
+    return true
+  }
+
+  init(): void {
+    const editor = this.editor
+    const t = editor.locale.t
+    const button = createButton({
+      editor,
+      commandName: 'numberedList',
+      plugin: this,
+      icon: icons.numberedList,
+      label: t('Numbered List')
+    })
+    editor.ui.componentFactory.add('listNumberedCustom', () => button)
+  }
+}

--- a/src/plugins/ckeditor/utils.ts
+++ b/src/plugins/ckeditor/utils.ts
@@ -1,0 +1,36 @@
+import {type AttributeCommand, ButtonView, type Editor, type Plugin} from 'ckeditor5'
+
+/*
+* Custom toolbar buttons behave the same as their CKEditor-provided counterparts,
+* except they don't move focus to the textbox when you click them.
+* Instead, the RichTextEditor component handles focus management.
+*/
+export function createButton(
+  {
+    editor, commandName, plugin, icon, label, keystroke
+  }: {
+    editor: Editor;
+    commandName: string;
+    icon: string;
+    label: string;
+    plugin: Plugin;
+    keystroke?: string;
+}
+): ButtonView {
+    const command = editor.commands.get(commandName) as AttributeCommand
+    const button = new ButtonView(editor.locale)
+    button.set({
+      label,
+      icon,
+      keystroke,
+      isToggleable: true,
+      tooltip: true
+    })
+    button.bind('isEnabled').to(command, 'isEnabled')
+    button.bind('isOn').to(command, 'value')
+
+    plugin.listenTo(button, 'execute', () => {
+      editor.execute(commandName)
+    })
+    return button
+}


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6519

You can't add custom plugins to the pre-built EditorClassic, so I recreated it using CKEditor's interactive builder. I made a plugin for each button that toggles a style so that if you trigger the click event using a mouse, focus will stay on the button.
 
I also added custom focus indicators and border styles to match the Vuetify components.