### PR TITLE
BOAC-6705: restores comment attachments after canceling delete

### DIFF
--- a/src/components/comment/AdvisingComments.vue
+++ b/src/components/comment/AdvisingComments.vue
@@ -77,7 +77,7 @@
             :date="comment.createdAt"
             :include-time-of-day="comment.createdAt.length > 10"
             class="mb-2"
-            :class="{'font-weight-bold': !comment.read && comment.createdAt === comment.updatedAt}"
+            :class="{'unread-message': !comment.read && comment.createdAt === comment.updatedAt}"
           />
         </div>
         <div v-if="comment.updatedAt && comment.createdAt !== comment.updatedAt" class="pl-2">
@@ -87,7 +87,7 @@
             :date="comment.updatedAt"
             :include-time-of-day="comment.updatedAt.length > 10"
             class="mb-2"
-            :class="{'font-weight-bold': !comment.read}"
+            :class="{'unread-message': !comment.read}"
           />
         </div>
       </footer>

--- a/src/components/comment/EditComment.vue
+++ b/src/components/comment/EditComment.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-import {get, isEmpty, reject, trim} from 'lodash'
+import {clone, get, isEmpty, reject, trim} from 'lodash'
 import {onMounted, ref} from 'vue'
 import AdvisingNoteAttachments from '@/components/note/AdvisingNoteAttachments'
 import ProgressButton from '@/components/util/ProgressButton'
@@ -95,7 +95,7 @@ const isUpdatingAttachments = ref(false)
 
 onMounted(() => {
   if (props.comment) {
-    commentAttachments.value = props.comment.attachments
+    commentAttachments.value = clone(props.comment.attachments)
     commentText.value = props.comment.body
   }
 })

--- a/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
+++ b/src/components/student/profile/academic-timeline/AcademicTimelineTable.vue
@@ -135,7 +135,7 @@
               :message="message"
             />
           </div>
-          <div class="column-message" :class="{'font-weight-bold': !message.read}">
+          <div class="column-message" :class="{'unread-message': !message.read}">
             <div class="d-flex flex-column">
               <v-btn
                 v-if="isExpanded(message) && (!editModeNoteId || message.id !== editModeNoteId)"
@@ -910,6 +910,9 @@ const userCanDelete = message => {
 .message-row.expanded .academic-timeline-column-date {
   min-width: 12rem;
   width: 12rem;
+}
+.unread-message {
+  font-weight: bold;
 }
 </style>
 

--- a/tests/test_api/test_peer_advising_search_controller.py
+++ b/tests/test_api/test_peer_advising_search_controller.py
@@ -120,7 +120,7 @@ class TestPeerAdvisingNoteSearch:
         self._assert(api_json, note_count=0, student_count=0)
 
     def test_search_excludes_same_dept_non_pam_note(self, client, fake_auth, mock_ce3_advising_note):  # noqa: ARG002
-        """Does not include a peer advising note created by a non-PAM advisor in the same department."""
+        """Does not include a note created bxy a non-PAM advisor in the same department."""
         fake_auth.login(ce3_navcal_peer_advisor_uid)
         navcal_department = PeerAdvisingDepartment.get_department_by_name('NAVCAL')
         api_json = _api_search(client, 'darling', peer_advising_department_id=navcal_department.id)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6705

I also removed the bold style from unread comments when they are displayed on the PAM dashboard or peer advisor views, since notes (and their comments) only get marked read when viewed in the Academic Timeline.