### PR TITLE
BOAC-6668: caches alert counts for curated groups

### DIFF
--- a/boac/api/alerts_controller.py
+++ b/boac/api/alerts_controller.py
@@ -30,6 +30,7 @@ from boac.api.decorators import advisor_required
 from boac.lib.http import tolerant_jsonify
 from boac.models.alert import Alert
 from boac.models.cohort_filter import CohortFilter
+from boac.models.curated_group import CuratedGroup
 
 
 @app.route('/api/alerts/<alert_id>/dismiss')
@@ -38,4 +39,5 @@ def dismiss_alert(alert_id):
     user_id = current_user.get_id()
     Alert.dismiss(alert_id, user_id)
     CohortFilter.refresh_alert_counts_for_owner(user_id)
+    CuratedGroup.clear_cached_alert_counts_for_owner(alert_id, user_id)
     return tolerant_jsonify({'message': f'Alert {alert_id} dismissed by UID {current_user.uid}'}), 200

--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -29,8 +29,9 @@ from threading import Thread
 from flask import current_app as app
 
 from boac import std_commit
+from boac.api.util import alert_counts_for_curated_group
 from boac.externals.data_loch import get_admitted_students_by_sids, get_student_profiles, get_user_permissions_per_affiliations
-from boac.lib.util import utc_now
+from boac.lib.util import get_benchmarker, utc_now
 from boac.merged.sis_terms import all_term_ids, current_term_id
 from boac.models.alert import Alert
 from boac.models.curated_group import CuratedGroupStudent
@@ -158,8 +159,22 @@ def disable_accounts_with_no_recent_activity():
 
 
 def refresh_alerts(term_id):
+    from boac.models import json_cache
+    from boac.models.curated_group import CuratedGroup
     Alert.deactivate_all_for_term(term_id)
     Alert.update_all_for_term(term_id)
+    json_cache.clear('alert_counts_curated_group_%')
+    benchmark = get_benchmarker('alert_counts_curated_group_cache_refresh')
+    benchmark('begin')
+    new_alert_counts = []
+    for curated_group in CuratedGroup.query.filter_by(domain='default').all():
+        new_alert_counts.append(alert_counts_for_curated_group(
+            benchmark=benchmark,
+            viewer_id=curated_group.owner_id,
+            group_id=curated_group.id,
+        ))
+    benchmark('end')
+    app.logger.info(f'Cached student alert counts for {len(new_alert_counts)} curated groups')
 
 
 def refresh_calnet_attributes():

--- a/boac/api/cohort_controller.py
+++ b/boac/api/cohort_controller.py
@@ -85,32 +85,29 @@ def get_cohorts_by_dept_code(dept_code):
 def students_with_alerts(cohort_id):
     benchmark = get_benchmarker(f'cohort {cohort_id} students_with_alerts')
     benchmark('begin')
-    offset = get_param(request.args, 'offset', 0)
-    limit = get_param(request.args, 'limit', 50)
     cohort = CohortFilter.find_by_id(cohort_id)
     benchmark('fetched cohort')
     if cohort:
         cohort_owner_uid = AuthorizedUser.get_uid_per_id(cohort.owner_id)
         if can_current_user_view_cohort(cohort_owner_uid):
             cohort = cohort.to_api_json(
-                alert_limit=limit,
-                alert_offset=offset,
                 include_alerts_for_user_id=current_user.get_id(),
                 include_students=False,
             )
             _decorate_cohort(cohort)
-            students = cohort.get('alerts', [])
-            alert_sids = [s['sid'] for s in students]
-            alert_profiles = get_student_profile_summaries(alert_sids)
-            benchmark('fetched student profiles')
-            alert_profiles_by_sid = {p['sid']: p for p in alert_profiles}
-            for student in students:
-                student.update(alert_profiles_by_sid[student['sid']])
-                # The enrolled units count is the one piece of term data we want to preserve.
-                if student.get('term'):
-                    student['term'] = {'enrolledUnits': student['term'].get('enrolledUnits')}
+            alerts_by_sid = cohort.get('alerts')
+            if alerts_by_sid:
+                students_with_alerts = get_student_profile_summaries(list(alerts_by_sid.keys()))
+                benchmark('fetched student profiles')
+                for student in students_with_alerts:
+                    student['alertCount'] = alerts_by_sid[student['sid']]
+                    # The enrolled units count is the one piece of term data we want to preserve.
+                    if student.get('term'):
+                        student['term'] = {'enrolledUnits': student['term'].get('enrolledUnits')}
+            else:
+                students_with_alerts = []
             benchmark('end')
-            return tolerant_jsonify(students)
+            return tolerant_jsonify(students_with_alerts)
         else:
             raise ResourceNotFoundError(f'No cohort found with identifier: {cohort_id}')
     else:

--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -53,6 +53,18 @@ def get_section(term_id, section_id):
         raise ResourceNotFoundError(f'No section {section_id} in term {term_id}')
     student_profiles = get_course_student_profiles(term_id, section_id, offset=offset, limit=limit, featured=featured)
     section.update(student_profiles)
-    Alert.include_alert_counts_for_students(benchmark=benchmark, viewer_user_id=current_user.get_id(), group=student_profiles)
+    _include_alert_counts(student_profiles, benchmark)
     benchmark('end')
     return tolerant_jsonify(section)
+
+
+def _include_alert_counts(student_profiles, benchmark):
+    alert_counts = Alert.current_alert_counts_for_sids(
+        benchmark=benchmark,
+        viewer_id=current_user.get_id(),
+        sids=[s['sid'] for s in student_profiles.get('students', [])],
+    )
+    counts_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}
+    for student in student_profiles.get('students'):
+        sid = student['sid']
+        student['alertCount'] = counts_per_sid.get(sid) if sid in counts_per_sid else 0

--- a/boac/api/curated_group_controller.py
+++ b/boac/api/curated_group_controller.py
@@ -29,7 +29,7 @@ from flask_login import current_user
 from boac.api.csv_file_download_utils import response_with_students_csv_download
 from boac.api.decorators import advisor_required
 from boac.api.errors import BadRequestError, ForbiddenRequestError, ResourceNotFoundError
-from boac.api.util import is_unauthorized_domain
+from boac.api.util import alert_counts_for_curated_group, is_unauthorized_domain
 from boac.lib.http import tolerant_jsonify
 from boac.lib.util import get as get_param
 from boac.lib.util import get_benchmarker
@@ -39,7 +39,6 @@ from boac.merged.calnet import get_calnet_user_for_uid
 from boac.merged.sis_terms import current_term_id
 from boac.merged.student import get_student_profile_summaries
 from boac.merged.student import get_student_query_scope as get_query_scope
-from boac.models.alert import Alert
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.curated_group import CuratedGroup
 from boac.models.university_dept import UniversityDept
@@ -68,8 +67,6 @@ def get_curated_groups_by_dept_code(dept_code):
                 curated_group_owner['curatedGroups'].append(curated_group)
         # Order by owner name
         api_json = sorted(api_json, key=lambda user: user['name'] or f"UID: {user['uid']}")
-        for user in api_json:
-            user['curatedGroups'] = sorted(user['curatedGroups'], key=lambda c: c['name'])
     return tolerant_jsonify(api_json)
 
 
@@ -154,8 +151,6 @@ def download_csv(curated_group_id):
 @app.route('/api/curated_group/<curated_group_id>/students_with_alerts')
 @advisor_required
 def get_students_with_alerts(curated_group_id):
-    offset = get_param(request.args, 'offset', 0)
-    limit = get_param(request.args, 'limit', 50)
     benchmark = get_benchmarker(f'curated group {curated_group_id} students_with_alerts')
     benchmark('begin')
     curated_group = CuratedGroup.find_by_id(curated_group_id)
@@ -163,18 +158,7 @@ def get_students_with_alerts(curated_group_id):
         raise ResourceNotFoundError(f'Sorry, no curated group found with id {curated_group_id}.')
     if not _can_current_user_view_curated_group(curated_group):
         raise ForbiddenRequestError(f'Current user, {current_user.uid}, cannot view curated group {curated_group.id}')
-    students = Alert.include_alert_counts_for_students(
-        benchmark=benchmark,
-        viewer_user_id=current_user.get_id(),
-        group={'sids': CuratedGroup.get_all_sids(curated_group_id)},
-        count_only=True,
-        offset=offset,
-        limit=limit,
-    )
-    alert_count_per_sid = {}
-    for s in list(filter(lambda s: s.get('alertCount') > 0, students)):
-        sid = s.get('sid')
-        alert_count_per_sid[sid] = s.get('alertCount')
+    alert_count_per_sid = _include_alert_counts(curated_group_id, benchmark)
     sids = list(alert_count_per_sid.keys())
     benchmark('begin profile query')
     students_with_alerts = get_student_profile_summaries(sids=sids)
@@ -265,7 +249,11 @@ def _curated_group_with_complete_student_profiles(
         )
     else:
         api_json['students'] = get_student_profile_summaries(sids, term_id=term_id)
-    Alert.include_alert_counts_for_students(benchmark=benchmark, viewer_user_id=current_user.get_id(), group=api_json)
+    _include_alert_counts(
+        curated_group_id,
+        benchmark,
+        students=api_json['students'],
+    )
     benchmark('begin get_referencing_cohort_ids')
     api_json['referencingCohortIds'] = curated_group.get_referencing_cohort_ids()
     benchmark('end')
@@ -278,3 +266,20 @@ def _can_current_user_view_curated_group(curated_group):
         bool(len(AuthorizedUser.find_by_id(owner_id).department_memberships))
         and (current_user.can_access_admitted_students or curated_group.domain == 'default')
     )
+
+
+def _include_alert_counts(
+        curated_group_id,
+        benchmark,
+        students=None,
+    ):
+    alert_counts = alert_counts_for_curated_group(
+        benchmark=benchmark,
+        viewer_id=current_user.get_id(),
+        group_id=curated_group_id,
+    )
+    counts_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}
+    for student in students or []:
+        sid = student['sid']
+        student['alertCount'] = counts_per_sid.get(sid) if sid in counts_per_sid else 0
+    return counts_per_sid

--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -414,7 +414,7 @@ def _student_search(search_phrase, params, order_by):
     )
     students = student_results['students']
     sids = [s['sid'] for s in students]
-    alert_counts = Alert.current_alert_counts_for_sids(benchmark, current_user.get_id(), sids)
+    alert_counts = Alert.current_alert_counts_for_sids(benchmark, current_user.get_id(), sids=sids)
     add_alert_counts(alert_counts, students)
     benchmark('end')
     return {

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -49,11 +49,26 @@ from boac.models.comment_parent import EFORM_COMMENT_PARENT_TYPES
 from boac.models.comment_read import CommentRead
 from boac.models.curated_group import CuratedGroup
 from boac.models.degree_progress_course import ACCENT_COLOR_CODES
+from boac.models.json_cache import stow
 from boac.models.note import Note, note_contact_type_enum
 from boac.models.note_read import NoteRead
 from boac.models.peer_advising_department_member import PeerAdvisingDepartmentMember
 from boac.models.university_dept import UniversityDept
 from boac.models.user_login import UserLogin
+
+
+@stow('alert_counts_curated_group_{group_id}_user_{viewer_id}')
+def alert_counts_for_curated_group(
+    benchmark,
+    viewer_id,
+    group_id,
+):
+    return Alert.current_alert_counts_for_curated_group(
+        benchmark=benchmark,
+        viewer_id=viewer_id,
+        group_id=group_id,
+        count_only=True,
+    )
 
 
 def can_access_admitted_students(user):
@@ -365,14 +380,9 @@ def _attach_external_comments(appointments, eforms):
 
 
 def get_current_user_profile():
-    cohorts = []
-    user_id = current_user.get_id()
-    for cohort in CohortFilter.get_cohorts(user_id):
-        cohort['isOwnedByCurrentUser'] = True
-        cohorts.append(cohort)
     return {
         **current_user.to_api_json(),
-        'myCohorts': cohorts,
+        'myCohorts': get_my_cohorts(),
         'myCuratedGroups': get_my_curated_groups(),
         'myDraftNoteCount': Note.get_draft_note_count(None if current_user.is_admin else current_user.uid),
         'preferences': {
@@ -420,24 +430,35 @@ def get_note_topics_from_http_post():
     return topics if isinstance(topics, list) else list(filter(None, str(topics).split(',')))
 
 
+def get_my_cohorts():
+    benchmark = get_benchmarker('my_cohorts')
+    benchmark('begin')
+    cohorts = []
+    user_id = current_user.get_id()
+    for cohort in CohortFilter.get_cohorts(user_id):
+        cohort['isOwnedByCurrentUser'] = True
+        cohorts.append(cohort)
+    benchmark('end')
+    return cohorts
+
+
 def get_my_curated_groups():
     benchmark = get_benchmarker('my_curated_groups')
+    benchmark('begin')
     curated_groups = []
     user_id = current_user.get_id()
     for curated_group in CuratedGroup.get_curated_groups(owner_id=user_id):
-        students = [{'sid': sid} for sid in CuratedGroup.get_all_sids(curated_group.id)]
-        students_with_alerts = Alert.include_alert_counts_for_students(
+        api_json = curated_group.to_api_json(include_students=False)
+        students_with_alerts = alert_counts_for_curated_group(
             benchmark=benchmark,
-            viewer_user_id=user_id,
-            group={'students': students},
-            count_only=True,
+            viewer_id=user_id,
+            group_id=curated_group.id,
         )
         curated_groups.append({
-            **curated_group.to_api_json(include_students=False),
+            **api_json,
             'alertCount': sum(s['alertCount'] for s in students_with_alerts),
-            'sids': [student['sid'] for student in students],
-            'totalStudentCount': len(students),
         })
+    benchmark('end')
     return curated_groups
 
 

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -124,14 +124,41 @@ class Alert(Base):
             raise BadRequestError(f'No alert found for id {alert_id}')
 
     @classmethod
+    def current_alert_counts_for_curated_group(
+        cls,
+        benchmark,
+        viewer_id,
+        group_id,
+        count_only=False,
+    ):
+        query = """
+            SELECT alerts.sid, count(*) as alert_count
+            FROM student_group_members sgm
+            JOIN alerts ON sgm.sid = alerts.sid
+            LEFT JOIN alert_views
+                ON alert_views.alert_id = alerts.id
+                AND alert_views.viewer_id = :viewer_id
+            WHERE alerts.deleted_at IS NULL
+                AND alerts.key LIKE :key
+                AND sgm.student_group_id = :group_id
+                AND alert_views.dismissed_at IS NULL
+            GROUP BY alerts.sid
+            ORDER BY alert_count DESC, alerts.sid
+        """
+        params = {
+            'viewer_id': viewer_id,
+            'key': current_term_id() + '_%',
+            'group_id': group_id,
+        }
+        return cls.alert_counts_by_query(benchmark, query, params, count_only=count_only)
+
+    @classmethod
     def current_alert_counts_for_sids(
         cls,
         benchmark,
         viewer_id,
-        sids,
+        sids=None,
         count_only=False,
-        offset=None,
-        limit=None,
     ):
         query = """
             SELECT alerts.sid, count(*) as alert_count
@@ -145,16 +172,10 @@ class Alert(Base):
             GROUP BY alerts.sid
             ORDER BY alert_count DESC, alerts.sid
         """
-        if offset:
-            query += ' OFFSET :offset'
-        if limit:
-            query += ' LIMIT :limit'
         params = {
             'viewer_id': viewer_id,
             'key': current_term_id() + '_%',
             'sids': sids,
-            'offset': offset,
-            'limit': limit,
         }
         return cls.alert_counts_by_query(benchmark, query, params, count_only=count_only)
 
@@ -429,28 +450,3 @@ class Alert(Base):
         message = f'Student is no longer enrolled in the {term_name_for_sis_id(term_id)} term.'
         cls.create_or_activate(sid=sid, alert_type='withdrawal', key=key, message=message, preserve_creation_date=True)
 
-    @classmethod
-    def include_alert_counts_for_students(
-        cls,
-        benchmark,
-        viewer_user_id,
-        group,
-        count_only=False,
-        offset=None,
-        limit=None,
-    ):
-        sids = group.get('sids') if 'sids' in group else [s['sid'] for s in group.get('students', [])]
-        alert_counts = cls.current_alert_counts_for_sids(
-            benchmark,
-            viewer_user_id,
-            sids,
-            count_only=count_only,
-            offset=offset,
-            limit=limit,
-        )
-        if 'students' in group:
-            counts_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}
-            for student in group.get('students'):
-                sid = student['sid']
-                student['alertCount'] = counts_per_sid.get(sid) if sid in counts_per_sid else 0
-        return alert_counts

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -149,7 +149,7 @@ class CohortFilter(Base):
     @classmethod
     def get_cohorts(cls, user_id):
         query = text("""
-            SELECT id, domain, name, filter_criteria, alert_count, sids, student_count
+            SELECT id, domain, name, filter_criteria, alert_count, student_count
             FROM cohort_filters c
             WHERE c.owner_id = :user_id
             ORDER BY c.domain, c.name
@@ -163,7 +163,6 @@ class CohortFilter(Base):
                 'name': row['name'],
                 'criteria': row['filter_criteria'],
                 'alertCount': row['alert_count'],
-                'sids': row['sids'],
                 'totalStudentCount': row['student_count'],
             }
         return [transform(row) for row in results.mappings()]
@@ -210,20 +209,19 @@ class CohortFilter(Base):
         query = text("""
             UPDATE cohort_filters
             SET alert_count = updated_cohort_counts.alert_count
-            FROM
-            (
-                SELECT cohort_filters.id AS cohort_filter_id, count(*) AS alert_count
-                FROM alerts
-                JOIN cohort_filters
+            FROM (
+                SELECT cohort_filters.id AS cohort_filter_id,
+                sum(CASE WHEN alert_views.dismissed_at IS NULL THEN 1 ELSE 0 END) as alert_count
+                FROM cohort_filters
+                JOIN alerts
                     ON alerts.sid = ANY(cohort_filters.sids)
-                    AND alerts.key LIKE :key
-                    AND alerts.deleted_at IS NULL
-                    AND cohort_filters.owner_id = :owner_id
                 LEFT JOIN alert_views
                     ON alert_views.alert_id = alerts.id
-                    AND alert_views.viewer_id = :owner_id
-                WHERE alert_views.dismissed_at IS NULL
-                GROUP BY cohort_filters.id
+                   AND alert_views.viewer_id = cohort_filters.owner_id
+                where  cohort_filters.owner_id = :owner_id
+                AND alerts.key LIKE :key
+                AND alerts.deleted_at IS NULL
+                GROUP BY cohort_filter_id
             ) updated_cohort_counts
             WHERE cohort_filters.id = updated_cohort_counts.cohort_filter_id
         """)
@@ -279,8 +277,6 @@ class CohortFilter(Base):
         offset=0,
         limit=50,
         term_id=None,
-        alert_offset=None,
-        alert_limit=None,
         include_sids=False,
         include_students=True,
         include_profiles=False,
@@ -338,18 +334,20 @@ class CohortFilter(Base):
                     'students': results['students'],
                 })
             if include_alerts_for_user_id and self.domain == 'default':
-                alert_count_per_sid = Alert.include_alert_counts_for_students(
+                alert_counts = Alert.current_alert_counts_for_sids(
                     benchmark=benchmark,
-                    viewer_user_id=include_alerts_for_user_id,
-                    group=results,
-                    offset=alert_offset,
-                    limit=alert_limit,
+                    viewer_id=include_alerts_for_user_id,
+                    sids=results['sids'],
                 )
+                alert_count_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}
+                for student in cohort_json.get('students') or []:
+                    sid = student['sid']
+                    student['alertCount'] = alert_count_per_sid.get(sid) if sid in alert_count_per_sid else 0
                 cohort_json.update({
                     'alerts': alert_count_per_sid,
                 })
                 if self.alert_count is None:
-                    alert_count = sum(student['alertCount'] for student in alert_count_per_sid)
+                    alert_count = sum(alert_count_per_sid.values())
                     self.update_alert_count(alert_count)
                     cohort_json.update({
                         'alertCount': alert_count,

--- a/boac/models/curated_group.py
+++ b/boac/models/curated_group.py
@@ -26,9 +26,9 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from sqlalchemy import text
 
 from boac import db, std_commit
-from boac.lib.util import get_benchmarker
 from boac.merged.admitted_student import get_admitted_students_by_sids
 from boac.merged.student import query_students
+from boac.models import json_cache
 from boac.models.base import Base
 from boac.models.cohort_filter import CohortFilter
 from boac.models.db_relationships import cohort_domain_type
@@ -82,6 +82,7 @@ class CuratedGroup(Base):
             JOIN authorized_users au ON sg.owner_id = au.id
             WHERE au.uid = ANY(:uids) AND {'TRUE' if include_admitted_students else "sg.domain = 'default'"}
             GROUP BY sg.id, sg.name, au.id, sgm.sid, au.uid
+            ORDER BY sg.name
         """)
         curated_groups_by_id = {}
         for row in db.session.execute(query, {'uids': uids}).mappings():
@@ -163,6 +164,18 @@ class CuratedGroup(Base):
                 CohortFilter.delete(cohort_filter_id)
                 std_commit()
 
+    @classmethod
+    def clear_cached_alert_counts_for_owner(cls, alert_id, user_id):
+        query = """SELECT DISTINCT m.student_group_id
+                  FROM alerts a
+                  JOIN student_group_members m ON m.sid = a.sid
+                  WHERE a.id = :alert_id"""
+        params = {'alert_id': alert_id}
+        results = db.session.execute(text(query), params)
+        curated_group_ids = [row['student_group_id'] for row in results.mappings()]
+        for group_id in curated_group_ids:
+            json_cache.clear(f'alert_counts_curated_group_{group_id}_user_{user_id}')
+
     def get_referencing_cohort_ids(self):
         query = text("""SELECT
             c.id, c.filter_criteria
@@ -175,8 +188,6 @@ class CuratedGroup(Base):
         return cohort_filter_ids
 
     def to_api_json(self, include_students, order_by='last_name', offset=0, limit=50):
-        benchmark = get_benchmarker(f'CuratedGroup {self.id} to_api_json')
-        benchmark('begin')
         sids = CuratedGroupStudent.get_sids(curated_group_id=self.id)
         feed = {
             'domain': self.domain,
@@ -207,7 +218,6 @@ class CuratedGroup(Base):
                     feed['students'] = result['students']
             else:
                 feed['students'] = []
-        benchmark('end')
         return feed
 
 

--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -57,8 +57,10 @@ class JsonCache(Base):
 
 def clear(key_like):
     matches = db.session.query(JsonCache).filter(JsonCache.key.like(key_like))
-    app.logger.info(f'Will delete {matches.count()} entries matching {key_like}')
-    matches.delete(synchronize_session=False)
+    if matches.count():
+        app.logger.error(matches.all())
+        app.logger.info(f'Will delete {matches.count()} entries matching {key_like}')
+        matches.delete(synchronize_session=False)
 
 
 def stow(key_pattern, for_term=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,7 +250,7 @@ def fake_aws(app):
 
 
 @pytest.fixture
-def create_alerts(client, db_session):
+def create_alerts(client, db_session, fake_auth):
     """Create assignment and midterm grade alerts."""
     # Create three canned alerts for the current term and one for the previous term.
     from boac.models.alert import Alert
@@ -279,6 +279,8 @@ def create_alerts(client, db_session):
         message='Week 5 homework in BOSCRSR 27B is late.',
     )
     # Load our usual student of interest into the cache and generate midterm alerts from fixture data.
+    admin_uid = '177473'
+    fake_auth.login(admin_uid)
     client.get('/api/student/by_uid/61889')
     Alert.update_all_for_term(2178)
 

--- a/tests/test_api/test_alerts_controller.py
+++ b/tests/test_api/test_alerts_controller.py
@@ -23,15 +23,21 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+from boac.api.util import alert_counts_for_curated_group
+from boac.lib.util import get_benchmarker
+from boac.models import json_cache
 from boac.models.alert import Alert
+from boac.models.authorized_user import AuthorizedUser
+from boac.models.curated_group import CuratedGroup
 from tests.test_api.api_test_utils import all_cohorts_owned_by
 
 admin_uid = '2040'
 asc_advisor_uid = '1081940'
-coe_advisor = '1133399'
+coe_advisor_uid = '1133399'
 
 
 class TestAlertsController:
+    """Dismiss Alert API."""
 
     @classmethod
     def _get_alerts(cls, client, uid):
@@ -60,7 +66,7 @@ class TestAlertsController:
         assert len(advisor_1_alerts) == 4
         assert len(self._get_dismissed(advisor_1_alerts)) == 1
 
-        fake_auth.login(coe_advisor)
+        fake_auth.login(coe_advisor_uid)
         advisor_2_alerts = self._get_alerts(client, 61889)
         assert len(advisor_2_alerts) == 4
         assert len(self._get_dismissed(advisor_2_alerts)) == 0
@@ -92,16 +98,18 @@ class TestAlertsController:
         assert next((a for a in advisor_1_alerts if a['key'] == '2178_500600700'), None)
         assert len(self._get_dismissed(advisor_1_alerts)) == 0
 
-        fake_auth.login(coe_advisor)
+        fake_auth.login(coe_advisor_uid)
         advisor_2_alerts = self._get_alerts(client, 61889)
         assert len(advisor_2_alerts) == 3
         assert next((a for a in advisor_2_alerts if a['key'] == '2178_500600700'), None)
         assert len(self._get_dismissed(advisor_1_alerts)) == 0
 
-    def test_alert_dismissal_updates_cohort_alert_counts(self, db, create_alerts, fake_auth, client):  # noqa: ARG002
+    def test_alert_dismissal_updates_cohort_alert_counts(self, create_alerts, db, fake_auth, client):  # noqa: ARG002
+        """Updates alert counts for cohorts the student belongs to."""
         fake_auth.login(asc_advisor_uid)
         cohort_id = all_cohorts_owned_by(asc_advisor_uid)[0]['id']
         response = client.get(f'/api/cohort/{cohort_id}')
+        assert response.status_code == 200
         assert response.json['alertCount'] == 6
 
         alerts = self._get_alerts(client, 61889)
@@ -110,3 +118,56 @@ class TestAlertsController:
 
         response = client.get(f'/api/cohort/{cohort_id}')
         assert response.json['alertCount'] == 5
+
+    def test_cohort_single_alert_dismissal(self, create_alerts, db, fake_auth, client):  # noqa: ARG002
+        """Sets the cohort alert count to zero when the last remaining alert is dismissed."""
+        fake_auth.login(asc_advisor_uid)
+        cohort_id = all_cohorts_owned_by(asc_advisor_uid)[1]['id']
+        response = client.get(f'/api/cohort/{cohort_id}')
+        assert response.status_code == 200
+        assert response.json['alertCount'] == 1
+
+        alerts = self._get_alerts(client, 98765)
+        client.get('/api/alerts/' + str(alerts[0]['id']) + '/dismiss')
+        db.session.expire_all()
+
+        response = client.get(f'/api/cohort/{cohort_id}')
+        assert response.json['alertCount'] == 0
+
+    def test_clears_cached_curated_group_alert_counts(self, db, create_alerts, fake_auth, client):  # noqa: ARG002
+        """Clears cached alert counts for curated groups the student belongs to."""
+        fake_auth.login(coe_advisor_uid)
+        group_id = CuratedGroup.get_curated_groups_owned_by(uids=[coe_advisor_uid])[0]['id']
+        response = client.get(f'/api/curated_group/{group_id}/students_with_alerts')
+        assert response.status_code == 200
+        student = next(s for s in response.json if s['uid'] == '61889')
+        assert student['alertCount'] == 4
+
+        # Make sure alert counts for this curated group are cached
+        coe_advisor = AuthorizedUser.find_by_uid(coe_advisor_uid)
+        alert_counts_for_curated_group(
+            benchmark=get_benchmarker('test_alert_dismissal_clears_cached_curated_group_alert_counts'),
+            viewer_id=coe_advisor.id,
+            group_id=group_id,
+        )
+        cached_counts = json_cache.fetch(f'alert_counts_curated_group_{group_id}_user_{coe_advisor.id}')
+        assert cached_counts == [{'sid': '11667051', 'alertCount': 4}]
+
+        # Dismiss the alert
+        alerts = self._get_alerts(client, 61889)
+        client.get('/api/alerts/' + str(alerts[0]['id']) + '/dismiss')
+        db.session.expire_all()
+
+        # Alert counts for this curated group have been removed from cache
+        cached_counts = json_cache.fetch(f'alert_counts_curated_group_{group_id}_user_{coe_advisor.id}')
+        assert cached_counts is None
+
+        response = client.get(f'/api/curated_group/{group_id}/students_with_alerts')
+        assert response.status_code == 200
+        student = next(s for s in response.json if s['uid'] == '61889')
+        assert student['alertCount'] == 3
+
+        # Updated alert counts for this curated group are cached
+        cached_counts = json_cache.fetch(f'alert_counts_curated_group_{group_id}_user_{coe_advisor.id}')
+        assert cached_counts == [{'sid': '11667051', 'alertCount': 3}]
+

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -26,6 +26,10 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import pytest
 
 from boac import std_commit
+from boac.api.cache_utils import refresh_alerts
+from boac.api.util import alert_counts_for_curated_group
+from boac.lib.util import get_benchmarker
+from boac.models import json_cache
 from boac.models.alert import Alert
 from boac.models.authorized_user import AuthorizedUser
 from boac.models.curated_group import CuratedGroup, CuratedGroupStudent
@@ -35,21 +39,13 @@ from boac.models.university_dept_member import UniversityDeptMember
 from tests.test_api.api_test_utils import all_cohorts_owned_by
 
 admin_uid = '177473'
+asc_advisor_uid = '6446'
 coe_advisor_uid = '1022796'
 
 
 @pytest.mark.usefixtures('db_session')
 class TestCacheUtils:
-
-    def test_creates_alert_for_midterm_grade(self):
-        from boac.api.cache_utils import refresh_alerts
-        refresh_alerts(2178)
-        alerts = Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')
-        alert = next((a for a in alerts if a['alertType'] == 'midterm'), None)
-        assert alert
-        assert alert['alertType'] == 'midterm'
-        assert alert['key'] == '2178_90100'
-        assert alert['message'] == 'BURMESE 1A midpoint deficient grade of D+.'
+    """Cache Utils."""
 
     def test_update_curated_group_lists(self):
         from boac.api.cache_utils import update_curated_group_lists
@@ -84,7 +80,41 @@ class TestCacheUtils:
             assert cohort['alertCount'] >= 0
 
 
+class TestRefreshAlerts:
+    """Alerts Refresh."""
+
+    def test_creates_alert_for_midterm_grade(self):
+        """Generates alerts for non-passing midterm grades."""
+        refresh_alerts(2178)
+        alerts = Alert.current_alerts_for_sid(sid='11667051', viewer_id='2040')
+        alert = next((a for a in alerts if a['alertType'] == 'midterm'), None)
+        assert alert
+        assert alert['alertType'] == 'midterm'
+        assert alert['key'] == '2178_90100'
+        assert alert['message'] == 'BURMESE 1A midpoint deficient grade of D+.'
+
+    def test_refreshes_cached_curated_group_alert_counts(self, create_alerts):  # noqa: ARG002
+        """Updates cached alert counts for curated groups."""
+        group_id = CuratedGroup.get_curated_groups_owned_by(uids=[asc_advisor_uid])[0]['id']
+        asc_advisor = AuthorizedUser.find_by_uid(asc_advisor_uid)
+
+        # Cache alert counts for this curated group
+        alert_counts_for_curated_group(
+            benchmark=get_benchmarker('test_refreshes_cached_curated_group_alert_counts'),
+            viewer_id=asc_advisor.id,
+            group_id=group_id,
+        )
+        cached_counts = json_cache.fetch(f'alert_counts_curated_group_{group_id}_user_{asc_advisor.id}')
+        assert {'sid': '11667051', 'alertCount': 4} in cached_counts
+
+        refresh_alerts(2178)
+
+        cached_counts = json_cache.fetch(f'alert_counts_curated_group_{group_id}_user_{asc_advisor.id}')
+        assert {'sid': '11667051', 'alertCount': 2} in cached_counts
+
+
 class TestRefreshCalnetAttributes:
+    """Calnet Attributes Refresh."""
 
     def test_removes_and_restores(self):
         from boac.api.cache_utils import refresh_calnet_attributes
@@ -107,7 +137,7 @@ class TestRefreshCalnetAttributes:
 
 
 class TestRefreshCurrentTermIndex:
-    """Test current term index refresh."""
+    """Current term index refresh."""
 
     def test_refresh_current_term_index(self):
         """Deletes existing index from the cache and adds a fresh one."""
@@ -129,6 +159,7 @@ class TestRefreshCurrentTermIndex:
 
 
 class TestRefreshDepartmentMemberships:
+    """Department Memberships Refresh."""
 
     def test_adds_coe_advisors(self):
         """Adds COE advisors newly found in the loch."""

--- a/tests/test_api/test_cohort_controller.py
+++ b/tests/test_api/test_cohort_controller.py
@@ -47,6 +47,7 @@ coe_advisor_uid = '1133399'
 
 
 class TestCohortById:
+    """Cohort by ID API."""
 
     @classmethod
     def setup_class(cls):
@@ -451,6 +452,7 @@ class TestCohortById:
 
 
 class TestCohortsEveryone:
+    """Everyone's Cohorts API."""
 
     @classmethod
     def _api_cohorts_by_dept_code(cls, client, dept_code, expected_status_code=200):
@@ -503,6 +505,7 @@ class TestCohortsEveryone:
 
 
 class TestCohortCreate:
+    """Create Cohort API."""
 
     def test_create_cohort(self, client, fake_auth):
         """Creates custom cohort, owned by current user."""
@@ -718,6 +721,7 @@ class TestCohortCreate:
 
 
 class TestCohortUpdate:
+    """Update Cohort API."""
 
     @classmethod
     def _post_cohort_update(cls, client, json_data=()):
@@ -846,6 +850,7 @@ class TestCohortUpdate:
 
 
 class TestCohortDelete:
+    """Delete Cohort API."""
 
     def test_delete_cohort_not_authenticated(self, client):
         """Custom cohort deletion requires authentication."""
@@ -895,6 +900,7 @@ class TestCohortDelete:
 
 
 class TestCohortPerFilters:
+    """Cohort per Filters API."""
 
     @classmethod
     def _api_get_students_per_filters(cls, client, json_data=(), expected_status_code=200):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6668

For a user with a ton of cohorts and curated groups, this cuts the response time of `/api/profile/my` from ~33 seconds in my local environment to 15-18 seconds. The size of the response is reduced from ~900 KB to ~50 KB.

- removes the list of SIDs from each cohort in the API response because it isn't used.
- removes the LIMIT and ORDER params on the backend; the front-end never sends them.
- caches the alert count per each curated group and viewer_id.
- deletes from the cache when an alert is dismissed so that the count will be recalculated the next time it's needed.
- refreshes all cached curated group alert counts during the nightly job run, after the alerts are refreshed.
- fixes this bug:  when a cohort has only one alert and that alert gets dismissed, the alert_count was never getting set to zero because the SQL was excluding cohorts with no alerts.