### PR TITLE
BOAC-6729: on basic search, discards prior advanced search settings

### DIFF
--- a/src/components/search/AdvancedSearch.vue
+++ b/src/components/search/AdvancedSearch.vue
@@ -126,6 +126,10 @@ const search = () => {
         }
       }
       searchStore.setIsSearching(true)
+      searchStore.setIncludeAdmits(currentUser.canAccessAdmittedStudents)
+      searchStore.setIncludeCourses(currentUser.canAccessCanvasData)
+      searchStore.setIncludeNotes(currentUser.canAccessAdvisingData)
+      searchStore.setIncludeStudents(true)
       router.push(searchPage)
       addToSearchHistory(q).then(history => {
         searchStore.setSearchHistory(history)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6729

This was causing some BEA test failures when a basic search is performed after doing an advanced search with only Students and Courses selected.