### PR TITLE
BOAC-6679: marks note comments read/unread

### DIFF
--- a/boac/api/decorators.py
+++ b/boac/api/decorators.py
@@ -71,7 +71,6 @@ def advising_data_access_required(func):
         if is_authorized or _api_key_ok():
             return func(*args, **kw)
         else:
-            app.logger.error(current_user.to_api_json())
             app.logger.warning(f'Unauthorized request to {request.path}')
             return login_manager.unauthorized()
     return _advising_data_access_required

--- a/boac/api/notes_controller.py
+++ b/boac/api/notes_controller.py
@@ -44,6 +44,7 @@ from boac.api.util import (
     get_note_topics_from_http_post,
     get_template_attachment_ids_from_http_post,
     is_valid_date_string,
+    update_note_comment,
     validate_note_contact_type,
 )
 from boac.externals import data_loch
@@ -84,7 +85,12 @@ def get_note(note_id):
 @app.route('/api/notes/<note_id>/mark_read', methods=['POST'])
 @advising_data_access_required
 def mark_note_read(note_id):
-    if NoteRead.find_or_create(current_user.get_id(), note_id):
+    note_ids = [note_id]
+    if is_int(note_id):
+        comments = Note.get_notes_by_parent_id(int(note_id))
+        note_ids.extend([comment.id for comment in comments])
+    reads = NoteRead.find_or_create(current_user.get_id(), note_ids)
+    if reads and len(reads):
         return tolerant_jsonify({'status': 'created'}, status=201)
     else:
         raise BadRequestError(f'Failed to mark note {note_id} as read by user {current_user.uid}')
@@ -121,61 +127,15 @@ def add_note_comment():
         raise ResourceNotFoundError('Note not found')
     pam_membership = get_department_membership_with_role(current_user, 'peer_advisor_manager')
     peer_advising_department_id = pam_membership.get('peerAdvisingDepartmentId', None) if pam_membership else None
-    comment = create_note_comment(parent_note, request.form, peer_advising_department_id)
-    note_read = NoteRead.find_or_create(current_user.get_id(), comment.id)
-    return tolerant_jsonify(get_boac_note_as_compatible_json(note=comment, note_read=note_read))
+    comment = create_note_comment(parent_note, params, peer_advising_department_id)
+    return tolerant_jsonify(get_boac_note_as_compatible_json(note=comment, note_read=True))
 
 
 @app.route('/api/note/edit_comment', methods=['POST'])
 @advising_data_access_required
 def edit_note_comment():
-    params = request.form
-    comment_id = params.get('id')
-    if not comment_id or not is_int(comment_id):
-        raise BadRequestError('Request has missing or invalid request parameters')
-    comment = Note.find_by_id(note_id=int(comment_id))
-    if not comment or not comment.parent_note_id:
-        raise ResourceNotFoundError('Note not found')
-    if not can_current_user_edit_note(comment):
-        raise ResourceNotFoundError('Note not found')
-
-    body = process_input_from_rich_text_editor(params.get('body'))
-    if not body or not body.strip():
-        raise BadRequestError('Request has missing or invalid request parameters')
-
-    delete_ids_ = params.get('deleteAttachmentIds') or []
-    delete_ids_ = delete_ids_ if isinstance(delete_ids_, list) else str(delete_ids_).split(',')
-    delete_attachment_ids = [int(id_) for id_ in delete_ids_ if is_int(id_)]
-    attachments = get_note_attachments_from_http_post(tolerate_none=True)
-    attachment_limit = app.config['NOTES_ATTACHMENTS_MAX_PER_NOTE']
-    existing_attachment_count = len(comment.attachments) - len(delete_attachment_ids)
-    if existing_attachment_count + len(attachments) > attachment_limit:
-        raise BadRequestError(f'No more than {attachment_limit} attachments may be uploaded at once.')
-
-    comment = Note.update(
-        body=body,
-        contact_type=comment.contact_type,
-        is_draft=False,
-        is_private=comment.is_private,
-        note_id=comment.id,
-        set_date=comment.set_date,
-        sid=comment.sid,
-        subject=comment.subject,
-        topics=[topic.topic for topic in comment.topics],
-        note_template_id=comment.note_template_id,
-    )
-    for attachment_id in delete_attachment_ids:
-        comment = Note.delete_attachment(
-            note_id=comment.id,
-            attachment_id=attachment_id,
-        )
-    for attachment in attachments:
-        comment = Note.add_attachment(
-            note_id=comment.id,
-            attachment=attachment,
-        )
-    note_read = NoteRead.find_or_create(current_user.get_id(), comment.id)
-    return tolerant_jsonify(get_boac_note_as_compatible_json(note=comment, note_read=note_read))
+    comment = update_note_comment(request.form)
+    return tolerant_jsonify(get_boac_note_as_compatible_json(note=comment, note_read=True))
 
 
 @app.route('/api/note/delete_comment/<comment_id>', methods=['DELETE'])
@@ -257,7 +217,7 @@ def update_note():
             topics=topics,
             note_template_id=note_template_id,
         )
-        note_read = NoteRead.find_or_create(current_user.get_id(), note_id)
+        note_read = NoteRead.find_or_create(current_user.get_id(), [note_id])
         api_json = get_boac_note_as_compatible_json(note=note, note_read=note_read)
     return tolerant_jsonify(api_json)
 
@@ -366,7 +326,7 @@ def add_attachments(note_id):
     return tolerant_jsonify(
         get_boac_note_as_compatible_json(
             note=note,
-            note_read=NoteRead.find_or_create(current_user.get_id(), note_id),
+            note_read=NoteRead.find_or_create(current_user.get_id(), [note_id]),
         ),
     )
 
@@ -386,7 +346,7 @@ def remove_attachment(note_id, attachment_id):
     return tolerant_jsonify(
         get_boac_note_as_compatible_json(
             note=note,
-            note_read=NoteRead.find_or_create(current_user.get_id(), note_id),
+            note_read=NoteRead.find_or_create(current_user.get_id(), [note_id]),
         ),
     )
 

--- a/boac/api/peer_advising_notes_controller.py
+++ b/boac/api/peer_advising_notes_controller.py
@@ -38,6 +38,7 @@ from boac.api.util import (
     get_note_attachments_from_http_post,
     get_note_author_profile_of_current_user,
     get_note_topics_from_http_post,
+    update_note_comment,
     validate_note_contact_type,
 )
 from boac.externals import data_loch
@@ -124,57 +125,15 @@ def create_peer_advising_note():
         sid=sid,
         note_template_id=note_template_id,
     )
-    NoteRead.find_or_create(note_id=note.id, viewer_id=current_user.get_id())
+    NoteRead.find_or_create(note_ids=[note.id], viewer_id=current_user.get_id())
     return tolerant_jsonify(get_boac_note_as_compatible_json(note, note_read=True))
 
 
 @app.route('/api/peer_advising/note/edit_comment', methods=['POST'])
 @peer_advisor_required
 def edit_peer_advising_note_comment():
-    params = request.form
-    comment_id = params.get('id')
-    if not comment_id or not is_int(comment_id):
-        raise BadRequestError('Request has missing or invalid request parameters')
-    comment = Note.find_by_id(note_id=int(comment_id))
-    if not comment or not comment.parent_note_id or not can_current_user_edit_note(comment):
-        raise ResourceNotFoundError('Note not found')
-    body = process_input_from_rich_text_editor(params.get('body'))
-    if not body or not body.strip():
-        raise BadRequestError('Request has missing or invalid request parameters')
-
-    delete_ids_ = params.get('deleteAttachmentIds') or []
-    delete_ids_ = delete_ids_ if isinstance(delete_ids_, list) else str(delete_ids_).split(',')
-    delete_attachment_ids = [int(id_) for id_ in delete_ids_ if is_int(id_)]
-    attachments = get_note_attachments_from_http_post(tolerate_none=True)
-    attachment_limit = app.config['NOTES_ATTACHMENTS_MAX_PER_NOTE']
-    existing_attachment_count = len(comment.attachments) - len(delete_attachment_ids)
-    if existing_attachment_count + len(attachments) > attachment_limit:
-        raise BadRequestError(f'No more than {attachment_limit} attachments may be uploaded at once.')
-
-    comment = Note.update(
-        body=body,
-        contact_type=comment.contact_type,
-        is_draft=False,
-        is_private=comment.is_private,
-        note_id=comment.id,
-        set_date=comment.set_date,
-        sid=comment.sid,
-        subject=comment.subject,
-        topics=[topic.topic for topic in comment.topics],
-        note_template_id=comment.note_template_id,
-    )
-    for attachment_id in delete_attachment_ids:
-        comment = Note.delete_attachment(
-            note_id=comment.id,
-            attachment_id=attachment_id,
-        )
-    for attachment in attachments:
-        comment = Note.add_attachment(
-            note_id=comment.id,
-            attachment=attachment,
-        )
-    note_read = NoteRead.find_or_create(current_user.get_id(), comment.id)
-    return tolerant_jsonify(get_boac_note_as_compatible_json(note=comment, note_read=note_read))
+    comment = update_note_comment(request.form)
+    return tolerant_jsonify(get_boac_note_as_compatible_json(note=comment, note_read=True))
 
 
 @app.route('/api/peer_advising/<sid>/enrollments')
@@ -224,7 +183,7 @@ def add_peer_advising_attachments(note_id):
     return tolerant_jsonify(
         get_boac_note_as_compatible_json(
             note=note,
-            note_read=NoteRead.find_or_create(user_id, note_id),
+            note_read=NoteRead.find_or_create(user_id, [note_id]),
         ),
     )
 
@@ -277,7 +236,7 @@ def remove_peer_advising_note_attachment(note_id, attachment_id):
     return tolerant_jsonify(
         get_boac_note_as_compatible_json(
             note=note,
-            note_read=NoteRead.find_or_create(current_user.get_id(), note_id),
+            note_read=NoteRead.find_or_create(current_user.get_id(), [note_id]),
         ),
     )
 
@@ -433,7 +392,7 @@ def update_peer_advising_note():
         topics=topics,
         note_template_id=note_template_id,
     )
-    note_read = NoteRead.find_or_create(current_user.get_id(), note_id)
+    note_read = NoteRead.find_or_create(current_user.get_id(), [note_id])
     api_json = get_boac_note_as_compatible_json(note=note, note_read=note_read)
     return tolerant_jsonify(api_json)
 

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -30,13 +30,13 @@ from flask import current_app as app
 from flask import request
 from flask_login import current_user
 
-from boac.api.errors import BadRequestError, UnauthorizedRequestError
+from boac.api.errors import BadRequestError, ResourceNotFoundError, UnauthorizedRequestError
 from boac.externals.data_loch import get_sis_holds
 from boac.lib.berkeley import ACADEMIC_STANDING_DESCRIPTIONS, dept_codes_where_advising
-from boac.lib.util import get_benchmarker, join_if_present, process_input_from_rich_text_editor, to_iso_format
+from boac.lib.util import get_benchmarker, is_int, join_if_present, process_input_from_rich_text_editor, to_iso_format, utc_now
 from boac.merged import calnet
 from boac.merged.advising_appointment import get_advising_appointments
-from boac.merged.advising_note import can_current_user_access_note, get_advising_notes, note_to_compatible_json
+from boac.merged.advising_note import can_current_user_access_note, can_current_user_edit_note, get_advising_notes, note_to_compatible_json
 from boac.merged.calnet import get_calnet_user_for_uid
 from boac.merged.cohort_filter_options import PROTECTED_COHORT_FILTERS_COENG, PROTECTED_COHORT_FILTERS_UWASC, CohortFilterOptions
 from boac.merged.sis_terms import current_term_id
@@ -165,7 +165,7 @@ def create_note_comment(parent_note, params, peer_advising_department_id=None):
     author = get_note_author_profile_of_current_user()
     if not author['author_role']:
         raise UnauthorizedRequestError('Unauthorized.')
-    return Note.create(
+    comment = Note.create(
         **author,
         attachments=attachments,
         body=body,
@@ -175,7 +175,57 @@ def create_note_comment(parent_note, params, peer_advising_department_id=None):
         sid=parent_note.sid,
         subject='',
     )
+    NoteRead.delete_for_note(parent_note.id, except_viewer_id=current_user.get_id())
+    NoteRead.find_or_create(viewer_id=current_user.get_id(), note_ids=[comment.id])
+    return comment
 
+
+def update_note_comment(params):
+    comment_id = params.get('id')
+    if not comment_id or not is_int(comment_id):
+        raise BadRequestError('Request has missing or invalid request parameters')
+    comment = Note.find_by_id(note_id=int(comment_id))
+    if not comment or not comment.parent_note_id or not can_current_user_edit_note(comment):
+        raise ResourceNotFoundError('Note not found')
+    body = process_input_from_rich_text_editor(params.get('body'))
+    if not body or not body.strip():
+        raise BadRequestError('Request has missing or invalid request parameters')
+
+    delete_ids_ = params.get('deleteAttachmentIds') or []
+    delete_ids_ = delete_ids_ if isinstance(delete_ids_, list) else str(delete_ids_).split(',')
+    delete_attachment_ids = [int(id_) for id_ in delete_ids_ if is_int(id_)]
+    attachments = get_note_attachments_from_http_post(tolerate_none=True)
+    attachment_limit = app.config['NOTES_ATTACHMENTS_MAX_PER_NOTE']
+    existing_attachment_count = len(comment.attachments) - len(delete_attachment_ids)
+    if existing_attachment_count + len(attachments) > attachment_limit:
+        raise BadRequestError(f'No more than {attachment_limit} attachments may be uploaded at once.')
+
+    comment = Note.update(
+        body=body,
+        contact_type=comment.contact_type,
+        is_draft=False,
+        is_private=comment.is_private,
+        note_id=comment.id,
+        set_date=comment.set_date,
+        sid=comment.sid,
+        subject=comment.subject,
+        topics=[topic.topic for topic in comment.topics],
+        note_template_id=comment.note_template_id,
+        updated_at=utc_now(),
+    )
+    for attachment_id in delete_attachment_ids:
+        comment = Note.delete_attachment(
+            note_id=comment.id,
+            attachment_id=attachment_id,
+        )
+    for attachment in attachments:
+        comment = Note.add_attachment(
+            note_id=comment.id,
+            attachment=attachment,
+        )
+    NoteRead.delete_for_note(comment.id, except_viewer_id=current_user.get_id())
+    NoteRead.delete_for_note(comment.parent_note_id, except_viewer_id=current_user.get_id())
+    return comment
 
 def put_notifications(student):
     sid = student['sid']

--- a/boac/lib/util.py
+++ b/boac/lib/util.py
@@ -27,7 +27,7 @@ import inspect
 import re
 import string
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from html.parser import HTMLParser
 
 import pytz
@@ -198,7 +198,7 @@ def unix_timestamp_to_localtime(epoch):
 
 
 def utc_now():
-    return datetime.utcnow().replace(tzinfo=pytz.utc)
+    return datetime.now(UTC).replace(tzinfo=pytz.utc)
 
 
 def utc_timestamp_to_localtime(_str):

--- a/boac/merged/advising_note.py
+++ b/boac/merged/advising_note.py
@@ -607,7 +607,7 @@ def note_to_compatible_json(
         attachments=None,
         note_read=False,
 ):
-    # We have legacy notes and notes created via BOAC. The following sets a standard for the front-end.
+    # We have legacy notes and notes created via BOA. The following sets a standard for the front-end.
     omit_note_body = note.get('is_private') and not current_user.can_access_private_notes
     data_source = note.get('data_source') if note.get('eform_id') else None
     return {
@@ -632,7 +632,7 @@ def note_to_compatible_json(
         'subcategory': note.get('note_subcategory'),
         'subject': note.get('subject'),
         'topics': topics,
-        'updatedAt': resolve_sis_updated_at(note),
+        'updatedAt': to_iso_format(note.get('updated_at')) if note.get('parent_note_id') else resolve_sis_updated_at(note),
         'updatedBy': note.get('updated_by'),
     }
 

--- a/boac/models/note.py
+++ b/boac/models/note.py
@@ -609,6 +609,7 @@ class Note(Base):
             template_attachment_ids=(),
             topics=(),
             note_template_id=None,
+            updated_at=None,
     ):
         note = cls.find_by_id(note_id=note_id)
 
@@ -631,6 +632,8 @@ class Note(Base):
                         note_ids=[note.id],
                         s3_path=template_attachment.path_to_attachment,
                     )
+            if updated_at:
+                note.updated_at = updated_at
             std_commit()
             db.session.refresh(note)
 
@@ -747,8 +750,8 @@ class Note(Base):
         sql = f"""
             SELECT id FROM notes
             WHERE deleted_at IS NULL
-                AND sid = :sid
-                {'AND is_draft IS FALSE' if exclude_draft_notes else ''}
+              AND sid = :sid
+              {'AND is_draft IS FALSE' if exclude_draft_notes else ''}
         """
         results = db.session.execute(text(sql), {'sid': sid})
         note_ids = [row['id'] for row in results.mappings()]

--- a/boac/models/note_read.py
+++ b/boac/models/note_read.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from datetime import datetime
 
-from sqlalchemy import text
+from sqlalchemy import and_, text
 
 from boac import db, std_commit
 
@@ -48,22 +48,37 @@ class NoteRead(db.Model):
         self.note_id = note_id
 
     @classmethod
-    def find_or_create(cls, viewer_id, note_id):
-        note_id = str(note_id)
-        sql = """
-            INSERT INTO notes_read (created_at, note_id, viewer_id) VALUES (now(), :note_id, :viewer_id)
-            ON CONFLICT DO NOTHING;
-        """
-        db.session.execute(text(sql), {
-            'note_id': note_id,
-            'viewer_id': viewer_id,
-        })
+    def delete_for_note(cls, note_id, except_viewer_id=None):
+        criteria = [
+            cls.note_id == str(note_id),
+        ]
+        if except_viewer_id:
+            criteria.append(cls.viewer_id != except_viewer_id)
+
+        for row in cls.query.filter(and_(*criteria)).all():
+            db.session.delete(row)
         std_commit()
-        return cls.query.filter(cls.viewer_id == viewer_id, cls.note_id == note_id).first()
+
+    @classmethod
+    def find_or_create(cls, viewer_id, note_ids):
+        params = {
+            'viewer_id': viewer_id,
+        }
+        values = []
+        for index, note_id in enumerate(note_ids):
+            values.append(f'(now(), :note_id_{index}, :viewer_id)')
+            params[f'note_id_{index}'] = note_id
+
+        sql = f"""INSERT INTO notes_read (created_at, note_id, viewer_id) VALUES
+                  {', '.join(values)}
+            ON CONFLICT DO NOTHING;"""
+        db.session.execute(text(sql), params)
+        std_commit()
+        return cls.query.filter(NoteRead.viewer_id == viewer_id, NoteRead.note_id.in_([str(note_id) for note_id in note_ids])).all()
 
     @classmethod
     def get_notes_read_by_user(cls, viewer_id, note_ids):
-        return cls.query.filter(NoteRead.viewer_id == viewer_id, NoteRead.note_id.in_(note_ids)).all()
+        return cls.query.filter(NoteRead.viewer_id == viewer_id, NoteRead.note_id.in_([str(note_id) for note_id in note_ids])).all()
 
     @classmethod
     def when_user_read_note(cls, viewer_id, note_id):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ import boac.factory
 from boac import std_commit
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.note import Note
+from boac.models.note_read import NoteRead
 from boac.models.note_template import NoteTemplate
 from boac.models.note_template_attachment import NoteTemplateAttachment
 from boac.models.peer_advising_department import PeerAdvisingDepartment
@@ -283,8 +284,69 @@ def mock_advising_note(app, db):
         topics=['collaborative synergies', 'integrated architectures', 'vertical solutions', 'Other / Reason not listed'],
     )
     Note.refresh_search_index()
+    std_commit(allow_test_environment=True)
     yield note
     Note.delete(note_id=note.id)
+    Note.refresh_search_index()
+    std_commit(allow_test_environment=True)
+
+
+@pytest.fixture
+def mock_advising_note_with_comments(app, db, fake_auth, mock_advising_note):
+    """Create advising note with comments."""
+    asc_advisor_uid = '1081940'
+    ce3_advisor_uid = '2525'
+
+    # Add a comment from the note author
+    fake_auth.login(mock_advising_note.author_uid)
+    author_comment = Note.create(
+        author_uid=mock_advising_note.author_uid,
+        author_name='COE Add Visor',
+        author_role='advisor',
+        author_dept_codes=['UWASC'],
+        sid=mock_advising_note.sid,
+        body='A comment from the note author.',
+        parent_note_id=mock_advising_note.id,
+        subject='',
+    )
+    db.session.add(author_comment)
+    logout_user()
+
+    # Add a comment from an advisor in the same department
+    fake_auth.login(asc_advisor_uid)
+    dept_comment = Note.create(
+        author_uid=asc_advisor_uid,
+        author_name='Milt Deacon',
+        author_role='advisor',
+        author_dept_codes=['UWASC'],
+        sid=mock_advising_note.sid,
+        body='A comment from an advisor in the author\'s department.',
+        parent_note_id=mock_advising_note.id,
+        subject='',
+    )
+    db.session.add(dept_comment)
+    logout_user()
+
+    # Add a comment from an advisor in a different department
+    fake_auth.login(ce3_advisor_uid)
+    comment = Note.create(
+        author_uid=ce3_advisor_uid,
+        author_name='Grigsby Columbo',
+        author_role='advisor',
+        author_dept_codes=['ZCEEE'],
+        sid=mock_advising_note.sid,
+        body='A comment from an advisor in a different department.',
+        parent_note_id=mock_advising_note.id,
+        subject='',
+    )
+    db.session.add(comment)
+    logout_user()
+
+    Note.refresh_search_index()
+    std_commit(allow_test_environment=True)
+    yield Note.find_by_id(note_id=mock_advising_note.id)
+
+    Note.delete(note_id=mock_advising_note.id)
     Note.refresh_search_index()
     std_commit(allow_test_environment=True)
 
@@ -336,182 +398,6 @@ def mock_note_template(app, db):
             yield NoteTemplate.find_by_id(note_template.id)
 
             NoteTemplate.delete(note_template_id=note_template.id)
-
-
-@pytest.fixture
-def mock_private_advising_note(app, db):
-    """Create a private advising note with attachment (mock s3)."""
-    note = _create_mock_note(
-        app=app,
-        attachment='fixtures/mock_advising_note_attachment_1.txt',
-        author_dept_codes=['ZCEEE'],
-        author_uid='2525',
-        db=db,
-        is_private=True,
-    )
-    yield note
-    Note.delete(note_id=note.id)
-    std_commit(allow_test_environment=True)
-
-
-@pytest.fixture
-def user_factory(app, db):
-    def _user_factory(
-            automate_degree_progress_permission=None,
-            can_access_canvas_data=True,
-            dept_codes=None,
-            degree_progress_permission=None,
-            has_calnet_record=True,
-            is_admin=False,
-    ):
-        return _create_user(
-            app=app,
-            automate_degree_progress_permission=automate_degree_progress_permission,
-            can_access_canvas_data=can_access_canvas_data,
-            db=db,
-            degree_progress_permission=degree_progress_permission,
-            dept_codes=dept_codes or ['COENG'],
-            has_calnet_record=has_calnet_record,
-            is_admin=is_admin,
-        )
-    return _user_factory
-
-
-def pytest_itemcollected(item):
-    """Print docstrings during test runs for more readable output."""
-    par = item.parent.obj
-    node = item.obj
-    pref = par.__doc__.strip() if par.__doc__ else par.__class__.__name__
-    suf = node.__doc__.strip() if node.__doc__ else node.__name__
-    if pref or suf:
-        item._nodeid = ' '.join((pref, suf))
-
-
-def _create_mock_note(
-        app,
-        attachment,
-        author_dept_codes,
-        author_uid,
-        db,
-        is_draft=False,
-        is_private=False,
-        topics=(),
-):
-    with mock_advising_note_s3_bucket(app):
-        base_dir = app.config['BASE_DIR']
-        attachment = f'{base_dir}/{attachment}'
-        with open(attachment, 'r') as file:
-            note = Note.create(
-                attachments=[
-                    {
-                        'name': attachment.rsplit('/', 1)[-1],
-                        'byte_stream': file.read(),
-                    },
-                ],
-                author_uid=author_uid,
-                author_name='Joni Mitchell CC',
-                author_role='Director',
-                author_dept_codes=author_dept_codes,
-                body="""
-                    My darling dime store thief, in the War of Independence
-                    Rock 'n Roll rang sweet as victory, under neon signs
-                """,
-                is_draft=is_draft,
-                is_private=is_private,
-                sid='11667051',
-                subject='In France they kiss on main street',
-                topics=topics,
-            )
-            db.session.add(note)
-            std_commit(allow_test_environment=True)
-            return note
-
-
-def _create_user(
-        app,
-        automate_degree_progress_permission,
-        can_access_canvas_data,
-        db,
-        dept_codes,
-        degree_progress_permission,
-        has_calnet_record,
-        is_admin,
-):
-    from sqlalchemy import create_engine
-    from sqlalchemy.sql import text
-
-    from boac.models.json_cache import insert_row as insert_in_json_cache
-    from boac.models.university_dept import UniversityDept
-    from boac.models.university_dept_member import UniversityDeptMember
-
-    uid = str(round(time.time() * 1000))
-    csid = datetime.now().strftime('%H%M%S%f')
-    data_loch_test_data = [DATA_LOCH_TEST_DATA_BY_DEPT[dept_code] for dept_code in dept_codes]
-    first_name = ''.join(random.choices(string.ascii_uppercase, k=6))
-    last_name = ''.join(random.choices(string.ascii_uppercase, k=6))
-
-    if data_loch_test_data:
-        sql = ''
-        for data_loch_row in data_loch_test_data:
-            def _to_sql_value(value):
-                return 'NULL' if value is None else f"'{value}'"
-
-            advisor_attributes = data_loch_row['advisor_attributes']
-            advisor_role = data_loch_row['advisor_role']
-            sql += f"""
-                INSERT INTO boac_advisor.advisor_attributes
-                (sid, uid, first_name, last_name, title, dept_code, email, campus_email)
-                VALUES
-                (
-                    '{csid}', '{uid}', '{first_name}', '{last_name}', 'Academic Advisor',
-                    {_to_sql_value(advisor_attributes['dept_code'])}, NULL, '{uid}@berkeley.edu'
-                );
-                INSERT INTO boac_advisor.advisor_roles
-                (sid, uid, advisor_type_code, advisor_type, instructor_type_code, instructor_type, academic_program_code, academic_program, cs_permissions)
-                VALUES
-                (
-                    '{csid}', '{uid}', {_to_sql_value(advisor_role['advisor_type_code'])}, 'College Advisor', 'ADV', 'Advisor Only',
-                    {_to_sql_value(advisor_role['academic_program_code'])},
-                    {_to_sql_value(advisor_role['academic_program_description'])},
-                    {_to_sql_value(advisor_role['cs_permissions'])}
-                );
-            """  # noqa: E501
-        with create_engine(app.config['DATA_LOCH_RDS_URI']).connect() as conn:
-            conn.execute(text(sql))
-            conn.commit()
-
-    if has_calnet_record:
-        insert_in_json_cache(
-            f'calnet_user_for_uid_{uid}',
-            {
-                'uid': uid,
-                'csid': csid,
-                'firstName': first_name,
-                'lastName': last_name,
-                'name': f'{first_name} {last_name}',
-            },
-        )
-    is_coe = 'COENG' in dept_codes
-    authorized_user = AuthorizedUser(
-        automate_degree_progress_permission=is_coe if automate_degree_progress_permission is None else automate_degree_progress_permission,
-        can_access_canvas_data=can_access_canvas_data,
-        created_by='0',
-        degree_progress_permission=degree_progress_permission,
-        is_admin=is_admin,
-        uid=uid,
-    )
-    db.session.add(authorized_user)
-    for dept_code in dept_codes:
-        university_dept = UniversityDept.find_by_dept_code(dept_code)
-        UniversityDeptMember.create_or_update_membership(
-            university_dept_id=university_dept.id,
-            authorized_user_id=authorized_user.id,
-            role='advisor',
-            automate_membership=True,
-        )
-
-    std_commit(allow_test_environment=True)
-    return authorized_user
 
 
 @pytest.fixture
@@ -601,20 +487,22 @@ def mock_navcal_peer_advising_note(fake_auth, db):
 @pytest.fixture
 def mock_navcal_peer_advising_note_with_comments(fake_auth, db, mock_navcal_peer_advising_note):
     """Create a NAVCAL Peer Advising Note with comments."""
-    peer_advisor_author_uid = '1133400'
-    advisor_uid = '2525'
-    foreign_dept_advisor_uid = '1133399'
+    navcal_peer_advisor_author_uid = '1133400'
+    navcal_peer_advisor_uid = '188444'
+    navcal_peer_advising_manager_uid = '2525'
+    mech_eng_peer_advising_manager_uid = '1133399'
+    non_pam_advisor_uid = '242881'
     navcal_department = PeerAdvisingDepartment.get_department_by_name('NAVCAL')
     mech_eng_department = PeerAdvisingDepartment.get_department_by_name('Mechanical Engineering')
 
-    # Add a comment from a peer advisor
-    fake_auth.login(peer_advisor_author_uid)
+    # Add a comment from the note author
+    fake_auth.login(navcal_peer_advisor_author_uid)
     peer_comment = Note.create(
-        author_uid=peer_advisor_author_uid,
+        author_uid=navcal_peer_advisor_author_uid,
         author_name='Peer',
         author_role='peer_advisor',
         author_dept_codes=[],
-        sid='9000000000',
+        sid=mock_navcal_peer_advising_note.sid,
         body='A comment from a peer.',
         parent_note_id=mock_navcal_peer_advising_note.id,
         peer_advising_department_id=navcal_department.id,
@@ -623,15 +511,15 @@ def mock_navcal_peer_advising_note_with_comments(fake_auth, db, mock_navcal_peer
     db.session.add(peer_comment)
     logout_user()
 
-    # Add a comment from an advisor in the same department
-    fake_auth.login(advisor_uid)
+    # Add a comment from another peer advisor
+    fake_auth.login(navcal_peer_advisor_uid)
     peer_comment = Note.create(
-        author_uid=advisor_uid,
-        author_name='Grigsby Columbo',
-        author_role='peer_advisor_manager',
+        author_uid=navcal_peer_advisor_uid,
+        author_name='Peer',
+        author_role='peer_advisor',
         author_dept_codes=[],
-        sid='9000000000',
-        body='A comment from the advisor.',
+        sid=mock_navcal_peer_advising_note.sid,
+        body='A comment from a peer.',
         parent_note_id=mock_navcal_peer_advising_note.id,
         peer_advising_department_id=navcal_department.id,
         subject='',
@@ -639,20 +527,52 @@ def mock_navcal_peer_advising_note_with_comments(fake_auth, db, mock_navcal_peer
     db.session.add(peer_comment)
     logout_user()
 
-    # Add a comment from an advisor in a different department
-    fake_auth.login(foreign_dept_advisor_uid)
-    peer_comment = Note.create(
-        author_uid=foreign_dept_advisor_uid,
+    # Add a comment from a Peer Advising Manager in the same department
+    fake_auth.login(navcal_peer_advising_manager_uid)
+    dept_advisor_comment = Note.create(
+        author_uid=navcal_peer_advising_manager_uid,
+        author_name='Grigsby Columbo',
+        author_role='peer_advisor_manager',
+        author_dept_codes=[],
+        sid=mock_navcal_peer_advising_note.sid,
+        body='A comment from the advisor.',
+        parent_note_id=mock_navcal_peer_advising_note.id,
+        peer_advising_department_id=navcal_department.id,
+        subject='',
+    )
+    db.session.add(dept_advisor_comment)
+    logout_user()
+
+    # Add a comment from Peer Advising Manager in a different department
+    fake_auth.login(mech_eng_peer_advising_manager_uid)
+    advisor_comment = Note.create(
+        author_uid=mech_eng_peer_advising_manager_uid,
         author_name='Joni Mitchell',
         author_role='peer_advisor_manager',
         author_dept_codes=[],
-        sid='9000000000',
+        sid=mock_navcal_peer_advising_note.sid,
         body='A comment from a different department.',
         parent_note_id=mock_navcal_peer_advising_note.id,
         peer_advising_department_id=mech_eng_department.id,
         subject='',
     )
-    db.session.add(peer_comment)
+    db.session.add(advisor_comment)
+    logout_user()
+
+    # Add a comment from non-Peer Advising Manager
+    fake_auth.login(non_pam_advisor_uid)
+    advisor_comment = Note.create(
+        author_uid=non_pam_advisor_uid,
+        author_name='Joni Mitchell',
+        author_role='peer_advisor_manager',
+        author_dept_codes=[],
+        sid=mock_navcal_peer_advising_note.sid,
+        body='A comment from a different department.',
+        parent_note_id=mock_navcal_peer_advising_note.id,
+        peer_advising_department_id=None,
+        subject='',
+    )
+    db.session.add(advisor_comment)
     logout_user()
 
     std_commit(allow_test_environment=True)
@@ -662,3 +582,180 @@ def mock_navcal_peer_advising_note_with_comments(fake_auth, db, mock_navcal_peer
     std_commit(allow_test_environment=True)
 
 
+@pytest.fixture
+def mock_private_advising_note(app, db):
+    """Create a private advising note with attachment (mock s3)."""
+    note = _create_mock_note(
+        app=app,
+        attachment='fixtures/mock_advising_note_attachment_1.txt',
+        author_dept_codes=['ZCEEE'],
+        author_uid='2525',
+        db=db,
+        is_private=True,
+    )
+    yield note
+    Note.delete(note_id=note.id)
+    std_commit(allow_test_environment=True)
+
+
+@pytest.fixture
+def user_factory(app, db):
+    def _user_factory(
+            automate_degree_progress_permission=None,
+            can_access_canvas_data=True,
+            dept_codes=None,
+            degree_progress_permission=None,
+            has_calnet_record=True,
+            is_admin=False,
+    ):
+        return _create_user(
+            app=app,
+            automate_degree_progress_permission=automate_degree_progress_permission,
+            can_access_canvas_data=can_access_canvas_data,
+            db=db,
+            degree_progress_permission=degree_progress_permission,
+            dept_codes=dept_codes or ['COENG'],
+            has_calnet_record=has_calnet_record,
+            is_admin=is_admin,
+        )
+    return _user_factory
+
+
+def pytest_itemcollected(item):
+    """Print docstrings during test runs for more readable output."""
+    par = item.parent.obj
+    node = item.obj
+    pref = par.__doc__.strip() if par.__doc__ else par.__class__.__name__
+    suf = node.__doc__.strip() if node.__doc__ else node.__name__
+    if pref or suf:
+        item._nodeid = ' '.join((pref, suf))
+
+
+def _create_mock_note(
+        app,
+        attachment,
+        author_dept_codes,
+        author_uid,
+        db,
+        is_draft=False,
+        is_private=False,
+        topics=(),
+):
+    with mock_advising_note_s3_bucket(app):
+        base_dir = app.config['BASE_DIR']
+        attachment = f'{base_dir}/{attachment}'
+        with open(attachment, 'r') as file:
+            note = Note.create(
+                attachments=[
+                    {
+                        'name': attachment.rsplit('/', 1)[-1],
+                        'byte_stream': file.read(),
+                    },
+                ],
+                author_uid=author_uid,
+                author_name='Joni Mitchell CC',
+                author_role='Director',
+                author_dept_codes=author_dept_codes,
+                body="""
+                    My darling dime store thief, in the War of Independence
+                    Rock 'n Roll rang sweet as victory, under neon signs
+                """,
+                is_draft=is_draft,
+                is_private=is_private,
+                sid='11667051',
+                subject='In France they kiss on main street',
+                topics=topics,
+            )
+            author_id = AuthorizedUser.get_id_per_uid(author_uid)
+            note_reads = NoteRead.find_or_create(author_id, [note.id])
+            db.session.add(note)
+            db.session.add(note_reads[0])
+            std_commit(allow_test_environment=True)
+            return note
+
+
+def _create_user(
+        app,
+        automate_degree_progress_permission,
+        can_access_canvas_data,
+        db,
+        dept_codes,
+        degree_progress_permission,
+        has_calnet_record,
+        is_admin,
+):
+    from sqlalchemy import create_engine
+    from sqlalchemy.sql import text
+
+    from boac.models.json_cache import insert_row as insert_in_json_cache
+    from boac.models.university_dept import UniversityDept
+    from boac.models.university_dept_member import UniversityDeptMember
+
+    uid = str(round(time.time() * 1000))
+    csid = datetime.now().strftime('%H%M%S%f')
+    data_loch_test_data = [DATA_LOCH_TEST_DATA_BY_DEPT[dept_code] for dept_code in dept_codes]
+    first_name = ''.join(random.choices(string.ascii_uppercase, k=6))
+    last_name = ''.join(random.choices(string.ascii_uppercase, k=6))
+
+    if data_loch_test_data:
+        sql = ''
+        for data_loch_row in data_loch_test_data:
+            def _to_sql_value(value):
+                return 'NULL' if value is None else f"'{value}'"
+
+            advisor_attributes = data_loch_row['advisor_attributes']
+            advisor_role = data_loch_row['advisor_role']
+            sql += f"""
+                INSERT INTO boac_advisor.advisor_attributes
+                (sid, uid, first_name, last_name, title, dept_code, email, campus_email)
+                VALUES
+                (
+                    '{csid}', '{uid}', '{first_name}', '{last_name}', 'Academic Advisor',
+                    {_to_sql_value(advisor_attributes['dept_code'])}, NULL, '{uid}@berkeley.edu'
+                );
+                INSERT INTO boac_advisor.advisor_roles
+                (sid, uid, advisor_type_code, advisor_type, instructor_type_code, instructor_type, academic_program_code, academic_program, cs_permissions)
+                VALUES
+                (
+                    '{csid}', '{uid}', {_to_sql_value(advisor_role['advisor_type_code'])}, 'College Advisor', 'ADV', 'Advisor Only',
+                    {_to_sql_value(advisor_role['academic_program_code'])},
+                    {_to_sql_value(advisor_role['academic_program_description'])},
+                    {_to_sql_value(advisor_role['cs_permissions'])}
+                );
+            """  # noqa: E501
+        with create_engine(app.config['DATA_LOCH_RDS_URI']).connect() as conn:
+            conn.execute(text(sql))
+            conn.commit()
+
+    if has_calnet_record:
+        insert_in_json_cache(
+            f'calnet_user_for_uid_{uid}',
+            {
+                'uid': uid,
+                'csid': csid,
+                'firstName': first_name,
+                'lastName': last_name,
+                'name': f'{first_name} {last_name}',
+            },
+        )
+    is_coe = 'COENG' in dept_codes
+    authorized_user = AuthorizedUser(
+        automate_degree_progress_permission=is_coe if automate_degree_progress_permission is None else automate_degree_progress_permission,
+        can_access_canvas_data=can_access_canvas_data,
+        created_by='0',
+        degree_progress_permission=degree_progress_permission,
+        is_admin=is_admin,
+        uid=uid,
+    )
+    db.session.add(authorized_user)
+    for dept_code in dept_codes:
+        university_dept = UniversityDept.find_by_dept_code(dept_code)
+        UniversityDeptMember.create_or_update_membership(
+            university_dept_id=university_dept.id,
+            authorized_user_id=authorized_user.id,
+            role='advisor',
+            automate_membership=True,
+        )
+
+    std_commit(allow_test_environment=True)
+    return authorized_user

--- a/tests/test_api/test_notes_controller.py
+++ b/tests/test_api/test_notes_controller.py
@@ -189,7 +189,7 @@ class TestGetNote:
         assert note['body'] == note['message']
         assert note['read'] is False
         # Mark as read and re-test
-        NoteRead.find_or_create(AuthorizedUser.get_id_per_uid(admin_uid), note['id'])
+        NoteRead.find_or_create(AuthorizedUser.get_id_per_uid(admin_uid), [note['id']])
         assert _api_note_by_id(client=client, note_id=mock_coe_advising_note.id)['read'] is True
 
     def test_restrictions_on_draft_note(self, client, fake_auth, mock_note_draft):
@@ -549,9 +549,14 @@ class TestAddNoteComment:
         )
 
     def test_advisor_note_comment(self, client, fake_auth, mock_advising_note):
-        """Advisor with note access can comment on a note."""
-        body = 'A very interesting comment!'
+        """Advisor with note access can comment on a note, marking it unread for other users."""
+        # Other user reads the note
+        fake_auth.login(asc_advisor_uid)
+        _api_mark_note_read(client, mock_advising_note.id)
+
+        # This user comments on the note
         fake_auth.login(l_s_major_advisor_uid)
+        body = 'A very interesting comment!'
         api_json = self._api_add_note_comment(
             body=body,
             client=client,
@@ -561,11 +566,29 @@ class TestAddNoteComment:
         assert api_json['parentNoteId'] == mock_advising_note.id
         assert api_json['peerAdvisingDepartmentId'] is None
         assert api_json['sid'] == mock_advising_note.sid
+        # Comment marked read by its author
+        comment_author_id = AuthorizedUser.get_id_per_uid(api_json['author']['uid'])
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=comment_author_id, note_ids=[api_json['id']])
+        assert len(notes_read) == 1
+
+        # Note and comment marked unread for other user
+        asc_advisor_id = AuthorizedUser.get_id_per_uid(asc_advisor_uid)
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=asc_advisor_id, note_ids=[mock_advising_note.id, api_json['id']])
+        assert len(notes_read) == 0
+
+        # Note and comment marked unread for note author
+        note_author_id = AuthorizedUser.get_id_per_uid(mock_advising_note.author_uid)
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=note_author_id, note_ids=[mock_advising_note.id, api_json['id']])
+        assert len(notes_read) == 0
 
     def test_advisor_peer_advising_note_comment(self, client, fake_auth, mock_navcal_peer_advising_note):
-        """Advisor with note access can comment on a Peer Advising note."""
-        body = 'Comment on a NAVCAL peer advising note from an ASC advisor'
+        """Advisor with note access can comment on a Peer Advising note, marking it unread for other users."""
+        # Other user reads the note
+        fake_auth.login(l_s_major_advisor_uid)
+        _api_mark_note_read(client, mock_navcal_peer_advising_note.id)
+
         fake_auth.login(asc_advisor_uid)
+        body = 'Comment on a NAVCAL peer advising note from an ASC advisor'
         api_json = self._api_add_note_comment(
             body=body,
             client=client,
@@ -575,6 +598,20 @@ class TestAddNoteComment:
         assert api_json['parentNoteId'] == mock_navcal_peer_advising_note.id
         assert api_json['peerAdvisingDepartmentId'] is None
         assert api_json['sid'] == mock_navcal_peer_advising_note.sid
+        # Comment marked read by its author
+        comment_author_id = AuthorizedUser.get_id_per_uid(api_json['author']['uid'])
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=comment_author_id, note_ids=[api_json['id']])
+        assert len(notes_read) == 1
+
+        # Note and comment marked unread for other user
+        l_s_advisor_id = AuthorizedUser.get_id_per_uid(l_s_major_advisor_uid)
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=l_s_advisor_id, note_ids=[mock_navcal_peer_advising_note.id, api_json['id']])
+        assert len(notes_read) == 0
+
+        # Note and comment marked unread for note author
+        note_author_id = AuthorizedUser.get_id_per_uid(mock_navcal_peer_advising_note.author_uid)
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=note_author_id, note_ids=[mock_navcal_peer_advising_note.id, api_json['id']])
+        assert len(notes_read) == 0
 
     def test_pam_peer_advising_note_comment(self, client, fake_auth, mock_navcal_peer_advising_note):
         """Peer Advising Manager can comment on a Peer Advising note from the same department."""
@@ -623,6 +660,195 @@ class TestAddNoteComment:
         }
         response = client.post(
             '/api/note/add_comment',
+            buffered=True,
+            content_type='multipart/form-data',
+            data=data,
+        )
+        assert response.status_code == expected_status_code
+        return response.json
+
+
+class TestEditNoteComment:
+
+    def test_unauthorized_note_comment(self, client, fake_auth, mock_advising_note_with_comments):
+        """Unauthorized user cannot edit a note comment."""
+        comments = Note.get_notes_by_parent_id(mock_advising_note_with_comments.id)
+        for uid in [None, coe_advisor_no_advising_data_uid, l_s_director_no_advising_data_uid, ce3_navcal_peer_advisor_uid]:
+            if uid:
+                fake_auth.login(uid)
+            self._api_edit_note_comment(
+                body='Hack the body!',
+                client=client,
+                comment_id=comments[0].id,
+                parent_note_id=mock_advising_note_with_comments.id,
+                expected_status_code=401,
+            )
+
+    def test_admin_note_comment(self, client, fake_auth, mock_advising_note_with_comments):
+        """Admin user cannot edit a note comment."""
+        comments = Note.get_notes_by_parent_id(mock_advising_note_with_comments.id)
+        fake_auth.login(admin_uid)
+        self._api_edit_note_comment(
+            body='With great power comes great responsibility.',
+            client=client,
+            comment_id=comments[0].id,
+            parent_note_id=mock_advising_note_with_comments.id,
+            expected_status_code=404,
+        )
+
+    def test_advisor_nonexistent_note_comment(self, client, fake_auth, mock_advising_note_with_comments):
+        """Advisor with note access cannot edit nonexistent comment."""
+        fake_auth.login(l_s_major_advisor_uid)
+        self._api_edit_note_comment(
+            body='An orphan comment',
+            client=client,
+            comment_id=9999,
+            parent_note_id=mock_advising_note_with_comments.id,
+            expected_status_code=404,
+        )
+
+    def test_advisor_note_comment(self, client, fake_auth, mock_advising_note_with_comments):
+        """Advisor with note access can edit their own note comment, marking it unread for other users."""
+        # Other user reads the note
+        fake_auth.login(asc_advisor_uid)
+        _api_mark_note_read(client, mock_advising_note_with_comments.id)
+
+        # Comment author edits their comment
+        fake_auth.login(ce3_advisor_uid)
+        comments = Note.get_notes_by_parent_id(mock_advising_note_with_comments.id)
+        comment = next((c for c in comments if c.author_uid == ce3_advisor_uid), None)
+        body = 'A very interesting edit to this comment!'
+        api_json = self._api_edit_note_comment(
+            body=body,
+            client=client,
+            comment_id=comment.id,
+            parent_note_id=mock_advising_note_with_comments.id,
+        )
+        assert api_json['body'].strip().replace(' ', '') == body.strip().replace(' ', '')
+        assert api_json['parentNoteId'] == mock_advising_note_with_comments.id
+        assert api_json['peerAdvisingDepartmentId'] is None
+        assert api_json['sid'] == mock_advising_note_with_comments.sid
+        assert api_json['updatedAt']
+        assert api_json['createdAt'] != api_json['updatedAt']
+        # Comment marked read by its author
+        comment_author_id = AuthorizedUser.get_id_per_uid(api_json['author']['uid'])
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=comment_author_id, note_ids=[api_json['id']])
+        assert len(notes_read) == 1
+
+        # Note and comment marked unread for other user
+        asc_advisor_id = AuthorizedUser.get_id_per_uid(asc_advisor_uid)
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=asc_advisor_id, note_ids=[mock_advising_note_with_comments.id, api_json['id']])
+        assert len(notes_read) == 0
+
+        # Note and comment marked unread for note author
+        note_author_id = AuthorizedUser.get_id_per_uid(mock_advising_note_with_comments.author_uid)
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=note_author_id, note_ids=[mock_advising_note_with_comments.id, api_json['id']])
+        assert len(notes_read) == 0
+
+    def test_advisor_peer_advising_note_comment(self, client, fake_auth, mock_navcal_peer_advising_note_with_comments):
+        """Advisor with note access can edit their own comment on a Peer Advising note, marking it unread for other users."""
+        # Other user reads the note
+        fake_auth.login(asc_advisor_uid)
+        _api_mark_note_read(client, mock_navcal_peer_advising_note_with_comments.id)
+
+        fake_auth.login(l_s_major_advisor_uid)
+        comments = Note.get_notes_by_parent_id(mock_navcal_peer_advising_note_with_comments.id)
+        comment = next((c for c in comments if c.author_uid == l_s_major_advisor_uid), None)
+        body = 'Edited comment on a NAVCAL peer advising note from an CE3 advisor'
+        api_json = self._api_edit_note_comment(
+            body=body,
+            client=client,
+            comment_id=comment.id,
+            parent_note_id=mock_navcal_peer_advising_note_with_comments.id,
+        )
+        assert api_json['body'].strip().replace(' ', '') == body.strip().replace(' ', '')
+        assert api_json['parentNoteId'] == mock_navcal_peer_advising_note_with_comments.id
+        assert api_json['peerAdvisingDepartmentId'] is None
+        assert api_json['sid'] == mock_navcal_peer_advising_note_with_comments.sid
+        assert api_json['updatedAt']
+        assert api_json['createdAt'] != api_json['updatedAt']
+        # Comment marked read by its author
+        comment_author_id = AuthorizedUser.get_id_per_uid(api_json['author']['uid'])
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=comment_author_id, note_ids=[api_json['id']])
+        assert len(notes_read) == 1
+
+        # Note and comment marked unread for other user
+        asc_advisor_id = AuthorizedUser.get_id_per_uid(asc_advisor_uid)
+        notes_read = NoteRead.get_notes_read_by_user(
+            viewer_id=asc_advisor_id,
+            note_ids=[mock_navcal_peer_advising_note_with_comments.id, api_json['id']],
+        )
+        assert len(notes_read) == 0
+
+        # Note and comment marked unread for note author
+        note_author_id = AuthorizedUser.get_id_per_uid(mock_navcal_peer_advising_note_with_comments.author_uid)
+        notes_read = NoteRead.get_notes_read_by_user(
+            viewer_id=note_author_id,
+            note_ids=[mock_navcal_peer_advising_note_with_comments.id, api_json['id']],
+        )
+        assert len(notes_read) == 0
+
+    def test_pam_peer_advising_note_comment(self, client, fake_auth, mock_navcal_peer_advising_note_with_comments):
+        """Peer Advising Manager can edit their own comment on a Peer Advising note from the same department."""
+        navcal_department = PeerAdvisingDepartment.get_department_by_name('NAVCAL')
+
+        fake_auth.login(ce3_navcal_peer_advisor_manager_uid)
+        comments = Note.get_notes_by_parent_id(mock_navcal_peer_advising_note_with_comments.id)
+        comment = next((c for c in comments if c.author_uid == ce3_navcal_peer_advisor_manager_uid), None)
+        body = 'Edited comment on a NAVCAL peer advising note from a NAVCAL peer advising manager'
+        api_json = self._api_edit_note_comment(
+            body=body,
+            client=client,
+            comment_id=comment.id,
+            parent_note_id=mock_navcal_peer_advising_note_with_comments.id,
+        )
+        assert api_json['body'].strip().replace(' ', '') == body.strip().replace(' ', '')
+        assert api_json['parentNoteId'] == mock_navcal_peer_advising_note_with_comments.id
+        assert api_json['peerAdvisingDepartmentId'] == navcal_department.id
+        assert api_json['sid'] == mock_navcal_peer_advising_note_with_comments.sid
+        assert api_json['updatedAt']
+        assert api_json['createdAt'] != api_json['updatedAt']
+
+    def test_pam_cross_dept_peer_advising_note_comment(self, client, fake_auth, mock_navcal_peer_advising_note_with_comments):
+        """Peer Advising Manager can edit their own comment on a Peer Advising note from a different department."""
+        department = PeerAdvisingDepartment.get_department_by_name('Mechanical Engineering')
+
+        fake_auth.login(coe_advisor_uid)
+        comments = Note.get_notes_by_parent_id(mock_navcal_peer_advising_note_with_comments.id)
+        comment = next((c for c in comments if c.author_uid == coe_advisor_uid), None)
+        body = 'Edited comment on a NAVCAL peer advising note from a Mechanical Engineering peer advising manager'
+        api_json = self._api_edit_note_comment(
+            body=body,
+            client=client,
+            comment_id=comment.id,
+            parent_note_id=mock_navcal_peer_advising_note_with_comments.id,
+        )
+        assert api_json['body'].strip().replace(' ', '') == body.strip().replace(' ', '')
+        assert api_json['parentNoteId'] == mock_navcal_peer_advising_note_with_comments.id
+        assert api_json['peerAdvisingDepartmentId'] == department.id
+        assert api_json['sid'] == mock_navcal_peer_advising_note_with_comments.sid
+        assert api_json['updatedAt']
+        assert api_json['createdAt'] != api_json['updatedAt']
+
+
+    @classmethod
+    def _api_edit_note_comment(
+            cls,
+            body,
+            client,
+            comment_id,
+            parent_note_id,
+            attachments=None,
+            expected_status_code=200,
+    ):
+        data = {
+            'id': comment_id,
+            'parentNoteId': parent_note_id,
+            'body': body,
+            'attachments': attachments,
+        }
+        response = client.post(
+            '/api/note/edit_comment',
             buffered=True,
             content_type='multipart/form-data',
             data=data,
@@ -741,15 +967,15 @@ class TestMarkNoteRead:
 
     def test_mark_read_not_authenticated(self, client):
         """Returns 401 if not authenticated."""
-        assert client.post('/api/notes/11667051-00001/mark_read').status_code == 401
+        _api_mark_note_read(client, '11667051-00001', expected_status_code=401)
 
     def test_user_without_advising_data_access(self, client, fake_auth):
         """Denies access to a user who cannot access notes and appointments."""
         fake_auth.login(coe_advisor_no_advising_data_uid)
-        assert client.post('/api/notes/11667051-00001/mark_read').status_code == 401
+        _api_mark_note_read(client, '11667051-00001', expected_status_code=401)
 
-    def test_mark_note_read(self, client, fake_auth):
-        """Marks a note as read."""
+    def test_mark_external_note_read(self, client, fake_auth):
+        """Marks legacy notes and eForms as read."""
         fake_auth.login(coe_advisor_uid)
         all_notes_unread = _get_student_notifications(client, 61889)['note']
         assert len(all_notes_unread)
@@ -757,22 +983,16 @@ class TestMarkNoteRead:
             assert note['read'] is False
 
         # SIS notes
-        response = client.post('/api/notes/11667051-00001/mark_read')
-        assert response.status_code == 201
-        response = client.post('/api/notes/11667051-00003/mark_read')
-        assert response.status_code == 201
+        _api_mark_note_read(client, '11667051-00001')
+        _api_mark_note_read(client, '11667051-00003')
         # ASC note
-        response = client.post('/api/notes/11667051-139379/mark_read')
-        assert response.status_code == 201
+        _api_mark_note_read(client, '11667051-139379')
         # Data Science note
-        response = client.post('/api/notes/11667051-20190801112456/mark_read')
-        assert response.status_code == 201
+        _api_mark_note_read(client, '11667051-20190801112456')
         # E&I note
-        response = client.post('/api/notes/11667051-151620/mark_read')
-        assert response.status_code == 201
+        _api_mark_note_read(client, '11667051-151620')
         # SIS eForm
-        response = client.post('/api/notes/eform-10096/mark_read')
-        assert response.status_code == 201
+        _api_mark_note_read(client, 'eform-10096')
 
         notifications = _get_student_notifications(client, 61889)
         all_notes_after_read = notifications['note']
@@ -804,6 +1024,29 @@ class TestMarkNoteRead:
         assert all_eforms_after_read[1]['read'] is False
         assert all_eforms_after_read[2]['id'] == 'eform-10096'
         assert all_eforms_after_read[2]['read'] is True
+
+    def test_mark_boa_note_with_coments_read(self, client, fake_auth, mock_advising_note_with_comments):
+        """Marks a BOA note read, as well as each of its comments."""
+        fake_auth.login(coe_advisor_uid)
+        notes_unread = _get_student_notifications(client, coe_student['uid'])['note']
+        assert len(notes_unread)
+        for note in notes_unread:
+            assert note['read'] is False
+            if note['id'] == mock_advising_note_with_comments:
+              for comment in note.get['comments']:
+                  assert comment['read'] is False
+
+        _api_mark_note_read(client, mock_advising_note_with_comments.id)
+
+        notes = _get_student_notifications(client, coe_student['uid'])['note']
+        assert len(notes)
+        for note in notes:
+            if note['id'] == mock_advising_note_with_comments:
+              assert note['read'] is True
+              for comment in note.get['comments']:
+                  assert comment['read'] is True
+            else:
+                assert note['read'] is False
 
 
 class TestUpdateNotes:
@@ -1384,3 +1627,12 @@ def _api_note_attachments_upload(
         )
         assert response.status_code == expected_status_code
         return response.json
+
+def _api_mark_note_read(
+    client,
+    note_id,
+    expected_status_code=201,
+):
+    response = client.post(f'/api/notes/{note_id}/mark_read')
+    assert response.status_code == expected_status_code
+    return response.json

--- a/tests/test_api/test_peer_advising_notes_controller.py
+++ b/tests/test_api/test_peer_advising_notes_controller.py
@@ -28,6 +28,7 @@ import json
 from boac import std_commit
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.note import Note
+from boac.models.note_read import NoteRead
 from boac.models.peer_advising_department import PeerAdvisingDepartment
 from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
 from tests.util import mock_advising_note_s3_bucket
@@ -318,8 +319,7 @@ class TestPeerAdvisorAddNoteComment:
 
     @classmethod
     def setup_class(cls):
-        author_uid = ce3_navcal_peer_advisor_uid
-        peer_advisor_user_id = AuthorizedUser.get_id_per_uid(author_uid)
+        peer_advisor_user_id = AuthorizedUser.get_id_per_uid(ce3_navcal_peer_advisor_uid)
         memberships = PeerAdvisingDepartmentMember.find_peer_advising_memberships_by_user_id(peer_advisor_user_id)
         cls.ce3_navcal_peer_advising_department_id = memberships[0]['peer_advising_department_id']
 
@@ -368,6 +368,11 @@ class TestPeerAdvisorAddNoteComment:
 
     def test_peer_advisor_note_comment(self, client, fake_auth, mock_navcal_peer_advising_note):
         """Peer advisor can comment on a Peer Advising note within their department."""
+        # Peer Advising Manager reads a peer advisor's note
+        fake_auth.login(ce3_navcal_peer_advisor_manager_uid)
+        _api_mark_note_read(client, mock_navcal_peer_advising_note.id)
+
+        # Another Peer Advisor comments on the note
         body = 'A very interesting comment!'
         fake_auth.login(ce3_navcal_peer_advisor_2_uid)
         api_json = self._api_add_note_comment(
@@ -379,6 +384,23 @@ class TestPeerAdvisorAddNoteComment:
         assert api_json['parentNoteId'] == mock_navcal_peer_advising_note.id
         assert api_json['peerAdvisingDepartmentId'] == self.ce3_navcal_peer_advising_department_id
         assert api_json['sid'] == mock_navcal_peer_advising_note.sid
+        # Comment marked read by its author
+        comment_author_id = AuthorizedUser.get_id_per_uid(api_json['author']['uid'])
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=comment_author_id, note_ids=[api_json['id']])
+        assert len(notes_read) == 1
+
+        # Note and comment marked unread for Peer Advising Manager
+        manager_id = AuthorizedUser.get_id_per_uid(ce3_navcal_peer_advisor_manager_uid)
+        notes_read = NoteRead.get_notes_read_by_user(
+            viewer_id=manager_id,
+            note_ids=[mock_navcal_peer_advising_note.id, api_json['id']],
+        )
+        assert len(notes_read) == 0
+
+        # Note and comment marked unread for note author
+        note_author_id = AuthorizedUser.get_id_per_uid(mock_navcal_peer_advising_note.author_uid)
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=note_author_id, note_ids=[mock_navcal_peer_advising_note.id, api_json['id']])
+        assert len(notes_read) == 0
 
 
     @classmethod
@@ -409,8 +431,7 @@ class TestPeerAdvisorEditNoteComment:
 
     @classmethod
     def setup_class(cls):
-        author_uid = ce3_navcal_peer_advisor_uid
-        peer_advisor_user_id = AuthorizedUser.get_id_per_uid(author_uid)
+        peer_advisor_user_id = AuthorizedUser.get_id_per_uid(ce3_navcal_peer_advisor_uid)
         memberships = PeerAdvisingDepartmentMember.find_peer_advising_memberships_by_user_id(peer_advisor_user_id)
         cls.ce3_navcal_peer_advising_department_id = memberships[0]['peer_advising_department_id']
 
@@ -459,31 +480,58 @@ class TestPeerAdvisorEditNoteComment:
         comments = Note.get_notes_by_parent_id(mock_navcal_peer_advising_note_with_comments.id)
         fake_auth.login(ce3_navcal_peer_advisor_2_uid)
         for comment in comments:
-            self._api_edit_note_comment(
-                comment_id=comment.id,
-                body='A comment that has no business being here',
-                client=client,
-                parent_note_id=mock_navcal_peer_advising_note_with_comments.id,
-                expected_status_code=404,
-            )
+            if comment.author_uid != ce3_navcal_peer_advisor_2_uid:
+              self._api_edit_note_comment(
+                  comment_id=comment.id,
+                  body='A comment that has no business being here',
+                  client=client,
+                  parent_note_id=mock_navcal_peer_advising_note_with_comments.id,
+                  expected_status_code=404,
+              )
 
     def test_authorized_peer_advisor_note_comment(self, client, fake_auth, mock_navcal_peer_advising_note_with_comments):
         """Peer advisor can edit their own Peer Advising note comment."""
+        # Peer Advising Manager reads the note, marking the comment read as well
+        fake_auth.login(ce3_navcal_peer_advisor_manager_uid)
+        _api_mark_note_read(client, mock_navcal_peer_advising_note_with_comments.id)
+
+        # Comment author edits the comment
         body = 'A very interesting comment!'
         comments = Note.get_notes_by_parent_id(mock_navcal_peer_advising_note_with_comments.id)
-        fake_auth.login(ce3_navcal_peer_advisor_uid)
-        for comment in comments:
-            if comment.author_uid == ce3_navcal_peer_advisor_uid:
-                api_json = self._api_edit_note_comment(
-                    comment_id=comment.id,
-                    body=body,
-                    client=client,
-                    parent_note_id=mock_navcal_peer_advising_note_with_comments.id,
-                )
-                assert api_json['body'].strip().replace(' ', '') == body.strip().replace(' ', '')
-                assert api_json['peerAdvisingDepartmentId'] == self.ce3_navcal_peer_advising_department_id
-                assert api_json['sid'] == mock_navcal_peer_advising_note_with_comments.sid
+        fake_auth.login(ce3_navcal_peer_advisor_2_uid)
+        comment = next((c for c in comments if c.author_uid == ce3_navcal_peer_advisor_2_uid), None)
+        api_json = self._api_edit_note_comment(
+            comment_id=comment.id,
+            body=body,
+            client=client,
+            parent_note_id=mock_navcal_peer_advising_note_with_comments.id,
+        )
+        assert api_json['body'].strip().replace(' ', '') == body.strip().replace(' ', '')
+        assert api_json['peerAdvisingDepartmentId'] == self.ce3_navcal_peer_advising_department_id
+        assert api_json['sid'] == mock_navcal_peer_advising_note_with_comments.sid
+        assert api_json['updatedAt']
+        assert api_json['createdAt'] != api_json['updatedAt']
 
+        # Comment marked read by its author
+        comment_author_id = AuthorizedUser.get_id_per_uid(api_json['author']['uid'])
+        notes_read = NoteRead.get_notes_read_by_user(viewer_id=comment_author_id, note_ids=[api_json['id']])
+        assert len(notes_read) == 1
+
+        # Note and comment marked unread for Peer Advising Manager
+        manager_id = AuthorizedUser.get_id_per_uid(ce3_navcal_peer_advisor_manager_uid)
+        notes_read = NoteRead.get_notes_read_by_user(
+            viewer_id=manager_id,
+            note_ids=[mock_navcal_peer_advising_note_with_comments.id, api_json['id']],
+        )
+        assert len(notes_read) == 0
+
+        # Note and comment marked unread for note author
+        note_author_id = AuthorizedUser.get_id_per_uid(mock_navcal_peer_advising_note_with_comments.author_uid)
+        notes_read = NoteRead.get_notes_read_by_user(
+            viewer_id=note_author_id,
+            note_ids=[mock_navcal_peer_advising_note_with_comments.id, api_json['id']],
+        )
+        assert len(notes_read) == 0
 
     @classmethod
     def _api_edit_note_comment(
@@ -780,3 +828,13 @@ def _api_note_attachments_upload(
         )
         assert response.status_code == expected_status_code
         return response.json
+
+
+def _api_mark_note_read(
+    client,
+    note_id,
+    expected_status_code=201,
+):
+    response = client.post(f'/api/notes/{note_id}/mark_read')
+    assert response.status_code == expected_status_code
+    return response.json


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6679

1. When a parent note is marked "read", we should also mark each of its unread comments "read".

2. When a comment is created, it should be marked "read" for the user who created it. The note should be marked "unread" for everyone else.

3. When a comment is edited, it should be marked "unread" for everyone except the user who edited it.