### PR TITLE
BOAC-6668: commits cache delete to db before next fetch

### DIFF
--- a/boac/api/cache_utils.py
+++ b/boac/api/cache_utils.py
@@ -31,7 +31,7 @@ from flask import current_app as app
 from boac import std_commit
 from boac.api.util import alert_counts_for_curated_group
 from boac.externals.data_loch import get_admitted_students_by_sids, get_student_profiles, get_user_permissions_per_affiliations
-from boac.lib.util import get_benchmarker, utc_now
+from boac.lib.util import utc_now
 from boac.merged.sis_terms import all_term_ids, current_term_id
 from boac.models.alert import Alert
 from boac.models.curated_group import CuratedGroupStudent
@@ -164,16 +164,12 @@ def refresh_alerts(term_id):
     Alert.deactivate_all_for_term(term_id)
     Alert.update_all_for_term(term_id)
     json_cache.clear('alert_counts_curated_group_%')
-    benchmark = get_benchmarker('alert_counts_curated_group_cache_refresh')
-    benchmark('begin')
     new_alert_counts = []
     for curated_group in CuratedGroup.query.filter_by(domain='default').all():
         new_alert_counts.append(alert_counts_for_curated_group(
-            benchmark=benchmark,
             viewer_id=curated_group.owner_id,
             group_id=curated_group.id,
         ))
-    benchmark('end')
     app.logger.info(f'Cached student alert counts for {len(new_alert_counts)} curated groups')
 
 

--- a/boac/api/course_controller.py
+++ b/boac/api/course_controller.py
@@ -60,8 +60,8 @@ def get_section(term_id, section_id):
 
 def _include_alert_counts(student_profiles, benchmark):
     alert_counts = Alert.current_alert_counts_for_sids(
-        benchmark=benchmark,
         viewer_id=current_user.get_id(),
+        benchmark=benchmark,
         sids=[s['sid'] for s in student_profiles.get('students', [])],
     )
     counts_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}

--- a/boac/api/curated_group_controller.py
+++ b/boac/api/curated_group_controller.py
@@ -85,7 +85,11 @@ def create_curated_group():
     if 'sids' in params:
         sids = [sid for sid in set(params.get('sids')) if sid.isdigit()]
         CuratedGroup.add_students(curated_group_id=curated_group.id, sids=sids)
-    return tolerant_jsonify(curated_group.to_api_json(include_students=True))
+    api_json = curated_group.to_api_json(include_students=True)
+    if api_json['totalStudentCount']:
+        student_alerts = _include_alert_counts(curated_group.id)
+        api_json['alertCount']= sum(student_alerts.values())
+    return tolerant_jsonify(api_json)
 
 
 @app.route('/api/curated_group/delete/<curated_group_id>', methods=['DELETE'])
@@ -179,7 +183,10 @@ def remove_student_from_curated_groups(sid):
         if curated_group.owner_id != current_user.get_id():
             raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own curated group {curated_group.id}')
         CuratedGroup.remove_student(curated_group.id, sid)
-        curated_groups.append(curated_group.to_api_json(include_students=False))
+        api_json = curated_group.to_api_json(include_students=False)
+        student_alerts = _include_alert_counts(curated_group.id)
+        api_json['alertCount']= sum(student_alerts.values())
+        curated_groups.append(api_json)
     return tolerant_jsonify(curated_groups)
 
 
@@ -201,10 +208,18 @@ def add_students_to_curated_groups():
             raise ForbiddenRequestError(f'Current user, {current_user.uid}, does not own curated group {curated_group.id}')
         CuratedGroup.add_students(curated_group_id=curated_group_id, sids=sids)
         if return_student_profiles:
-            curated_groups.append(_curated_group_with_complete_student_profiles(curated_group_id=curated_group_id))
+            api_json = _curated_group_with_complete_student_profiles(curated_group_id=curated_group_id)
         else:
-            group = CuratedGroup.find_by_id(curated_group_id)
-            curated_groups.append(group.to_api_json(include_students=False))
+            api_json = curated_group.to_api_json(include_students=False)
+        user_id = current_user.get_id()
+        students_with_alerts = alert_counts_for_curated_group(
+            viewer_id=user_id,
+            group_id=curated_group.id,
+        )
+        curated_groups.append({
+            **api_json,
+            'alertCount': sum(s['alertCount'] for s in students_with_alerts),
+        })
     return tolerant_jsonify(curated_groups)
 
 
@@ -251,7 +266,7 @@ def _curated_group_with_complete_student_profiles(
         api_json['students'] = get_student_profile_summaries(sids, term_id=term_id)
     _include_alert_counts(
         curated_group_id,
-        benchmark,
+        benchmark=benchmark,
         students=api_json['students'],
     )
     benchmark('begin get_referencing_cohort_ids')
@@ -270,13 +285,13 @@ def _can_current_user_view_curated_group(curated_group):
 
 def _include_alert_counts(
         curated_group_id,
-        benchmark,
+        benchmark=None,
         students=None,
     ):
     alert_counts = alert_counts_for_curated_group(
-        benchmark=benchmark,
         viewer_id=current_user.get_id(),
         group_id=curated_group_id,
+        benchmark=benchmark,
     )
     counts_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}
     for student in students or []:

--- a/boac/api/search_controller.py
+++ b/boac/api/search_controller.py
@@ -414,7 +414,7 @@ def _student_search(search_phrase, params, order_by):
     )
     students = student_results['students']
     sids = [s['sid'] for s in students]
-    alert_counts = Alert.current_alert_counts_for_sids(benchmark, current_user.get_id(), sids=sids)
+    alert_counts = Alert.current_alert_counts_for_sids(current_user.get_id(), benchmark, sids=sids)
     add_alert_counts(alert_counts, students)
     benchmark('end')
     return {

--- a/boac/api/util.py
+++ b/boac/api/util.py
@@ -59,14 +59,14 @@ from boac.models.user_login import UserLogin
 
 @stow('alert_counts_curated_group_{group_id}_user_{viewer_id}')
 def alert_counts_for_curated_group(
-    benchmark,
     viewer_id,
     group_id,
+    benchmark=None,
 ):
     return Alert.current_alert_counts_for_curated_group(
-        benchmark=benchmark,
         viewer_id=viewer_id,
         group_id=group_id,
+        benchmark=benchmark,
         count_only=True,
     )
 
@@ -444,14 +444,11 @@ def get_my_cohorts():
 
 
 def get_my_curated_groups():
-    benchmark = get_benchmarker('my_curated_groups')
-    benchmark('begin')
     curated_groups = []
     user_id = current_user.get_id()
     for curated_group in CuratedGroup.get_curated_groups(owner_id=user_id):
         api_json = curated_group.to_api_json(include_students=False)
         students_with_alerts = alert_counts_for_curated_group(
-            benchmark=benchmark,
             viewer_id=user_id,
             group_id=curated_group.id,
         )
@@ -459,7 +456,6 @@ def get_my_curated_groups():
             **api_json,
             'alertCount': sum(s['alertCount'] for s in students_with_alerts),
         })
-    benchmark('end')
     return curated_groups
 
 

--- a/boac/models/alert.py
+++ b/boac/models/alert.py
@@ -126,9 +126,9 @@ class Alert(Base):
     @classmethod
     def current_alert_counts_for_curated_group(
         cls,
-        benchmark,
         viewer_id,
         group_id,
+        benchmark,
         count_only=False,
     ):
         query = """
@@ -150,13 +150,13 @@ class Alert(Base):
             'key': current_term_id() + '_%',
             'group_id': group_id,
         }
-        return cls.alert_counts_by_query(benchmark, query, params, count_only=count_only)
+        return cls.alert_counts_by_query(query, params, benchmark=benchmark, count_only=count_only)
 
     @classmethod
     def current_alert_counts_for_sids(
         cls,
-        benchmark,
         viewer_id,
+        benchmark,
         sids=None,
         count_only=False,
     ):
@@ -177,10 +177,13 @@ class Alert(Base):
             'key': current_term_id() + '_%',
             'sids': sids,
         }
-        return cls.alert_counts_by_query(benchmark, query, params, count_only=count_only)
+        return cls.alert_counts_by_query(query, params, benchmark=benchmark, count_only=count_only)
 
     @classmethod
-    def alert_counts_by_query(cls, benchmark, query, params, count_only=False):
+    def alert_counts_by_query(cls, query, params, benchmark=None, count_only=False):
+        if not benchmark:
+            # noop
+            benchmark = lambda x: x
         benchmark('begin current_alert_counts_for_sids query')
         results = db.session.execute(text(query), params)
         benchmark('end current_alert_counts_for_sids query')

--- a/boac/models/cohort_filter.py
+++ b/boac/models/cohort_filter.py
@@ -336,8 +336,8 @@ class CohortFilter(Base):
                 })
             if include_alerts_for_user_id and self.domain == 'default':
                 alert_counts = Alert.current_alert_counts_for_sids(
-                    benchmark=benchmark,
                     viewer_id=include_alerts_for_user_id,
+                    benchmark=benchmark,
                     sids=results['sids'],
                 )
                 alert_count_per_sid = {s.get('sid'): s.get('alertCount') for s in alert_counts}

--- a/boac/models/json_cache.py
+++ b/boac/models/json_cache.py
@@ -60,6 +60,7 @@ def clear(key_like):
     if matches.count():
         app.logger.info(f'Will delete {matches.count()} entries matching {key_like}')
         matches.delete(synchronize_session=False)
+        std_commit()
 
 
 def stow(key_pattern, for_term=False):

--- a/src/components/curated/dropdown/ManageStudent.vue
+++ b/src/components/curated/dropdown/ManageStudent.vue
@@ -142,7 +142,6 @@ import {
 import {alertScreenReader, pluralize, putFocusNextTick} from '@/lib/utils'
 import {onSafariActivatorMousedown, onSafariMenuClose, onSafariMenuOpen} from '@/lib/menu-focus'
 import {describeCuratedGroupDomain} from '@/lib/berkeley-utils'
-import {getUserProfile} from '@/api/user'
 import {useContextStore} from '@/stores/context'
 
 const props = defineProps({
@@ -276,8 +275,6 @@ const onSubmit = () => {
     }
     contextStore.broadcast('curated-group-deselect-all', props.domain)
     isAdding.value = isRemoving.value = false
-    // Changes in curated-group may impact cohort counts thus we refresh user-session object.
-    getUserProfile().then(contextStore.setCurrentUser)
   }
   Promise.all(actions).finally(() => setTimeout(done, confirmationTimeout.value))
 }

--- a/tests/test_api/test_alerts_controller.py
+++ b/tests/test_api/test_alerts_controller.py
@@ -24,7 +24,6 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from boac.api.util import alert_counts_for_curated_group
-from boac.lib.util import get_benchmarker
 from boac.models import json_cache
 from boac.models.alert import Alert
 from boac.models.authorized_user import AuthorizedUser
@@ -146,7 +145,6 @@ class TestAlertsController:
         # Make sure alert counts for this curated group are cached
         coe_advisor = AuthorizedUser.find_by_uid(coe_advisor_uid)
         alert_counts_for_curated_group(
-            benchmark=get_benchmarker('test_alert_dismissal_clears_cached_curated_group_alert_counts'),
             viewer_id=coe_advisor.id,
             group_id=group_id,
         )

--- a/tests/test_api/test_cache_utils.py
+++ b/tests/test_api/test_cache_utils.py
@@ -28,7 +28,6 @@ import pytest
 from boac import std_commit
 from boac.api.cache_utils import refresh_alerts
 from boac.api.util import alert_counts_for_curated_group
-from boac.lib.util import get_benchmarker
 from boac.models import json_cache
 from boac.models.alert import Alert
 from boac.models.authorized_user import AuthorizedUser
@@ -100,7 +99,6 @@ class TestRefreshAlerts:
 
         # Cache alert counts for this curated group
         alert_counts_for_curated_group(
-            benchmark=get_benchmarker('test_refreshes_cached_curated_group_alert_counts'),
             viewer_id=asc_advisor.id,
             group_id=group_id,
         )


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/BOAC-6668

The cache bug fix is a one-liner in boac/models/json_cache.py. Records were not actually being deleted from json_cache before the next time they were fetched.

Also included:
1. removes excess benchmarking
2. adds total alert counts to feeds returned when creating a curated group and adding/removing students, so that the new counts can be reflected in the UI immediately
3. removes a duplicate call to `api/profile/my` after students are added to or removed from a curated group