### PR TITLE
BOAC-6686 - Fix issue with eform title search

### DIFF
--- a/boac/merged/advising_eform.py
+++ b/boac/merged/advising_eform.py
@@ -33,7 +33,7 @@ from boac.merged.advising_search import (
     build_comment_search_result,
     get_students_by_sid,
     merge_search_feed,
-    parse_search_phrases,
+    parse_search_phrases_for_eforms,
     resolved_comment_total_count,
     student_search_feed,
 )
@@ -62,7 +62,7 @@ def search_advising_eforms(
     benchmark = get_benchmarker('search_advising_eforms')
     benchmark('begin')
 
-    search_terms = parse_search_phrases(search_phrase)
+    search_terms = parse_search_phrases_for_eforms(search_phrase)
 
     advisor_uid = get_uid_for_csid(app, advisor_csid) if (not advisor_uid and advisor_csid) else advisor_uid
 

--- a/boac/merged/advising_search.py
+++ b/boac/merged/advising_search.py
@@ -36,6 +36,31 @@ def parse_search_phrases(search_phrase):
     return list({t.group(0) for t in re.finditer(TEXT_SEARCH_PATTERN, search_phrase) if t})
 
 
+# Display-title prefixes from advising_eform._eform_summary_text and src/lib/note.ts.
+# Tokens listed only appear in the label, not in typical SIS field values.
+_EFORM_DISPLAY_TITLE_PREFIX_STRIP = (
+    ('Career Program Plan eForm', frozenset({'Career', 'eForm'})),
+    ('Reduced Course Load eForm', frozenset({'Course', 'Load', 'eForm'})),
+    ('Late Change of Schedule Request eForm', frozenset({'Late', 'Change', 'Schedule', 'Request', 'eForm'})),
+)
+
+
+def parse_search_phrases_for_eforms(search_phrase):
+    """Drop label-only tokens when the query includes a known eForm display-title prefix."""
+    terms = parse_search_phrases(search_phrase)
+    if not terms:
+        return terms
+    phrase = str(search_phrase).replace('\u2013', ' ').replace('\u2014', ' ').lower()
+    strip_tokens = set()
+    for prefix, tokens in _EFORM_DISPLAY_TITLE_PREFIX_STRIP:
+        if prefix.lower() in phrase:
+            strip_tokens |= tokens
+    if not strip_tokens:
+        return terms
+    stripped = [term for term in terms if term not in strip_tokens]
+    return stripped or terms
+
+
 def merge_search_feed(body_feed, comment_feed, offset, limit):
     combined = body_feed + comment_feed
     combined.sort(key=lambda row: row.get('createdAt') or '', reverse=True)


### PR DESCRIPTION
Jiras: 
- https://jira-secure.berkeley.edu/browse/BOAC-6687
- https://jira-secure.berkeley.edu/browse/BOAC-4451

It turns out the UI concats the eform titles and adds its own labels, so copy and pasting an entire eform title will lead no search results. This PR ignores labels that are added on the UI as part of the search. 