### PR TITLE
BOAC-6377: fix bugs

### DIFF
--- a/boac/api/degree_progress_api_utils.py
+++ b/boac/api/degree_progress_api_utils.py
@@ -81,12 +81,13 @@ def create_batch_degree_checks(template_id, sids):
             benchmark(f"processing chunk {i // chunk_size + 1} ({len(chunk)} students)")
             chunk_results = _bulk_clone_all(
                 template,
-                sids,
+                chunk,
                 created_by,
                 categories,
                 links,
                 transfer_categories,
                 links_by_cat,
+                benchmark,
             )
             results_by_sid.update(chunk_results)
             std_commit()
@@ -214,42 +215,30 @@ def clone(
 
 
 def _bulk_clone_all(
-    template, sids, created_by, categories, links, transfer_categories, links_by_cat,
+    template, sids, created_by, categories, links, transfer_categories, links_by_cat, benchmark,
 ):
     """Accumulates all rows in memory first, then bulk-inserts per table."""
     now = datetime.now()
     dept_codes = dept_codes_where_advising(current_user.departments)
 
     # templates
+    template_mappings = [
+        {
+            "advisor_dept_codes": dept_codes,
+            "created_by": created_by,
+            "degree_name": template.degree_name,
+            "parent_template_id": template.id,
+            "student_sid": sid,
+            "updated_by": created_by,
+        }
+        for sid in sids
+    ]
     db.session.bulk_insert_mappings(
-        DegreeProgressTemplate,
-        [
-            {
-                "advisor_dept_codes": dept_codes,
-                "created_by": created_by,
-                "degree_name": template.degree_name,
-                "parent_template_id": template.id,
-                "student_sid": sid,
-                "updated_by": created_by,
-            }
-            for sid in sids
-        ],
+        DegreeProgressTemplate, template_mappings, return_defaults=True,
     )
-
     db.session.flush()
 
-    # fetch mapping
-    rows = (
-        db.session.query(
-            DegreeProgressTemplate.student_sid,
-            DegreeProgressTemplate.id,
-        )
-        .filter(DegreeProgressTemplate.student_sid.in_(sids))
-        .filter(DegreeProgressTemplate.parent_template_id == template.id)
-        .all()
-    )
-
-    sid_to_template_id = {sid: t_id for sid, t_id in rows}
+    sid_to_template_id = {m["student_sid"]: m["id"] for m in template_mappings}
 
     # unit requirements
     ur_rows, ur_index = [], []
@@ -291,6 +280,7 @@ def _bulk_clone_all(
             cat_index.append((sid, c.id))
     db.session.bulk_save_objects(cat_rows, return_defaults=True)
     db.session.flush()
+    benchmark(f"cloned {len(cat_rows)} categories")
     sid_old_cat_to_new = {key: obj.id for key, obj in zip(cat_index, cat_rows)}
 
     # fix parent relationships + category↔unit links

--- a/scripts/db/migrate/2026/20260727-BOAC-6377/degree_progress_templates_index.sql
+++ b/scripts/db/migrate/2026/20260727-BOAC-6377/degree_progress_templates_index.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS degree_progress_templates_parent_template_id_student_sid_idx
+    ON degree_progress_templates (parent_template_id, student_sid);
+
+COMMIT;

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -250,6 +250,7 @@ ALTER TABLE ONLY degree_progress_templates
     ADD CONSTRAINT degree_progress_templates_created_by_fkey FOREIGN KEY (created_by) REFERENCES authorized_users(id) ON DELETE CASCADE;
 ALTER TABLE ONLY degree_progress_templates
     ADD CONSTRAINT degree_progress_templates_updated_by_fkey FOREIGN KEY (updated_by) REFERENCES authorized_users(id) ON DELETE CASCADE;
+CREATE INDEX degree_progress_templates_parent_template_id_student_sid_idx ON degree_progress_templates (parent_template_id, student_sid);
 
 --
 

--- a/tests/test_api/test_degree_progress_student_controller.py
+++ b/tests/test_api/test_degree_progress_student_controller.py
@@ -24,6 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 import json
+import time
 from datetime import datetime
 
 import pytest
@@ -36,6 +37,7 @@ from boac.models.degree_progress_category import DegreeProgressCategory
 from boac.models.degree_progress_course import DegreeProgressCourse
 from boac.models.degree_progress_note import DegreeProgressNote
 from boac.models.degree_progress_template import DegreeProgressTemplate
+from boac.models.degree_progress_unit_requirement import DegreeProgressUnitRequirement
 
 coe_advisor_read_only_uid = '6972201'
 coe_advisor_read_write_uid = '1133399'
@@ -364,6 +366,50 @@ class TestBatchStudentDegreeChecks:
             degree_check = DegreeProgressTemplate.find_by_id(api_json[sid])
             assert degree_check
             assert degree_check.student_sid == sid
+
+
+    def test_create_batch_at_scale(self, app, client, fake_auth, mock_template):
+        """A 5000-student batch clones every student correctly and completes without timing out."""
+        fake_auth.login(coe_advisor_read_write_uid)
+        user = AuthorizedUser.find_by_uid(coe_advisor_read_write_uid)
+        DegreeProgressUnitRequirement.create(
+            created_by=user.id,
+            min_units=12,
+            name='Unit Req 1',
+            template_id=mock_template.id,
+        )
+        std_commit(allow_test_environment=True)
+
+        # The route enforces DEGREE_CHECK_BATCH_STUDENT_LIMIT (degree_progress_student_controller.py);
+        # override it here so a 5000-sid batch can get through.
+        original_limit = app.config['DEGREE_CHECK_BATCH_STUDENT_LIMIT']
+        app.config['DEGREE_CHECK_BATCH_STUDENT_LIMIT'] = 5000
+        try:
+            student_sids = [str(9300000000 + i) for i in range(5000)]
+            start = time.time()
+            api_json = self._api_batch_degree_checks(client, sids=student_sids, template_id=mock_template.id)
+            elapsed = time.time() - start
+        finally:
+            app.config['DEGREE_CHECK_BATCH_STUDENT_LIMIT'] = original_limit
+
+        assert elapsed < 120
+
+        template_ids = set()
+        for sid in student_sids:
+            assert api_json[sid]
+            degree_check = DegreeProgressTemplate.find_by_id(api_json[sid])
+            assert degree_check
+            assert degree_check.student_sid == sid
+            template_ids.add(degree_check.id)
+
+        # Every student must get their own distinct cloned template, not a stale one reused across chunks.
+        assert len(template_ids) == len(student_sids)
+
+        unit_requirements = DegreeProgressUnitRequirement.query.filter(
+            DegreeProgressUnitRequirement.template_id.in_(template_ids),
+        ).all()
+        assert len(unit_requirements) == len(student_sids)
+        assert len({ur.template_id for ur in unit_requirements}) == len(student_sids)
 
 
 class TestCreateStudentDegreeCheck:


### PR DESCRIPTION
@pauline2k  I found the bug in the function, instead of passing "chunk", I passed the entire range of sids. You mentioned in the JIRA card that it takes about 30 seconds to run a chunk, so maybe it took 30 seconds to run 2000 users. 

Other changes are minor. I added an index on degree_progress_templates, though I don't expect it to have a significant impact on performance. I can remove that change if it could cause any complications in the production database.

Also added a test to run 5000 users (it will pass if it takes less than 120s). Locally it took less than 30s but the template is really tiny. A limit of number of users were added recently in the code so I had to bypass that. 