### PR TITLE
BOAC-6786 - Fix issue with Degree Checks undesired reordering list of courses

### DIFF
--- a/boac/api/degree_progress_api_utils.py
+++ b/boac/api/degree_progress_api_utils.py
@@ -368,6 +368,9 @@ def _get_categories(template):
     """Fetch all categories associated with a template."""
     return DegreeProgressCategory.query.filter_by(
         template_id=template.id,
+    ).order_by(
+        DegreeProgressCategory.created_at,
+        DegreeProgressCategory.id,
     ).all()
 
 

--- a/boac/api/degree_progress_student_controller.py
+++ b/boac/api/degree_progress_student_controller.py
@@ -163,7 +163,7 @@ def delete_course(course_id):
             if category and 'Placeholder' in category.category_type:
                 DegreeProgressCategory.delete(category_id=category.id)
 
-        matches = sorted(matches, key=lambda c: c.created_at)
+        matches = sorted(matches, key=lambda c: (c.created_at, c.id))
         if matches[0].id == course.id:
             if course.manually_created_by:
                 for match in matches:

--- a/boac/models/degree_progress_category.py
+++ b/boac/models/degree_progress_category.py
@@ -222,9 +222,9 @@ class DegreeProgressCategory(Base):
             # Order by ux_position_y, descending.
             _categories = sorted(_categories, key=lambda c: c['uxPositionY'], reverse=True)
             for _category in _categories:
-                # Order courses and course_requirements by name, ascending.
-                _category['courses'] = sorted(_category['courses'], key=lambda c: c['createdAt'])
-                _category['courseRequirements'] = sorted(_category['courseRequirements'], key=lambda c: c['createdAt'])
+                # Order courses and course_requirements by created_at, ascending.
+                _category['courses'] = sorted(_category['courses'], key=lambda c: (c['createdAt'], c['id']))
+                _category['courseRequirements'] = sorted(_category['courseRequirements'], key=lambda c: (c['createdAt'], c['id']))
             return _categories
         hierarchy = _sort(hierarchy)
         for category in hierarchy:

--- a/boac/models/degree_progress_template.py
+++ b/boac/models/degree_progress_template.py
@@ -238,7 +238,7 @@ class DegreeProgressTemplate(Base):
         # Sort courses by created_at (asc) so "copied" courses come after the primary assigned course.
         degree_progress_courses = {}
         degree_courses = DegreeProgressCourse.find_by_sid(degree_check_id=self.id, sid=sid)
-        for course in sorted(degree_courses, key=lambda c: c.created_at):
+        for course in sorted(degree_courses, key=lambda c: (c.created_at, c.id)):
             key = f'{course.section_id}_{course.term_id}_{course.manually_created_at}_{course.manually_created_by}'
             if key not in degree_progress_courses:
                 degree_progress_courses[key] = []


### PR DESCRIPTION
**Jira:** https://jira-secure.berkeley.edu/browse/BOAC-6786

The underlying cause appears to be BOAC-6377  ([link](https://github.com/ets-berkeley-edu/boac/pull/5539/)) (not the color coding) as it improved degree-check creation performance by bulk copying template categories instead of copying them one at a time in display order. The bulk copy loaded categories from the database without a defined order. It seems postgres returns rows in an order that doesn’t match how they were originally created.

The UI sorts requirements by `createdAt`. On a new student check, those timestamps are set at copy time. So if the copy happened in the wrong order, the student check shows the wrong order. It seems that advisors typically add course requirements in order (i.e. they created MATH 51 first, and then create MATH 52 next...etc.) 

**This fix will only fix any newly created degree checks in the future.** However, any degree checks assigned to students after v.6.13 was released will need to be manually fixed. We can probably write a script that matches the `createdAt` times of the cloned Degree Check requirements to the original degree check requirements, but this may be a bit risky in production. 